### PR TITLE
Add analyzer release tracking

### DIFF
--- a/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -50,3 +50,11 @@ Moq1000 | Moq | Warning | NoSealedClassMocksAnalyzer
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 Moq1002 | Moq | Warning | ConstructorArgumentsShouldMatchAnalyzer
+
+## Release 0.0.7
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1200 | Moq | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer

--- a/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -58,3 +58,11 @@ Moq1002 | Moq | Warning | ConstructorArgumentsShouldMatchAnalyzer
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 Moq1200 | Moq | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer
+
+## Release 0.0.8
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1300 | Moq | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer

--- a/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -66,3 +66,11 @@ Moq1200 | Moq | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 Moq1300 | Moq | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer
+
+## Release 0.0.9
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1201 | Moq | Error | SetupShouldNotIncludeAsyncResultAnalyzer

--- a/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -25,3 +25,20 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 Moq1001 | Moq | Warning | NoMocksForSealedClassesAnalyzer
 Moq1002 | Moq | Warning | NoParametersForMockedInterfacesAnalyzer
+
+## Release 0.0.4.43043
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1100 | Moq | Warning | CallbackSignatureShouldMatchMockedMethodAnalyzer
+Moq1000 | Moq | Warning | ConstructorArgumentsShouldMatchAnalyzer
+
+### Changed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1001 | Moq | Warning | NoConstructorArgumentsForInterfaceMockAnalyzer
+Moq1101 | Moq | Warning | NoMethodsInPropertySetupAnalyzer
+Moq1000 | Moq | Warning | NoSealedClassMocksAnalyzer

--- a/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -19,13 +19,6 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 Moq1003 | Moq | Warning | MatchingConstructorParametersAnalyzer
 
-### Changed Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-Moq1001 | Moq | Warning | NoMocksForSealedClassesAnalyzer
-Moq1002 | Moq | Warning | NoParametersForMockedInterfacesAnalyzer
-
 ## Release 0.0.4.43043
 
 ### New Rules
@@ -35,21 +28,13 @@ Rule ID | Category | Severity | Notes
 Moq1100 | Moq | Warning | CallbackSignatureShouldMatchMockedMethodAnalyzer
 Moq1000 | Moq | Warning | ConstructorArgumentsShouldMatchAnalyzer
 
-### Changed Rules
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-Moq1001 | Moq | Warning | NoConstructorArgumentsForInterfaceMockAnalyzer
-Moq1101 | Moq | Warning | NoMethodsInPropertySetupAnalyzer
-Moq1000 | Moq | Warning | NoSealedClassMocksAnalyzer
-
 ## Release 0.0.6
 
-### Changed Rules
+### Removed Rules
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-Moq1002 | Moq | Warning | ConstructorArgumentsShouldMatchAnalyzer
+Moq1003 | Moq | Warning | ConstructorArgumentsShouldMatchAnalyzer
 
 ## Release 0.0.7
 

--- a/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -1,0 +1,12 @@
+﻿; Shipped analyzer releases
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+## Release 0.0.1.22865
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1101 | Moq | Warning | CallbackSignatureAnalyzer
+Moq1002 | Moq | Warning | ShouldNotAllowParametersForMockedInterfaceAnalyzer
+Moq1001 | Moq | Warning | ShouldNotMockSealedClassesAnalyzer

--- a/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -42,3 +42,11 @@ Rule ID | Category | Severity | Notes
 Moq1001 | Moq | Warning | NoConstructorArgumentsForInterfaceMockAnalyzer
 Moq1101 | Moq | Warning | NoMethodsInPropertySetupAnalyzer
 Moq1000 | Moq | Warning | NoSealedClassMocksAnalyzer
+
+## Release 0.0.6
+
+### Changed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1002 | Moq | Warning | ConstructorArgumentsShouldMatchAnalyzer

--- a/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Shipped.md
@@ -10,3 +10,18 @@ Rule ID | Category | Severity | Notes
 Moq1101 | Moq | Warning | CallbackSignatureAnalyzer
 Moq1002 | Moq | Warning | ShouldNotAllowParametersForMockedInterfaceAnalyzer
 Moq1001 | Moq | Warning | ShouldNotMockSealedClassesAnalyzer
+
+## Release 0.0.3.40797
+
+### New Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1003 | Moq | Warning | MatchingConstructorParametersAnalyzer
+
+### Changed Rules
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1001 | Moq | Warning | NoMocksForSealedClassesAnalyzer
+Moq1002 | Moq | Warning | NoParametersForMockedInterfacesAnalyzer

--- a/Source/Moq.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,17 +1,2 @@
 ﻿; Unshipped analyzer release
 ; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
-
-### Changed Rules
-
-Documentation links added for every rule.
-
-Rule ID | Category | Severity | Notes
---------|----------|----------|-------
-Moq1000 | Moq | Warning | NoSealedClassMocksAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1000.md)
-Moq1001 | Moq | Warning | NoConstructorArgumentsForInterfaceMockAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1001.md)
-Moq1002 | Moq | Warning | ConstructorArgumentsShouldMatchAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1002.md)
-Moq1100 | Moq | Warning | CallbackSignatureShouldMatchMockedMethodAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1100.md)
-Moq1101 | Moq | Warning | NoMethodsInPropertySetupAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1101.md)
-Moq1200 | Moq | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1200.md)
-Moq1201 | Moq | Error | SetupShouldNotIncludeAsyncResultAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1201.md)
-Moq1300 | Moq | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1300.md)

--- a/Source/Moq.Analyzers/AnalyzerReleases.Unshipped.md
+++ b/Source/Moq.Analyzers/AnalyzerReleases.Unshipped.md
@@ -1,0 +1,17 @@
+﻿; Unshipped analyzer release
+; https://github.com/dotnet/roslyn-analyzers/blob/main/src/Microsoft.CodeAnalysis.Analyzers/ReleaseTrackingAnalyzers.Help.md
+
+### Changed Rules
+
+Documentation links added for every rule.
+
+Rule ID | Category | Severity | Notes
+--------|----------|----------|-------
+Moq1000 | Moq | Warning | NoSealedClassMocksAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1000.md)
+Moq1001 | Moq | Warning | NoConstructorArgumentsForInterfaceMockAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1001.md)
+Moq1002 | Moq | Warning | ConstructorArgumentsShouldMatchAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1002.md)
+Moq1100 | Moq | Warning | CallbackSignatureShouldMatchMockedMethodAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1100.md)
+Moq1101 | Moq | Warning | NoMethodsInPropertySetupAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1101.md)
+Moq1200 | Moq | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1200.md)
+Moq1201 | Moq | Error | SetupShouldNotIncludeAsyncResultAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1201.md)
+Moq1300 | Moq | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1300.md)

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -5,13 +5,14 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
 {
     private static readonly MoqMethodDescriptorBase MoqAsMethodDescriptor = new MoqAsMethodDescriptor();
 
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+    private static readonly DiagnosticDescriptor Rule = new(
         Diagnostics.AsShouldBeUsedOnlyForInterfaceId,
         Diagnostics.AsShouldBeUsedOnlyForInterfaceTitle,
         Diagnostics.AsShouldBeUsedOnlyForInterfaceMessage,
         Diagnostics.Category,
         DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{Diagnostics.AsShouldBeUsedOnlyForInterfaceId}.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -3,13 +3,14 @@ namespace Moq.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+    private static readonly DiagnosticDescriptor Rule = new(
         Diagnostics.CallbackSignatureShouldMatchMockedMethodId,
         Diagnostics.CallbackSignatureShouldMatchMockedMethodTitle,
         Diagnostics.CallbackSignatureShouldMatchMockedMethodMessage,
         Diagnostics.Category,
         DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{Diagnostics.CallbackSignatureShouldMatchMockedMethodId}.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -5,13 +5,14 @@ namespace Moq.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+    private static readonly DiagnosticDescriptor Rule = new(
         Diagnostics.ConstructorArgumentsShouldMatchId,
         Diagnostics.ConstructorArgumentsShouldMatchTitle,
         Diagnostics.ConstructorArgumentsShouldMatchMessage,
         Diagnostics.Category,
         DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{Diagnostics.ConstructorArgumentsShouldMatchId}.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -5,13 +5,14 @@ namespace Moq.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+    private static readonly DiagnosticDescriptor Rule = new(
         Diagnostics.NoConstructorArgumentsForInterfaceMockId,
         Diagnostics.NoConstructorArgumentsForInterfaceMockTitle,
         Diagnostics.NoConstructorArgumentsForInterfaceMockMessage,
         Diagnostics.Category,
         DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{Diagnostics.NoConstructorArgumentsForInterfaceMockId}.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -3,13 +3,14 @@ namespace Moq.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+    private static readonly DiagnosticDescriptor Rule = new(
         Diagnostics.NoMethodsInPropertySetupId,
         Diagnostics.NoMethodsInPropertySetupTitle,
         Diagnostics.NoMethodsInPropertySetupMessage,
         Diagnostics.Category,
         DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{Diagnostics.NoMethodsInPropertySetupId}.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {

--- a/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -3,13 +3,14 @@ namespace Moq.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+    private static readonly DiagnosticDescriptor Rule = new(
         Diagnostics.NoSealedClassMocksId,
         Diagnostics.NoSealedClassMocksTitle,
         Diagnostics.NoSealedClassMocksMessage,
         Diagnostics.Category,
         DiagnosticSeverity.Warning,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{Diagnostics.NoSealedClassMocksId}.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -3,13 +3,14 @@ namespace Moq.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+    private static readonly DiagnosticDescriptor Rule = new(
         Diagnostics.SetupShouldBeUsedOnlyForOverridableMembersId,
         Diagnostics.SetupShouldBeUsedOnlyForOverridableMembersTitle,
         Diagnostics.SetupShouldBeUsedOnlyForOverridableMembersMessage,
         Diagnostics.Category,
         DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{Diagnostics.SetupShouldBeUsedOnlyForOverridableMembersId}.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -3,13 +3,14 @@
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
 {
-    private static readonly DiagnosticDescriptor Rule = new DiagnosticDescriptor(
+    private static readonly DiagnosticDescriptor Rule = new(
         Diagnostics.SetupShouldNotIncludeAsyncResultId,
         Diagnostics.SetupShouldNotIncludeAsyncResultTitle,
         Diagnostics.SetupShouldNotIncludeAsyncResultMessage,
         Diagnostics.Category,
         DiagnosticSeverity.Error,
-        isEnabledByDefault: true);
+        isEnabledByDefault: true,
+        helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{Diagnostics.SetupShouldNotIncludeAsyncResultId}.md");
 
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 


### PR DESCRIPTION
Enable analyzer release tracking (i.e. `AnalyzerReleases.Shipped.md`). Fixes #72.

Wokflow was as follows:

1. Download old release from NuGet
2. Open in ILSpy to view the analyzer metadata
3. Create appropriate release in `AnalyzerReleases.Shipped.md`
4. GOTO 1
5. Add help links pointing to our `//docs/rules` files
    - I tried to make the base URL a helper function, but the analyzer is unable to add documentation URLs to the Unshipped file if the URL isn't a constant. So instead I used string interpolation so at least the ID isn't repeated.
6. Use release analyzer codefix to add an unshipped section that adds help links