### PR TITLE
Move common namespaces to global using and clean up files

### DIFF
--- a/Source/Moq.Analyzers.Test/AbstractClassTests.cs
+++ b/Source/Moq.Analyzers.Test/AbstractClassTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class AbstractClassTests : DiagnosticVerifier
 {

--- a/Source/Moq.Analyzers.Test/AbstractClassTests.cs
+++ b/Source/Moq.Analyzers.Test/AbstractClassTests.cs
@@ -1,7 +1,5 @@
-﻿using System.IO;
-using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
-using Xunit;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/AbstractClassTests.cs
+++ b/Source/Moq.Analyzers.Test/AbstractClassTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class AsAcceptOnlyInterfaceAnalyzerTests : DiagnosticVerifier
 {

--- a/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
-using Xunit;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodAnalyzerTests.cs
@@ -1,8 +1,4 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Xunit;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class CallbackSignatureShouldMatchMockedMethodAnalyzerTests : CallbackSignatureShouldMatchMockedMethodBase
 {

--- a/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodBase.cs
+++ b/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodBase.cs
@@ -1,6 +1,5 @@
 ﻿using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodBase.cs
+++ b/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodBase.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodCodeFixTests.cs
+++ b/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodCodeFixTests.cs
@@ -1,11 +1,4 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
-using Xunit;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class CallbackSignatureShouldMatchMockedMethodCodeFixTests : CallbackSignatureShouldMatchMockedMethodBase
 {

--- a/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class ConstructorArgumentsShouldMatchAnalyzerTests : DiagnosticVerifier
 {

--- a/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
-using Xunit;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/GlobalUsings.cs
+++ b/Source/Moq.Analyzers.Test/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using TestHelper;

--- a/Source/Moq.Analyzers.Test/GlobalUsings.cs
+++ b/Source/Moq.Analyzers.Test/GlobalUsings.cs
@@ -1,1 +1,2 @@
+global using Microsoft.CodeAnalysis.Diagnostics;
 global using TestHelper;

--- a/Source/Moq.Analyzers.Test/Helpers/CodeFixVerifier.Helper.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/CodeFixVerifier.Helper.cs
@@ -1,7 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;

--- a/Source/Moq.Analyzers.Test/Helpers/CodeFixVerifier.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/CodeFixVerifier.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
 
 namespace TestHelper;

--- a/Source/Moq.Analyzers.Test/Helpers/CodeFixVerifier.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/CodeFixVerifier.cs
@@ -1,12 +1,8 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Threading;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Formatting;
-using Xunit;
 
 namespace TestHelper;
 

--- a/Source/Moq.Analyzers.Test/Helpers/DiagnosticResultLocation.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/DiagnosticResultLocation.cs
@@ -1,6 +1,4 @@
-﻿using System;
-
-namespace TestHelper;
+﻿namespace TestHelper;
 
 /// <summary>
 /// Location where the diagnostic appears, as determined by path, line number, and column number.

--- a/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -4,7 +4,6 @@ using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Text;
 using Moq;
 

--- a/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.Helper.cs
@@ -1,8 +1,5 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using System.Diagnostics;
-using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
 using Microsoft.CodeAnalysis;

--- a/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Text;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 

--- a/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/DiagnosticVerifier.cs
@@ -1,6 +1,5 @@
 ﻿using System.Text;
 using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace TestHelper;
 

--- a/Source/Moq.Analyzers.Test/ModuleInitializer.cs
+++ b/Source/Moq.Analyzers.Test/ModuleInitializer.cs
@@ -1,5 +1,4 @@
 ﻿using System.Runtime.CompilerServices;
-using VerifyTests;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/NoConstructorArgumentsForInterfaceMockAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/NoConstructorArgumentsForInterfaceMockAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class NoConstructorArgumentsForInterfaceMockAnalyzerTests : DiagnosticVerifier
 {

--- a/Source/Moq.Analyzers.Test/NoConstructorArgumentsForInterfaceMockAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/NoConstructorArgumentsForInterfaceMockAnalyzerTests.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
-using Xunit;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/NoConstructorArgumentsForInterfaceMockAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/NoConstructorArgumentsForInterfaceMockAnalyzerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/NoMethodsInPropertySetupAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/NoMethodsInPropertySetupAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class NoMethodsInPropertySetupAnalyzerTests : DiagnosticVerifier
 {

--- a/Source/Moq.Analyzers.Test/NoMethodsInPropertySetupAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/NoMethodsInPropertySetupAnalyzerTests.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
-using Xunit;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/NoMethodsInPropertySetupAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/NoMethodsInPropertySetupAnalyzerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/NoSealedClassMocksAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/NoSealedClassMocksAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class NoSealedClassMocksAnalyzerTests : DiagnosticVerifier
 {

--- a/Source/Moq.Analyzers.Test/NoSealedClassMocksAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/NoSealedClassMocksAnalyzerTests.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
-using Xunit;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/NoSealedClassMocksAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/NoSealedClassMocksAnalyzerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/PackageTests.cs
+++ b/Source/Moq.Analyzers.Test/PackageTests.cs
@@ -1,8 +1,4 @@
-﻿using System.IO;
-using System.Linq;
-using System.Reflection;
-using System.Threading.Tasks;
-using Xunit;
+﻿using System.Reflection;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests : DiagnosticVerifier
 {

--- a/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
-using Xunit;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
@@ -1,8 +1,5 @@
-﻿using System.IO;
-using System.Threading.Tasks;
-using Microsoft.CodeAnalysis.Diagnostics;
+﻿using Microsoft.CodeAnalysis.Diagnostics;
 using TestHelper;
-using Xunit;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
@@ -1,5 +1,4 @@
 ﻿using Microsoft.CodeAnalysis.Diagnostics;
-using TestHelper;
 
 namespace Moq.Analyzers.Test;
 

--- a/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
@@ -1,6 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Diagnostics;
-
-namespace Moq.Analyzers.Test;
+﻿namespace Moq.Analyzers.Test;
 
 public class SetupShouldNotIncludeAsyncResultAnalyzerTests : DiagnosticVerifier
 {

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Moq.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Moq.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -1,8 +1,5 @@
 ﻿using System.Collections.Immutable;
 using System.Composition;
-using System.Linq;
-using System.Threading;
-using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -1,9 +1,6 @@
 ﻿using System.Composition;
-using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using System.Composition;
+﻿using System.Composition;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Moq.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/GlobalUsings.cs
+++ b/Source/Moq.Analyzers/GlobalUsings.cs
@@ -1,0 +1,1 @@
+global using System.Collections.Immutable;

--- a/Source/Moq.Analyzers/GlobalUsings.cs
+++ b/Source/Moq.Analyzers/GlobalUsings.cs
@@ -1,2 +1,5 @@
 global using System.Collections.Immutable;
+global using Microsoft.CodeAnalysis;
+global using Microsoft.CodeAnalysis.CSharp;
+global using Microsoft.CodeAnalysis.CSharp.Syntax;
 global using Microsoft.CodeAnalysis.Diagnostics;

--- a/Source/Moq.Analyzers/GlobalUsings.cs
+++ b/Source/Moq.Analyzers/GlobalUsings.cs
@@ -1,1 +1,2 @@
 global using System.Collections.Immutable;
+global using Microsoft.CodeAnalysis.Diagnostics;

--- a/Source/Moq.Analyzers/Helpers.cs
+++ b/Source/Moq.Analyzers/Helpers.cs
@@ -1,6 +1,4 @@
 ﻿using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/Helpers.cs
+++ b/Source/Moq.Analyzers/Helpers.cs
@@ -1,6 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Linq;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 

--- a/Source/Moq.Analyzers/MoqMethodDescriptor.cs
+++ b/Source/Moq.Analyzers/MoqMethodDescriptor.cs
@@ -1,6 +1,4 @@
 ﻿using System.Text.RegularExpressions;
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/MoqMethodDescriptor.cs
+++ b/Source/Moq.Analyzers/MoqMethodDescriptor.cs
@@ -1,5 +1,4 @@
-﻿using System.Linq;
-using System.Text.RegularExpressions;
+﻿using System.Text.RegularExpressions;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -1,5 +1,4 @@
 using System.Collections.Immutable;
-using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Moq.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Moq.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Moq.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,7 +1,3 @@
-using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
 namespace Moq.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,7 +1,6 @@
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Immutable;
-using Microsoft.CodeAnalysis;
+﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -1,7 +1,6 @@
 ﻿using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Diagnostics;
 
 namespace Moq.Analyzers;
 

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -1,8 +1,4 @@
-﻿using Microsoft.CodeAnalysis;
-using Microsoft.CodeAnalysis.CSharp;
-using Microsoft.CodeAnalysis.CSharp.Syntax;
-
-namespace Moq.Analyzers;
+﻿namespace Moq.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Immutable;
+﻿using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;


### PR DESCRIPTION
This change moves over the high volume using statements that are often repeated at the top of every file. It does not move overall all namespace usage to global usings.

Fixes #62