### PR TITLE
Fix `dotnet test` when not generating code coverage reports

### DIFF
--- a/build/targets/tests/Tests.targets
+++ b/build/targets/tests/Tests.targets
@@ -25,6 +25,11 @@
     <ItemGroup>
       <_CoverageFiles Include="$(_TestCoverageGlob)" />
     </ItemGroup>
-    <ReportGenerator ProjectDirectory="$(MSBuildProjectDirectory)" ReportFiles="@(_CoverageFiles)" TargetDirectory="$(_TestCoverageReportDirectory)" ReportTypes="MarkdownSummaryGithub;Cobertura;HtmlInline" />
+    <ReportGenerator
+      Condition=" '@(_CoverageFiles)' != '' "
+      ProjectDirectory="$(MSBuildProjectDirectory)"
+      ReportFiles="@(_CoverageFiles)"
+      TargetDirectory="$(_TestCoverageReportDirectory)"
+      ReportTypes="MarkdownSummaryGithub;Cobertura;HtmlInline" />
   </Target>
 </Project>


### PR DESCRIPTION
#79 added code coverage reports, but broke a basic `dotnet test`. In that case no Cobertura reports are generated and thus the `<ReportGenerator>` task fails.

Fix by conditioning the report generator on having reports to process.