### PR TITLE
Convert from var to explicit type

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -88,9 +88,9 @@ dotnet_remove_unnecessary_suppression_exclusions = none
 [*.cs]
 
 # var preferences
-csharp_style_var_elsewhere = false:error
-csharp_style_var_for_built_in_types = false:error
-csharp_style_var_when_type_is_apparent = false:error
+csharp_style_var_elsewhere = false:warning
+csharp_style_var_for_built_in_types = false:warning
+csharp_style_var_when_type_is_apparent = false:warning
 
 # Expression-bodied members
 csharp_style_expression_bodied_accessors = true:silent

--- a/.editorconfig
+++ b/.editorconfig
@@ -88,9 +88,9 @@ dotnet_remove_unnecessary_suppression_exclusions = none
 [*.cs]
 
 # var preferences
-csharp_style_var_elsewhere = false:silent
-csharp_style_var_for_built_in_types = false:silent
-csharp_style_var_when_type_is_apparent = false:silent
+csharp_style_var_elsewhere = false:error
+csharp_style_var_for_built_in_types = false:error
+csharp_style_var_when_type_is_apparent = false:error
 
 # Expression-bodied members
 csharp_style_expression_bodied_accessors = true:silent

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -22,18 +22,18 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
-        var asInvocation = (InvocationExpressionSyntax)context.Node;
+        InvocationExpressionSyntax? asInvocation = (InvocationExpressionSyntax)context.Node;
 
         if (asInvocation.Expression is MemberAccessExpressionSyntax memberAccessExpression
             && Helpers.IsMoqAsMethod(context.SemanticModel, memberAccessExpression)
             && memberAccessExpression.Name is GenericNameSyntax genericName
             && genericName.TypeArgumentList.Arguments.Count == 1)
         {
-            var typeArgument = genericName.TypeArgumentList.Arguments[0];
-            var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArgument, context.CancellationToken);
+            TypeSyntax? typeArgument = genericName.TypeArgumentList.Arguments[0];
+            SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(typeArgument, context.CancellationToken);
             if (symbolInfo.Symbol is ITypeSymbol typeSymbol && typeSymbol.TypeKind != TypeKind.Interface)
             {
-                var diagnostic = Diagnostic.Create(Rule, typeArgument.GetLocation());
+                Diagnostic? diagnostic = Diagnostic.Create(Rule, typeArgument.GetLocation());
                 context.ReportDiagnostic(diagnostic);
             }
         }

--- a/Source/Moq.Analyzers/Helpers.cs
+++ b/Source/Moq.Analyzers/Helpers.cs
@@ -21,7 +21,7 @@ internal static class Helpers
 
     internal static bool IsCallbackOrReturnInvocation(SemanticModel semanticModel, InvocationExpressionSyntax callbackOrReturnsInvocation)
     {
-        var callbackOrReturnsMethod = callbackOrReturnsInvocation.Expression as MemberAccessExpressionSyntax;
+        MemberAccessExpressionSyntax? callbackOrReturnsMethod = callbackOrReturnsInvocation.Expression as MemberAccessExpressionSyntax;
 
         Debug.Assert(callbackOrReturnsMethod != null, nameof(callbackOrReturnsMethod) + " != null");
 
@@ -30,7 +30,7 @@ internal static class Helpers
             return false;
         }
 
-        var methodName = callbackOrReturnsMethod.Name.ToString();
+        string? methodName = callbackOrReturnsMethod.Name.ToString();
 
         // First fast check before walking semantic model
         if (!string.Equals(methodName, "Callback", StringComparison.Ordinal)
@@ -39,7 +39,7 @@ internal static class Helpers
             return false;
         }
 
-        var symbolInfo = semanticModel.GetSymbolInfo(callbackOrReturnsMethod);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(callbackOrReturnsMethod);
         return symbolInfo.CandidateReason switch
         {
             CandidateReason.OverloadResolutionFailure => symbolInfo.CandidateSymbols.Any(IsCallbackOrReturnSymbol),
@@ -50,7 +50,7 @@ internal static class Helpers
 
     internal static InvocationExpressionSyntax? FindSetupMethodFromCallbackInvocation(SemanticModel semanticModel, ExpressionSyntax expression)
     {
-        var invocation = expression as InvocationExpressionSyntax;
+        InvocationExpressionSyntax? invocation = expression as InvocationExpressionSyntax;
         if (invocation?.Expression is not MemberAccessExpressionSyntax method) return null;
         if (IsMoqSetupMethod(semanticModel, method)) return invocation;
         return FindSetupMethodFromCallbackInvocation(semanticModel, method.Expression);
@@ -58,20 +58,20 @@ internal static class Helpers
 
     internal static InvocationExpressionSyntax? FindMockedMethodInvocationFromSetupMethod(InvocationExpressionSyntax? setupInvocation)
     {
-        var setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0].Expression as LambdaExpressionSyntax;
+        LambdaExpressionSyntax? setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0].Expression as LambdaExpressionSyntax;
         return setupLambdaArgument?.Body as InvocationExpressionSyntax;
     }
 
     internal static ExpressionSyntax? FindMockedMemberExpressionFromSetupMethod(InvocationExpressionSyntax? setupInvocation)
     {
-        var setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0].Expression as LambdaExpressionSyntax;
+        LambdaExpressionSyntax? setupLambdaArgument = setupInvocation?.ArgumentList.Arguments[0].Expression as LambdaExpressionSyntax;
         return setupLambdaArgument?.Body as ExpressionSyntax;
     }
 
     internal static IEnumerable<IMethodSymbol> GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(SemanticModel semanticModel, InvocationExpressionSyntax? setupMethodInvocation)
     {
-        var setupLambdaArgument = setupMethodInvocation?.ArgumentList.Arguments[0].Expression as LambdaExpressionSyntax;
-        var mockedMethodInvocation = setupLambdaArgument?.Body as InvocationExpressionSyntax;
+        LambdaExpressionSyntax? setupLambdaArgument = setupMethodInvocation?.ArgumentList.Arguments[0].Expression as LambdaExpressionSyntax;
+        InvocationExpressionSyntax? mockedMethodInvocation = setupLambdaArgument?.Body as InvocationExpressionSyntax;
 
         return GetAllMatchingSymbols<IMethodSymbol>(semanticModel, mockedMethodInvocation);
     }
@@ -79,10 +79,10 @@ internal static class Helpers
     internal static IEnumerable<T> GetAllMatchingSymbols<T>(SemanticModel semanticModel, ExpressionSyntax? expression)
         where T : class
     {
-        var matchingSymbols = new List<T>();
+        List<T>? matchingSymbols = new List<T>();
         if (expression != null)
         {
-            var symbolInfo = semanticModel.GetSymbolInfo(expression);
+            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(expression);
             if (symbolInfo is { CandidateReason: CandidateReason.None, Symbol: T })
             {
                 matchingSymbols.Add(symbolInfo.Symbol as T);
@@ -100,7 +100,7 @@ internal static class Helpers
     {
         // TODO: Check what is the best way to do such checks
         if (symbol is not IMethodSymbol methodSymbol) return false;
-        var methodName = methodSymbol.ToString();
+        string? methodName = methodSymbol.ToString();
         return methodName.StartsWith("Moq.Language.ICallback", StringComparison.Ordinal)
                || methodName.StartsWith("Moq.Language.IReturns", StringComparison.Ordinal);
     }

--- a/Source/Moq.Analyzers/MoqMethodDescriptor.cs
+++ b/Source/Moq.Analyzers/MoqMethodDescriptor.cs
@@ -20,7 +20,7 @@ internal class MoqMethodDescriptor
 
     public bool IsMoqMethod(SemanticModel semanticModel, MemberAccessExpressionSyntax? method)
     {
-        var methodName = method?.Name.ToString();
+        string? methodName = method?.Name.ToString();
 
         Debug.Assert(!string.IsNullOrEmpty(methodName), nameof(methodName) + " != null or empty");
 
@@ -36,7 +36,7 @@ internal class MoqMethodDescriptor
             return false;
         }
 
-        var symbolInfo = semanticModel.GetSymbolInfo(method);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(method);
         return symbolInfo.CandidateReason switch
         {
             CandidateReason.OverloadResolutionFailure => symbolInfo.CandidateSymbols.OfType<IMethodSymbol>().Any(s => FullMethodNamePattern.IsMatch(s.ToString())),

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -27,7 +27,7 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
-        var objectCreation = (ObjectCreationExpressionSyntax)context.Node;
+        ObjectCreationExpressionSyntax? objectCreation = (ObjectCreationExpressionSyntax)context.Node;
 
         // TODO Think how to make this piece more elegant while fast
         GenericNameSyntax? genericName = objectCreation.Type as GenericNameSyntax;
@@ -42,7 +42,7 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         if (!string.Equals(genericName.Identifier.ToFullString(), "Mock", StringComparison.Ordinal)) return;
 
         // Full check
-        var constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation, context.CancellationToken);
+        SymbolInfo constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation, context.CancellationToken);
         if (constructorSymbolInfo.Symbol is not IMethodSymbol constructorSymbol || constructorSymbol.ContainingType == null || constructorSymbol.ContainingType.ConstructedFrom == null) return;
         if (constructorSymbol.MethodKind != MethodKind.Constructor) return;
         if (!string.Equals(
@@ -57,9 +57,9 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         if (!constructorSymbol.Parameters.Any(x => x.IsParams)) return;
 
         // Find mocked type
-        var typeArguments = genericName.TypeArgumentList.Arguments;
+        SeparatedSyntaxList<TypeSyntax> typeArguments = genericName.TypeArgumentList.Arguments;
         if (typeArguments.Count != 1) return;
-        var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0], context.CancellationToken);
+        SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0], context.CancellationToken);
         if (symbolInfo.Symbol is not INamedTypeSymbol symbol) return;
 
         // Checked mocked type
@@ -67,7 +67,7 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         {
             Debug.Assert(objectCreation.ArgumentList != null, "objectCreation.ArgumentList != null");
 
-            var diagnostic = Diagnostic.Create(Rule, objectCreation.ArgumentList?.GetLocation());
+            Diagnostic? diagnostic = Diagnostic.Create(Rule, objectCreation.ArgumentList?.GetLocation());
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -25,19 +25,19 @@ public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
-        var setupGetOrSetInvocation = (InvocationExpressionSyntax)context.Node;
+        InvocationExpressionSyntax? setupGetOrSetInvocation = (InvocationExpressionSyntax)context.Node;
 
         if (setupGetOrSetInvocation.Expression is not MemberAccessExpressionSyntax setupGetOrSetMethod) return;
         if (!string.Equals(setupGetOrSetMethod.Name.ToFullString(), "SetupGet", StringComparison.Ordinal)
             && !string.Equals(setupGetOrSetMethod.Name.ToFullString(), "SetupSet", StringComparison.Ordinal)) return;
 
-        var mockedMethodCall = Helpers.FindMockedMethodInvocationFromSetupMethod(setupGetOrSetInvocation);
+        InvocationExpressionSyntax? mockedMethodCall = Helpers.FindMockedMethodInvocationFromSetupMethod(setupGetOrSetInvocation);
         if (mockedMethodCall == null) return;
 
-        var mockedMethodSymbol = context.SemanticModel.GetSymbolInfo(mockedMethodCall, context.CancellationToken).Symbol;
+        ISymbol? mockedMethodSymbol = context.SemanticModel.GetSymbolInfo(mockedMethodCall, context.CancellationToken).Symbol;
         if (mockedMethodSymbol == null) return;
 
-        var diagnostic = Diagnostic.Create(Rule, mockedMethodCall.GetLocation());
+        Diagnostic? diagnostic = Diagnostic.Create(Rule, mockedMethodCall.GetLocation());
         context.ReportDiagnostic(diagnostic);
     }
 }

--- a/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -25,7 +25,7 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
-        var objectCreation = (ObjectCreationExpressionSyntax)context.Node;
+        ObjectCreationExpressionSyntax? objectCreation = (ObjectCreationExpressionSyntax)context.Node;
 
         // TODO Think how to make this piece more elegant while fast
         GenericNameSyntax? genericName = objectCreation.Type as GenericNameSyntax;
@@ -40,7 +40,7 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
         if (!string.Equals(genericName.Identifier.ToFullString(), "Mock", StringComparison.Ordinal)) return;
 
         // Full check
-        var constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation, context.CancellationToken);
+        SymbolInfo constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation, context.CancellationToken);
         if (constructorSymbolInfo.Symbol is not IMethodSymbol constructorSymbol || constructorSymbol.ContainingType == null || constructorSymbol.ContainingType.ConstructedFrom == null) return;
         if (constructorSymbol.MethodKind != MethodKind.Constructor) return;
         if (!string.Equals(
@@ -49,15 +49,15 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
                 StringComparison.Ordinal)) return;
 
         // Find mocked type
-        var typeArguments = genericName.TypeArgumentList.Arguments;
+        SeparatedSyntaxList<TypeSyntax> typeArguments = genericName.TypeArgumentList.Arguments;
         if (typeArguments.Count != 1) return;
-        var symbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0], context.CancellationToken);
+        SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(typeArguments[0], context.CancellationToken);
         if (symbolInfo.Symbol is not INamedTypeSymbol symbol) return;
 
         // Checked mocked type
         if (symbol.IsSealed && symbol.TypeKind != TypeKind.Delegate)
         {
-            var diagnostic = Diagnostic.Create(Rule, typeArguments[0].GetLocation());
+            Diagnostic? diagnostic = Diagnostic.Create(Rule, typeArguments[0].GetLocation());
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -22,21 +22,21 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
 
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
-        var setupInvocation = (InvocationExpressionSyntax)context.Node;
+        InvocationExpressionSyntax? setupInvocation = (InvocationExpressionSyntax)context.Node;
 
         if (setupInvocation.Expression is MemberAccessExpressionSyntax memberAccessExpression && Helpers.IsMoqSetupMethod(context.SemanticModel, memberAccessExpression))
         {
-            var mockedMemberExpression = Helpers.FindMockedMemberExpressionFromSetupMethod(setupInvocation);
+            ExpressionSyntax? mockedMemberExpression = Helpers.FindMockedMemberExpressionFromSetupMethod(setupInvocation);
             if (mockedMemberExpression == null)
             {
                 return;
             }
 
-            var symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
+            SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
             if (symbolInfo.Symbol is IPropertySymbol or IMethodSymbol
                 && !IsMethodOverridable(symbolInfo.Symbol))
             {
-                var diagnostic = Diagnostic.Create(Rule, mockedMemberExpression.GetLocation());
+                Diagnostic? diagnostic = Diagnostic.Create(Rule, mockedMemberExpression.GetLocation());
                 context.ReportDiagnostic(diagnostic);
             }
         }

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -22,22 +22,22 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
 
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
-        var setupInvocation = (InvocationExpressionSyntax)context.Node;
+        InvocationExpressionSyntax? setupInvocation = (InvocationExpressionSyntax)context.Node;
 
         if (setupInvocation.Expression is MemberAccessExpressionSyntax memberAccessExpression && Helpers.IsMoqSetupMethod(context.SemanticModel, memberAccessExpression))
         {
-            var mockedMemberExpression = Helpers.FindMockedMemberExpressionFromSetupMethod(setupInvocation);
+            ExpressionSyntax? mockedMemberExpression = Helpers.FindMockedMemberExpressionFromSetupMethod(setupInvocation);
             if (mockedMemberExpression == null)
             {
                 return;
             }
 
-            var symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
+            SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
             if ((symbolInfo.Symbol is IPropertySymbol || symbolInfo.Symbol is IMethodSymbol)
                 && !IsMethodOverridable(symbolInfo.Symbol)
                 && IsMethodReturnTypeTask(symbolInfo.Symbol))
             {
-                var diagnostic = Diagnostic.Create(Rule, mockedMemberExpression.GetLocation());
+                Diagnostic? diagnostic = Diagnostic.Create(Rule, mockedMemberExpression.GetLocation());
                 context.ReportDiagnostic(diagnostic);
             }
         }
@@ -51,7 +51,7 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
 
     private static bool IsMethodReturnTypeTask(ISymbol methodSymbol)
     {
-        var type = methodSymbol.ToDisplayString();
+        string? type = methodSymbol.ToDisplayString();
         return string.Equals(type, "System.Threading.Tasks.Task", StringComparison.Ordinal)
                || string.Equals(type, "System.Threading.ValueTask", StringComparison.Ordinal)
                || type.StartsWith("System.Threading.Tasks.Task<", StringComparison.Ordinal)


### PR DESCRIPTION
There is mixed use of explicit types and var keyword. There are also cases where the var keyword cannot be used. Rather than have mixed cases, update all code to use explicit types and enable .editorconfig rule to enforce code style

Fixes #53