### PR TITLE
Enable ConcurrentExecution and disable generated code analysis

### DIFF
--- a/Source/Moq.Analyzers.Test/Helpers/AnalyzerTestExtensions.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/AnalyzerTestExtensions.cs
@@ -9,7 +9,6 @@ internal static class AnalyzerTestExtensions
         where TVerifier : IVerifier, new()
     {
         test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages([new PackageIdentity("Moq", "4.8.2")]); // TODO: See https://github.com/rjmurillo/moq.analyzers/issues/58
-        test.TestBehaviors = TestBehaviors.SkipGeneratedCodeCheck; // TODO: We should enable the generated code check
 
         return test;
     }

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -15,6 +15,8 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -18,6 +18,8 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
 
     public override void Initialize(AnalysisContext context)
     {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -18,6 +18,8 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ObjectCreationExpression);
     }
 

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -18,6 +18,8 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ObjectCreationExpression);
     }
 

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -18,6 +18,8 @@ public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 

--- a/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -18,6 +18,8 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ObjectCreationExpression);
     }
 

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -15,6 +15,8 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
 
     public override void Initialize(AnalysisContext context)
     {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -15,6 +15,8 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
 
     public override void Initialize(AnalysisContext context)
     {
+        context.EnableConcurrentExecution();
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 


### PR DESCRIPTION
Two simple and related performance improvements:

1. Enable concurrent execution of the analyzer. Verified via manual code inspection + tests that there's no state to maintain between invocations
2. Disable the analyzer in generate code contexts. Things like Razor and Entity Framework can generate large volumes of code that the user isn't directly responsible for.