### PR TITLE
Cache reference assemblies between tests to improve performance

### DIFF
--- a/Source/Moq.Analyzers.Test/Helpers/AnalyzerTestExtensions.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/AnalyzerTestExtensions.cs
@@ -8,7 +8,7 @@ internal static class AnalyzerTestExtensions
         where TAnalyzerTest : AnalyzerTest<TVerifier>
         where TVerifier : IVerifier, new()
     {
-        test.ReferenceAssemblies = ReferenceAssemblies.Net.Net80.AddPackages([new PackageIdentity("Moq", "4.8.2")]); // TODO: See https://github.com/rjmurillo/moq.analyzers/issues/58
+        test.ReferenceAssemblies = ReferenceAssemblyCatalog.Net80WithOldMoq;
 
         return test;
     }

--- a/Source/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalog.cs
+++ b/Source/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalog.cs
@@ -1,0 +1,20 @@
+﻿using Microsoft.CodeAnalysis.Testing;
+
+namespace Moq.Analyzers.Test.Helpers;
+
+/// <summary>
+/// The testing framework does heavy work to resolve references for set of <see cref="ReferenceAssemblies"/>, including potentially
+/// running the NuGet client to download packages. This class caches the ReferenceAssemblies class (which is thread-safe), so that
+/// package resolution only happens once for a given configuration.
+/// </summary>
+/// <remarks>
+/// This class is currently very simple and assumes that the only package that will be resolved is Moq for .NET 8.0. As our testing needs
+/// get more complicated, we can either manage the combinations ourselves
+/// (as done in https://github.com/dotnet/roslyn-analyzers/blob/4d5fd9da36d64d4c3370b8813122e226844fc6ed/src/Test.Utilities/AdditionalMetadataReferences.cs)
+/// or consider filing an issue in https://github.com/dotnet/roslyn-sdk to clarify best practices.
+/// </remarks>
+internal static class ReferenceAssemblyCatalog
+{
+    // TODO: We should also be testing a newer version of Moq. See https://github.com/rjmurillo/moq.analyzers/issues/58.
+    public static ReferenceAssemblies Net80WithOldMoq { get; } = ReferenceAssemblies.Net.Net80.AddPackages([new PackageIdentity("Moq", "4.8.2")]);
+}


### PR DESCRIPTION
The testing framework does a bunch of heavy lifting to resolve references for set of `ReferenceAssemblies`, including potentially running the NuGet client to download packages. This class caches the ReferenceAssemblies class (which is thread-safe), so that package resolution only happens once for a given configuration.

The is the same approach taken by https://github.com/dotnet/roslyn-analyzers/blob/4d5fd9da36d64d4c3370b8813122e226844fc6ed/src/Test.Utilities/AdditionalMetadataReferences.cs.

This cuts test time from ~40 seconds to ~20 seconds on my machine.