### PR TITLE
Fix SA0001: XML comment analysis is disabled due to project configuration

### DIFF
--- a/Source/Moq.Analyzers.Test/.editorconfig
+++ b/Source/Moq.Analyzers.Test/.editorconfig
@@ -1,0 +1,14 @@
+root = false
+
+# C# files
+[*.cs]
+
+#### XMLDocs validation ####
+# CS1573: Parameter 'parameter' has no matching param tag in the XML comment for 'parameter' (but other parameters do)
+dotnet_diagnostic.CS1573.severity = suggestion
+
+# CS1591: Missing XML comment for publicly visible type or member 'Type_or_Member'
+dotnet_diagnostic.CS1591.severity = suggestion
+
+# CS1712: Type parameter 'type parameter' has no matching typeparam tag in the XML comment on 'type' (but other type parameters do)
+dotnet_diagnostic.CS1712.severity = suggestion

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -1,5 +1,8 @@
 namespace Moq.Analyzers;
 
+/// <summary>
+/// Mock.As() should take interfaces only.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
 {
@@ -18,8 +21,10 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{RuleId}.md");
 
+    /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
+    /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -1,5 +1,8 @@
 namespace Moq.Analyzers;
 
+/// <summary>
+/// Callback signature must match the signature of the mocked method.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyzer
 {
@@ -16,11 +19,13 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
         isEnabledByDefault: true,
         helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{RuleId}.md");
 
+    /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {
         get { return ImmutableArray.Create(Rule); }
     }
 
+    /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -6,20 +6,26 @@ using Microsoft.CodeAnalysis.Text;
 
 namespace Moq.Analyzers;
 
+/// <summary>
+/// Fixes <see cref="CallbackSignatureShouldMatchMockedMethodAnalyzer"/>.
+/// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(CallbackSignatureShouldMatchMockedMethodCodeFix))]
 [Shared]
 public class CallbackSignatureShouldMatchMockedMethodCodeFix : CodeFixProvider
 {
+    /// <inheritdoc />
     public sealed override ImmutableArray<string> FixableDiagnosticIds
     {
         get { return ImmutableArray.Create(CallbackSignatureShouldMatchMockedMethodAnalyzer.RuleId); }
     }
 
+    /// <inheritdoc />
     public sealed override FixAllProvider GetFixAllProvider()
     {
         return WellKnownFixAllProviders.BatchFixer;
     }
 
+    /// <inheritdoc />
     public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
     {
         SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -2,6 +2,9 @@ using System.Diagnostics;
 
 namespace Moq.Analyzers;
 
+/// <summary>
+/// Parameters provided into mock do not match any existing constructors.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 {
@@ -18,6 +21,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{RuleId}.md");
 
+    /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {
         get { return ImmutableArray.Create(Rule); }

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -2,6 +2,9 @@ using System.Diagnostics;
 
 namespace Moq.Analyzers;
 
+/// <summary>
+/// Mocked interfaces cannot have constructor parameters.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
 {
@@ -18,11 +21,13 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{RuleId}.md");
 
+    /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {
         get { return ImmutableArray.Create(Rule); }
     }
 
+    /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -1,5 +1,8 @@
 namespace Moq.Analyzers;
 
+/// <summary>
+/// SetupGet/SetupSet should be used for properties, not for methods.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
 {
@@ -16,11 +19,13 @@ public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{RuleId}.md");
 
+    /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {
         get { return ImmutableArray.Create(Rule); }
     }
 
+    /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();

--- a/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -1,5 +1,8 @@
 namespace Moq.Analyzers;
 
+/// <summary>
+/// Sealed classes cannot be mocked.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
 {
@@ -16,11 +19,13 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{RuleId}.md");
 
+    /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics
     {
         get { return ImmutableArray.Create(Rule); }
     }
 
+    /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,5 +1,8 @@
 namespace Moq.Analyzers;
 
+/// <summary>
+/// Setup should be used only for overridable members.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnalyzer
 {
@@ -16,8 +19,10 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
         isEnabledByDefault: true,
         helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{RuleId}.md");
 
+    /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
+    /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -1,5 +1,8 @@
 ﻿namespace Moq.Analyzers;
 
+/// <summary>
+/// Setup of async method should use ReturnsAsync instead of .Result.
+/// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
 {
@@ -16,8 +19,10 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
         isEnabledByDefault: true,
         helpLinkUri: $"https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/{RuleId}.md");
 
+    /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => ImmutableArray.Create(Rule);
 
+    /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();

--- a/build/targets/codeanalysis/CodeAnalysis.props
+++ b/build/targets/codeanalysis/CodeAnalysis.props
@@ -4,6 +4,7 @@
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <AnalysisMode>preview</AnalysisMode>
     <WarningLevel>9999</WarningLevel>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix SA0001: XML comment analysis is disabled due to project configuration

Added xmldocs for all of our public types in the analyzer project. Added a `.editorconfig` in the test project the demotes the various "xmldocs missing on public types" diagnostics from warnings to info/suggestions.

This contributes to #26 (more work needed).