### PR TITLE
Fix trivial warnings

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -85,6 +85,10 @@ dotnet_code_quality_unused_parameters = all:suggestion
 # Suppression preferences
 dotnet_remove_unnecessary_suppression_exclusions = none
 
+# XMLDocs preferences
+# SA1600: Elements should be documented. We disable this it requires xmldocs for _all_ members. CS1591 already covers documenting public members.
+dotnet_diagnostic.SA1600.severity = silent
+
 #### C# Coding Conventions ####
 [*.cs]
 

--- a/.editorconfig
+++ b/.editorconfig
@@ -45,6 +45,7 @@ dotnet_style_qualification_for_event = false:silent
 dotnet_style_qualification_for_field = false:silent
 dotnet_style_qualification_for_method = false:silent
 dotnet_style_qualification_for_property = false:silent
+dotnet_diagnostic.SA1101.severity = silent # SA1101: Prefix local calls with this
 
 # Language keywords vs BCL types preferences
 dotnet_style_predefined_type_for_locals_parameters_members = true:silent

--- a/.editorconfig
+++ b/.editorconfig
@@ -38,6 +38,7 @@ insert_final_newline = true
 dotnet_separate_import_directive_groups = false
 dotnet_sort_system_directives_first = true
 file_header_template = unset
+dotnet_diagnostic.SA1633.severity = silent # A C# code file is missing a standard file header. https://github.com/DotNetAnalyzers/StyleCopAnalyzers/blob/master/documentation/SA1633.md
 
 # this. and Me. preferences
 dotnet_style_qualification_for_event = false:silent

--- a/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
@@ -9,11 +9,9 @@ public class AsAcceptOnlyInterfaceAnalyzerTests
     {
         return new object[][]
         {
-            // TODO: .As<BaseSampleClass> and .As<SampleClass> feels redundant
             ["""new Mock<BaseSampleClass>().As<{|Moq1300:BaseSampleClass|}>();"""],
             ["""new Mock<BaseSampleClass>().As<{|Moq1300:SampleClass|}>();"""],
             ["""new Mock<SampleClass>().As<ISampleInterface>();"""],
-            // TODO: Testing with .Setup() and .Returns() seems unnecessary.
             ["""new Mock<SampleClass>().As<ISampleInterface>().Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>())).Returns(10);"""],
         }.WithNamespaces().WithReferenceAssemblyGroups();
     }

--- a/Source/Moq.Analyzers.Test/GlobalSuppressions.cs
+++ b/Source/Moq.Analyzers.Test/GlobalSuppressions.cs
@@ -4,4 +4,3 @@
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1503:Braces must not be omitted", Justification = "Not required")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "Not required")]

--- a/Source/Moq.Analyzers.Test/GlobalSuppressions.cs
+++ b/Source/Moq.Analyzers.Test/GlobalSuppressions.cs
@@ -3,7 +3,6 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1652:Enable XML documentation output", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1503:Braces must not be omitted", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "Not required")]

--- a/Source/Moq.Analyzers.Test/GlobalSuppressions.cs
+++ b/Source/Moq.Analyzers.Test/GlobalSuppressions.cs
@@ -3,7 +3,5 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1652:Enable XML documentation output", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1503:Braces must not be omitted", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "Not required")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Not required")]

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -27,6 +27,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         get { return ImmutableArray.Create(Rule); }
     }
 
+    /// <inheritdoc />
     public override void Initialize(AnalysisContext context)
     {
         context.EnableConcurrentExecution();

--- a/Source/Moq.Analyzers/GlobalSuppressions.cs
+++ b/Source/Moq.Analyzers/GlobalSuppressions.cs
@@ -4,4 +4,3 @@
 // a specific target and scoped to a namespace, type, member, etc.
 
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1503:Braces must not be omitted", Justification = "Not required")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "Not required")]

--- a/Source/Moq.Analyzers/GlobalSuppressions.cs
+++ b/Source/Moq.Analyzers/GlobalSuppressions.cs
@@ -3,7 +3,6 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1633:File must have header", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1652:Enable XML documentation output", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1503:Braces must not be omitted", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "Not required")]

--- a/Source/Moq.Analyzers/GlobalSuppressions.cs
+++ b/Source/Moq.Analyzers/GlobalSuppressions.cs
@@ -3,7 +3,5 @@
 // Project-level suppressions either have no target or are given
 // a specific target and scoped to a namespace, type, member, etc.
 
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1652:Enable XML documentation output", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.LayoutRules", "SA1503:Braces must not be omitted", Justification = "Not required")]
 [assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.ReadabilityRules", "SA1101:Prefix local calls with this", Justification = "Not required")]
-[assembly: System.Diagnostics.CodeAnalysis.SuppressMessage("StyleCop.CSharp.DocumentationRules", "SA1600:Elements should be documented", Justification = "Not required")]


### PR DESCRIPTION
Contributes to #26 (more work needed).

Fix trivial cases of warnings and move some duplicated analyzer settings from `GlobalSupressions.cs` to `.editorconfig`.