### PR TITLE
Update code to remove warnings from backlog

### DIFF
--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -60,9 +60,9 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
             {
                 var mockedMethodArgumentType = context.SemanticModel.GetTypeInfo(mockedMethodArguments[i].Expression, context.CancellationToken);
                 var lambdaParameterType = context.SemanticModel.GetTypeInfo(lambdaParameters[i].Type, context.CancellationToken);
-                string mockedMethodTypeName = mockedMethodArgumentType.ConvertedType.ToString();
-                string lambdaParameterTypeName = lambdaParameterType.ConvertedType.ToString();
-                if (mockedMethodTypeName != lambdaParameterTypeName)
+                string? mockedMethodTypeName = mockedMethodArgumentType.ConvertedType?.ToString();
+                string? lambdaParameterTypeName = lambdaParameterType.ConvertedType?.ToString();
+                if (!string.Equals(mockedMethodTypeName, lambdaParameterTypeName, StringComparison.Ordinal))
                 {
                     var diagnostic = Diagnostic.Create(Rule, callbackLambda.ParameterList.GetLocation());
                     context.ReportDiagnostic(diagnostic);

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -1,4 +1,5 @@
 ﻿using System.Composition;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 
@@ -22,44 +23,63 @@ public class CallbackSignatureShouldMatchMockedMethodCodeFix : CodeFixProvider
     {
         var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
 
+        if (root == null)
+        {
+            return;
+        }
+
         var diagnostic = context.Diagnostics.First();
         var diagnosticSpan = diagnostic.Location.SourceSpan;
 
         // Find the type declaration identified by the diagnostic.
-        var badArgumentListSyntax = root.FindToken(diagnosticSpan.Start).Parent.AncestorsAndSelf().OfType<ParameterListSyntax>().First();
+        ParameterListSyntax? badArgumentListSyntax = root.FindToken(diagnosticSpan.Start)
+                                        .Parent?
+                                        .AncestorsAndSelf()
+                                        .OfType<ParameterListSyntax>()
+                                        .First();
 
         // Register a code action that will invoke the fix.
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: "Fix Moq callback signature",
-                createChangedDocument: c => FixCallbackSignature(root, context.Document, badArgumentListSyntax, c),
+                createChangedDocument: c => FixCallbackSignatureAsync(root, context.Document, badArgumentListSyntax, c),
                 equivalenceKey: "Fix Moq callback signature"),
             diagnostic);
     }
 
-    private async Task<Document> FixCallbackSignature(SyntaxNode root, Document document, ParameterListSyntax oldParameters, CancellationToken cancellationToken)
+    private async Task<Document> FixCallbackSignatureAsync(SyntaxNode root, Document document, ParameterListSyntax? oldParameters, CancellationToken cancellationToken)
     {
-        var semanticModel = await document.GetSemanticModelAsync(cancellationToken);
-        var callbackInvocation = oldParameters?.Parent?.Parent?.Parent?.Parent as InvocationExpressionSyntax;
-        if (callbackInvocation != null)
+        var semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
+
+        Debug.Assert(semanticModel != null, nameof(semanticModel) + " != null");
+
+        if (semanticModel == null)
         {
-            var setupMethodInvocation = Helpers.FindSetupMethodFromCallbackInvocation(semanticModel, callbackInvocation);
-            var matchingMockedMethods = Helpers.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(semanticModel, setupMethodInvocation).ToArray();
-
-            if (matchingMockedMethods.Length == 1)
-            {
-                var newParameters = SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(matchingMockedMethods[0].Parameters.Select(
-                    p =>
-                    {
-                        var type = SyntaxFactory.ParseTypeName(p.Type.ToMinimalDisplayString(semanticModel, oldParameters.SpanStart));
-                        return SyntaxFactory.Parameter(default(SyntaxList<AttributeListSyntax>), SyntaxFactory.TokenList(), type, SyntaxFactory.Identifier(p.Name), null);
-                    })));
-
-                var newRoot = root.ReplaceNode(oldParameters, newParameters);
-                return document.WithSyntaxRoot(newRoot);
-            }
+            return document;
         }
 
-        return document;
+        if (oldParameters?.Parent?.Parent?.Parent?.Parent is not InvocationExpressionSyntax callbackInvocation)
+        {
+            return document;
+        }
+
+        var setupMethodInvocation = Helpers.FindSetupMethodFromCallbackInvocation(semanticModel, callbackInvocation);
+        Debug.Assert(setupMethodInvocation != null, nameof(setupMethodInvocation) + " != null");
+        var matchingMockedMethods = Helpers.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(semanticModel, setupMethodInvocation).ToArray();
+
+        if (matchingMockedMethods.Length != 1 || oldParameters == null)
+        {
+            return document;
+        }
+
+        var newParameters = SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(matchingMockedMethods[0].Parameters.Select(
+            p =>
+            {
+                var type = SyntaxFactory.ParseTypeName(p.Type.ToMinimalDisplayString(semanticModel, oldParameters.SpanStart));
+                return SyntaxFactory.Parameter(default, SyntaxFactory.TokenList(), type, SyntaxFactory.Identifier(p.Name), null);
+            })));
+
+        var newRoot = root.ReplaceNode(oldParameters, newParameters);
+        return document.WithSyntaxRoot(newRoot);
     }
 }

--- a/Source/Moq.Analyzers/Diagnostics.cs
+++ b/Source/Moq.Analyzers/Diagnostics.cs
@@ -24,7 +24,6 @@ internal static class Diagnostics
     internal const string NoMethodsInPropertySetupTitle = "Moq: Property setup used for a method";
     internal const string NoMethodsInPropertySetupMessage = "SetupGet/SetupSet should be used for properties, not for methods.";
 
-
     internal const string SetupShouldBeUsedOnlyForOverridableMembersId = "Moq1200";
     internal const string SetupShouldBeUsedOnlyForOverridableMembersTitle = "Moq: Invalid setup parameter";
     internal const string SetupShouldBeUsedOnlyForOverridableMembersMessage = "Setup should be used only for overridable members.";

--- a/Source/Moq.Analyzers/Helpers.cs
+++ b/Source/Moq.Analyzers/Helpers.cs
@@ -1,84 +1,89 @@
-﻿using System.Text.RegularExpressions;
+﻿using System.Diagnostics;
+using System.Text.RegularExpressions;
 
 namespace Moq.Analyzers;
 
 internal static class Helpers
 {
-    private static MoqMethodDescriptor moqSetupMethodDescriptor = new MoqMethodDescriptor("Setup", new Regex("^Moq\\.Mock<.*>\\.Setup\\.*"));
+    private static readonly MoqMethodDescriptor MoqSetupMethodDescriptor = new("Setup", new Regex("^Moq\\.Mock<.*>\\.Setup\\.*"));
 
-    private static MoqMethodDescriptor moqAsMethodDescriptor = new MoqMethodDescriptor("As", new Regex("^Moq\\.Mock\\.As<\\.*"), isGeneric: true);
+    private static readonly MoqMethodDescriptor MoqAsMethodDescriptor = new("As", new Regex("^Moq\\.Mock\\.As<\\.*"), isGeneric: true);
 
     internal static bool IsMoqSetupMethod(SemanticModel semanticModel, MemberAccessExpressionSyntax method)
     {
-        return moqSetupMethodDescriptor.IsMoqMethod(semanticModel, method);
+        return MoqSetupMethodDescriptor.IsMoqMethod(semanticModel, method);
     }
 
     internal static bool IsMoqAsMethod(SemanticModel semanticModel, MemberAccessExpressionSyntax method)
     {
-        return moqAsMethodDescriptor.IsMoqMethod(semanticModel, method);
+        return MoqAsMethodDescriptor.IsMoqMethod(semanticModel, method);
     }
 
     internal static bool IsCallbackOrReturnInvocation(SemanticModel semanticModel, InvocationExpressionSyntax callbackOrReturnsInvocation)
     {
         var callbackOrReturnsMethod = callbackOrReturnsInvocation.Expression as MemberAccessExpressionSyntax;
-        var methodName = callbackOrReturnsMethod?.Name.ToString();
+
+        Debug.Assert(callbackOrReturnsMethod != null, nameof(callbackOrReturnsMethod) + " != null");
+
+        if (callbackOrReturnsMethod == null)
+        {
+            return false;
+        }
+
+        var methodName = callbackOrReturnsMethod.Name.ToString();
 
         // First fast check before walking semantic model
-        if (methodName != "Callback" && methodName != "Returns")
+        if (!string.Equals(methodName, "Callback", StringComparison.Ordinal)
+            && !string.Equals(methodName, "Returns", StringComparison.Ordinal))
         {
             return false;
         }
 
         var symbolInfo = semanticModel.GetSymbolInfo(callbackOrReturnsMethod);
-        if (symbolInfo.CandidateReason == CandidateReason.OverloadResolutionFailure)
+        return symbolInfo.CandidateReason switch
         {
-            return symbolInfo.CandidateSymbols.Any(s => IsCallbackOrReturnSymbol(s));
-        }
-        else if (symbolInfo.CandidateReason == CandidateReason.None)
-        {
-            return IsCallbackOrReturnSymbol(symbolInfo.Symbol);
-        }
-
-        return false;
+            CandidateReason.OverloadResolutionFailure => symbolInfo.CandidateSymbols.Any(IsCallbackOrReturnSymbol),
+            CandidateReason.None => IsCallbackOrReturnSymbol(symbolInfo.Symbol),
+            _ => false,
+        };
     }
 
-    internal static InvocationExpressionSyntax FindSetupMethodFromCallbackInvocation(SemanticModel semanticModel, ExpressionSyntax expression)
+    internal static InvocationExpressionSyntax? FindSetupMethodFromCallbackInvocation(SemanticModel semanticModel, ExpressionSyntax expression)
     {
         var invocation = expression as InvocationExpressionSyntax;
-        var method = invocation?.Expression as MemberAccessExpressionSyntax;
-        if (method == null) return null;
+        if (invocation?.Expression is not MemberAccessExpressionSyntax method) return null;
         if (IsMoqSetupMethod(semanticModel, method)) return invocation;
         return FindSetupMethodFromCallbackInvocation(semanticModel, method.Expression);
     }
 
-    internal static InvocationExpressionSyntax FindMockedMethodInvocationFromSetupMethod(InvocationExpressionSyntax setupInvocation)
+    internal static InvocationExpressionSyntax? FindMockedMethodInvocationFromSetupMethod(InvocationExpressionSyntax? setupInvocation)
     {
-        var setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0]?.Expression as LambdaExpressionSyntax;
+        var setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0].Expression as LambdaExpressionSyntax;
         return setupLambdaArgument?.Body as InvocationExpressionSyntax;
     }
 
-    internal static ExpressionSyntax FindMockedMemberExpressionFromSetupMethod(InvocationExpressionSyntax setupInvocation)
+    internal static ExpressionSyntax? FindMockedMemberExpressionFromSetupMethod(InvocationExpressionSyntax? setupInvocation)
     {
-        var setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0]?.Expression as LambdaExpressionSyntax;
+        var setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0].Expression as LambdaExpressionSyntax;
         return setupLambdaArgument?.Body as ExpressionSyntax;
     }
 
-    internal static IEnumerable<IMethodSymbol> GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(SemanticModel semanticModel, InvocationExpressionSyntax setupMethodInvocation)
+    internal static IEnumerable<IMethodSymbol> GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(SemanticModel semanticModel, InvocationExpressionSyntax? setupMethodInvocation)
     {
-        var setupLambdaArgument = setupMethodInvocation?.ArgumentList.Arguments[0]?.Expression as LambdaExpressionSyntax;
+        var setupLambdaArgument = setupMethodInvocation?.ArgumentList.Arguments[0].Expression as LambdaExpressionSyntax;
         var mockedMethodInvocation = setupLambdaArgument?.Body as InvocationExpressionSyntax;
 
         return GetAllMatchingSymbols<IMethodSymbol>(semanticModel, mockedMethodInvocation);
     }
 
-    internal static IEnumerable<T> GetAllMatchingSymbols<T>(SemanticModel semanticModel, ExpressionSyntax expression)
+    internal static IEnumerable<T> GetAllMatchingSymbols<T>(SemanticModel semanticModel, ExpressionSyntax? expression)
         where T : class
     {
         var matchingSymbols = new List<T>();
         if (expression != null)
         {
             var symbolInfo = semanticModel.GetSymbolInfo(expression);
-            if (symbolInfo.CandidateReason == CandidateReason.None && symbolInfo.Symbol is T)
+            if (symbolInfo is { CandidateReason: CandidateReason.None, Symbol: T })
             {
                 matchingSymbols.Add(symbolInfo.Symbol as T);
             }
@@ -91,12 +96,12 @@ internal static class Helpers
         return matchingSymbols;
     }
 
-    private static bool IsCallbackOrReturnSymbol(ISymbol symbol)
+    private static bool IsCallbackOrReturnSymbol(ISymbol? symbol)
     {
         // TODO: Check what is the best way to do such checks
-        var methodSymbol = symbol as IMethodSymbol;
-        if (methodSymbol == null) return false;
+        if (symbol is not IMethodSymbol methodSymbol) return false;
         var methodName = methodSymbol.ToString();
-        return methodName.StartsWith("Moq.Language.ICallback") || methodName.StartsWith("Moq.Language.IReturns");
+        return methodName.StartsWith("Moq.Language.ICallback", StringComparison.Ordinal)
+               || methodName.StartsWith("Moq.Language.IReturns", StringComparison.Ordinal);
     }
 }

--- a/Source/Moq.Analyzers/Moq.Analyzers.csproj
+++ b/Source/Moq.Analyzers/Moq.Analyzers.csproj
@@ -6,6 +6,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <IncludeBuildOutput>false</IncludeBuildOutput><!-- Don't place the output assembly in the package's lib/ folder -->
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking><!-- Don't add the TargetFramework as a package dependency -->
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules><!-- Resolves RS1036 -->
   </PropertyGroup>
 
   <PropertyGroup Label="Package metadata">

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -1,3 +1,5 @@
+using System.Diagnostics;
+
 namespace Moq.Analyzers;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
@@ -28,38 +30,44 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         var objectCreation = (ObjectCreationExpressionSyntax)context.Node;
 
         // TODO Think how to make this piece more elegant while fast
-        GenericNameSyntax genericName = objectCreation.Type as GenericNameSyntax;
-        if (objectCreation.Type is QualifiedNameSyntax)
+        GenericNameSyntax? genericName = objectCreation.Type as GenericNameSyntax;
+        if (objectCreation.Type is QualifiedNameSyntax qualifiedName)
         {
-            var qualifiedName = objectCreation.Type as QualifiedNameSyntax;
             genericName = qualifiedName.Right as GenericNameSyntax;
         }
 
         if (genericName?.Identifier == null || genericName.TypeArgumentList == null) return;
 
         // Quick and dirty check
-        if (genericName.Identifier.ToFullString() != "Mock") return;
+        if (!string.Equals(genericName.Identifier.ToFullString(), "Mock", StringComparison.Ordinal)) return;
 
         // Full check
         var constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation, context.CancellationToken);
-        var constructorSymbol = constructorSymbolInfo.Symbol as IMethodSymbol;
-        if (constructorSymbol == null || constructorSymbol.ContainingType == null || constructorSymbol.ContainingType.ConstructedFrom == null) return;
+        if (constructorSymbolInfo.Symbol is not IMethodSymbol constructorSymbol || constructorSymbol.ContainingType == null || constructorSymbol.ContainingType.ConstructedFrom == null) return;
         if (constructorSymbol.MethodKind != MethodKind.Constructor) return;
-        if (constructorSymbol.ContainingType.ConstructedFrom.ToDisplayString() != "Moq.Mock<T>") return;
+        if (!string.Equals(
+                constructorSymbol.ContainingType.ConstructedFrom.ToDisplayString(),
+                "Moq.Mock<T>",
+                StringComparison.Ordinal))
+        {
+            return;
+        }
+
         if (constructorSymbol.Parameters == null || constructorSymbol.Parameters.Length == 0) return;
         if (!constructorSymbol.Parameters.Any(x => x.IsParams)) return;
 
         // Find mocked type
         var typeArguments = genericName.TypeArgumentList.Arguments;
-        if (typeArguments == null || typeArguments.Count != 1) return;
+        if (typeArguments.Count != 1) return;
         var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0], context.CancellationToken);
-        var symbol = symbolInfo.Symbol as INamedTypeSymbol;
-        if (symbol == null) return;
+        if (symbolInfo.Symbol is not INamedTypeSymbol symbol) return;
 
         // Checked mocked type
         if (symbol.TypeKind == TypeKind.Interface)
         {
-            var diagnostic = Diagnostic.Create(Rule, objectCreation.ArgumentList.GetLocation());
+            Debug.Assert(objectCreation.ArgumentList != null, "objectCreation.ArgumentList != null");
+
+            var diagnostic = Diagnostic.Create(Rule, objectCreation.ArgumentList?.GetLocation());
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -27,9 +27,9 @@ public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
     {
         var setupGetOrSetInvocation = (InvocationExpressionSyntax)context.Node;
 
-        var setupGetOrSetMethod = setupGetOrSetInvocation.Expression as MemberAccessExpressionSyntax;
-        if (setupGetOrSetMethod == null) return;
-        if (setupGetOrSetMethod.Name.ToFullString() != "SetupGet" && setupGetOrSetMethod.Name.ToFullString() != "SetupSet") return;
+        if (setupGetOrSetInvocation.Expression is not MemberAccessExpressionSyntax setupGetOrSetMethod) return;
+        if (!string.Equals(setupGetOrSetMethod.Name.ToFullString(), "SetupGet", StringComparison.Ordinal)
+            && !string.Equals(setupGetOrSetMethod.Name.ToFullString(), "SetupSet", StringComparison.Ordinal)) return;
 
         var mockedMethodCall = Helpers.FindMockedMethodInvocationFromSetupMethod(setupGetOrSetInvocation);
         if (mockedMethodCall == null) return;

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -33,19 +33,17 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
             }
 
             var symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
-            if (symbolInfo.Symbol is IPropertySymbol || symbolInfo.Symbol is IMethodSymbol)
+            if (symbolInfo.Symbol is IPropertySymbol or IMethodSymbol
+                && !IsMethodOverridable(symbolInfo.Symbol))
             {
-                if (IsMethodOverridable(symbolInfo.Symbol) == false)
-                {
-                    var diagnostic = Diagnostic.Create(Rule, mockedMemberExpression.GetLocation());
-                    context.ReportDiagnostic(diagnostic);
-                }
+                var diagnostic = Diagnostic.Create(Rule, mockedMemberExpression.GetLocation());
+                context.ReportDiagnostic(diagnostic);
             }
         }
     }
 
     private static bool IsMethodOverridable(ISymbol methodSymbol)
     {
-        return methodSymbol.IsSealed == false && (methodSymbol.IsVirtual || methodSymbol.IsAbstract || methodSymbol.IsOverride);
+        return !methodSymbol.IsSealed && (methodSymbol.IsVirtual || methodSymbol.IsAbstract || methodSymbol.IsOverride);
     }
 }


### PR DESCRIPTION
This reduces the backlog of warnings by about half, removing many cases for passing null references to methods and null dereference. The remaining warnings are from multiple sources: TODO, diagnostic best practices, and some tricker items we'll need to look at

Related to #26