### PR TITLE
Add more analyzers and bump Meziantou.Analzer to latest version

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -89,6 +89,8 @@ dotnet_remove_unnecessary_suppression_exclusions = none
 # XMLDocs preferences
 # SA1600: Elements should be documented. We disable this it requires xmldocs for _all_ members. CS1591 already covers documenting public members.
 dotnet_diagnostic.SA1600.severity = silent
+# AV2305: Missing XML comment for internally visible type, member or parameter
+dotnet_diagnostic.AV2305.severity = silent
 
 #### C# Coding Conventions ####
 [*.cs]
@@ -380,6 +382,14 @@ dotnet_naming_style.s_camelcase.required_prefix = s_
 dotnet_naming_style.s_camelcase.required_suffix =
 dotnet_naming_style.s_camelcase.word_separator =
 dotnet_naming_style.s_camelcase.capitalization = camel_case
+
+# AV1580: Method argument calls a nested method
+# Because debugger breakpoints cannot be set inside expressions, avoid overuse of nested method calls.
+# Example: string result = ConvertToXml(ApplyTransforms(ExecuteQuery(GetConfigurationSettings(source))));
+# requires extra steps to inspect intermediate method return values. On the other hard, were this expression broken into intermediate variables, setting a breakpoint on one of them would be sufficient.
+#
+# This is moved to silent because it's flagging foo.AsSpan()
+dotnet_diagnostic.AV1580.severity = silent
 
 # MA0040: Forward the CancellationToken parameter to methods that take one
 dotnet_diagnostic.MA0040.severity = error

--- a/.editorconfig
+++ b/.editorconfig
@@ -397,3 +397,13 @@ dotnet_diagnostic.AV1580.severity = silent
 dotnet_diagnostic.MA0040.severity = error
 # Async analyzer
 dotnet_diagnostic.CA2016.severity = error
+
+#### Handling TODOs ####
+# This is a popular rule in analyzers. Everyone has an opinion and
+# some of the severity levels conflict. We don't need all of these
+# to fire, only one. Pick one and mark it as informational so we
+# don't lose track.
+# S1135: Track uses of "TODO" tags
+dotnet_diagnostic.S1135.severity = suggestion
+# AV2318: Work-tracking TODO comment should be removed
+dotnet_diagnostic.AV2318.severity = none

--- a/.editorconfig
+++ b/.editorconfig
@@ -82,6 +82,8 @@ dotnet_style_readonly_field = true:warning
 
 # Parameter preferences
 dotnet_code_quality_unused_parameters = all:suggestion
+# AV1561: Signature contains too many parameters
+dotnet_diagnostic.AV1561.severity = suggestion
 
 # Suppression preferences
 dotnet_remove_unnecessary_suppression_exclusions = none

--- a/Source/Moq.Analyzers.Test/.editorconfig
+++ b/Source/Moq.Analyzers.Test/.editorconfig
@@ -12,3 +12,7 @@ dotnet_diagnostic.CS1591.severity = suggestion
 
 # CS1712: Type parameter 'type parameter' has no matching typeparam tag in the XML comment on 'type' (but other type parameters do)
 dotnet_diagnostic.CS1712.severity = suggestion
+
+# VSTHRD200: Use "Async" suffix for async methods
+# Just about every test method is async, doesn't provide any real value and clustters up test window
+dotnet_diagnostic.VSTHRD200.severity = none

--- a/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -35,6 +35,7 @@ public class ConstructorArgumentsShouldMatchAnalyzerTests
             ["""new Mock<AbstractGenericClassDefaultCtor<object>>{|Moq1002:(42)|};"""],
             ["""new Mock<AbstractGenericClassDefaultCtor<object>>();"""],
             ["""new Mock<AbstractGenericClassDefaultCtor<object>>(MockBehavior.Default);"""],
+
             // TODO: "I think this _should_ fail, but currently passes. Tracked by #55."
             // ["""new Mock<AbstractClassWithCtor>();"""],
             ["""new Mock<AbstractClassWithCtor>{|Moq1002:("42")|};"""],

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -23,7 +23,6 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Verify.Nupkg" />
-    <PackageReference Include="Verify.Xunit" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Moq.Analyzers\Moq.Analyzers.csproj" AddPackageAsOutput="true" />

--- a/Source/Moq.Analyzers.Test/PackageTests.cs
+++ b/Source/Moq.Analyzers.Test/PackageTests.cs
@@ -4,16 +4,11 @@ namespace Moq.Analyzers.Test;
 
 public class PackageTests
 {
-    private static readonly FileInfo Package;
-
-    static PackageTests()
-    {
-        Package = new FileInfo(Assembly.GetExecutingAssembly().Location)
-            .Directory!
-            .GetFiles("Moq.Analyzers*.nupkg")
-            .OrderByDescending(fileInfo => fileInfo.LastWriteTimeUtc)
-            .First();
-    }
+    private static readonly FileInfo Package = new FileInfo(Assembly.GetExecutingAssembly().Location)
+        .Directory!
+        .GetFiles("Moq.Analyzers*.nupkg")
+        .OrderByDescending(fileInfo => fileInfo.LastWriteTimeUtc)
+        .First();
 
     [Fact]
     public Task Baseline()

--- a/Source/Moq.Analyzers.Test/PackageTests.cs
+++ b/Source/Moq.Analyzers.Test/PackageTests.cs
@@ -11,7 +11,7 @@ public class PackageTests
         Package = new FileInfo(Assembly.GetExecutingAssembly().Location)
             .Directory!
             .GetFiles("Moq.Analyzers*.nupkg")
-            .OrderByDescending(f => f.LastWriteTimeUtc)
+            .OrderByDescending(fileInfo => fileInfo.LastWriteTimeUtc)
             .First();
     }
 

--- a/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/Source/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -32,6 +32,7 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         if (context.Node is not InvocationExpressionSyntax invocationExpression)

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -67,10 +67,10 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
         }
         else
         {
-            for (int i = 0; i < mockedMethodArguments.Count; i++)
+            for (int argumentIndex = 0; argumentIndex < mockedMethodArguments.Count; argumentIndex++)
             {
-                TypeInfo mockedMethodArgumentType = context.SemanticModel.GetTypeInfo(mockedMethodArguments[i].Expression, context.CancellationToken);
-                TypeInfo lambdaParameterType = context.SemanticModel.GetTypeInfo(lambdaParameters[i].Type, context.CancellationToken);
+                TypeInfo mockedMethodArgumentType = context.SemanticModel.GetTypeInfo(mockedMethodArguments[argumentIndex].Expression, context.CancellationToken);
+                TypeInfo lambdaParameterType = context.SemanticModel.GetTypeInfo(lambdaParameters[argumentIndex].Type, context.CancellationToken);
                 string? mockedMethodTypeName = mockedMethodArgumentType.ConvertedType?.ToString();
                 string? lambdaParameterTypeName = lambdaParameterType.ConvertedType?.ToString();
                 if (!string.Equals(mockedMethodTypeName, lambdaParameterTypeName, StringComparison.Ordinal))

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -33,6 +33,7 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         InvocationExpressionSyntax? callbackOrReturnsInvocation = (InvocationExpressionSyntax)context.Node;

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -54,6 +54,7 @@ public class CallbackSignatureShouldMatchMockedMethodCodeFix : CodeFixProvider
             diagnostic);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private async Task<Document> FixCallbackSignatureAsync(SyntaxNode root, Document document, ParameterListSyntax? oldParameters, CancellationToken cancellationToken)
     {
         SemanticModel? semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -48,9 +48,9 @@ public class CallbackSignatureShouldMatchMockedMethodCodeFix : CodeFixProvider
         // Register a code action that will invoke the fix.
         context.RegisterCodeFix(
             CodeAction.Create(
-                title: "Fix Moq callback signature",
-                createChangedDocument: cancellationToken => FixCallbackSignatureAsync(root, context.Document, badArgumentListSyntax, cancellationToken),
-                equivalenceKey: "Fix Moq callback signature"),
+                "Fix Moq callback signature",
+                cancellationToken => FixCallbackSignatureAsync(root, context.Document, badArgumentListSyntax, cancellationToken),
+                "Fix Moq callback signature"),
             diagnostic);
     }
 

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -49,7 +49,7 @@ public class CallbackSignatureShouldMatchMockedMethodCodeFix : CodeFixProvider
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: "Fix Moq callback signature",
-                createChangedDocument: c => FixCallbackSignatureAsync(root, context.Document, badArgumentListSyntax, c),
+                createChangedDocument: cancellationToken => FixCallbackSignatureAsync(root, context.Document, badArgumentListSyntax, cancellationToken),
                 equivalenceKey: "Fix Moq callback signature"),
             diagnostic);
     }
@@ -81,10 +81,10 @@ public class CallbackSignatureShouldMatchMockedMethodCodeFix : CodeFixProvider
         }
 
         ParameterListSyntax? newParameters = SyntaxFactory.ParameterList(SyntaxFactory.SeparatedList(matchingMockedMethods[0].Parameters.Select(
-            p =>
+            parameterSymbol =>
             {
-                TypeSyntax? type = SyntaxFactory.ParseTypeName(p.Type.ToMinimalDisplayString(semanticModel, oldParameters.SpanStart));
-                return SyntaxFactory.Parameter(default, SyntaxFactory.TokenList(), type, SyntaxFactory.Identifier(p.Name), null);
+                TypeSyntax? type = SyntaxFactory.ParseTypeName(parameterSymbol.Type.ToMinimalDisplayString(semanticModel, oldParameters.SpanStart));
+                return SyntaxFactory.Parameter(default, SyntaxFactory.TokenList(), type, SyntaxFactory.Identifier(parameterSymbol.Name), null);
             })));
 
         SyntaxNode? newRoot = root.ReplaceNode(oldParameters, newParameters);

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -35,6 +35,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ObjectCreationExpression);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         ObjectCreationExpressionSyntax? objectCreation = (ObjectCreationExpressionSyntax)context.Node;

--- a/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/Source/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -49,7 +49,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         IMethodSymbol? constructorSymbol = GetConstructorSymbol(context, objectCreation);
 
         // Vararg parameter is the one that takes all arguments for mocked class constructor
-        IParameterSymbol? varArgsConstructorParameter = constructorSymbol?.Parameters.FirstOrDefault(x => x.IsParams);
+        IParameterSymbol? varArgsConstructorParameter = constructorSymbol?.Parameters.FirstOrDefault(parameterSymbol => parameterSymbol.IsParams);
 
         // Vararg parameter are not used, so there are no arguments for mocked class constructor
         if (varArgsConstructorParameter == null) return;
@@ -61,14 +61,14 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        int varArgsConstructorParameterIdx = constructorSymbol.Parameters.IndexOf(varArgsConstructorParameter);
+        int varArgsConstructorParameterIndex = constructorSymbol.Parameters.IndexOf(varArgsConstructorParameter);
 
         // Find mocked type
         INamedTypeSymbol? mockedTypeSymbol = GetMockedSymbol(context, genericName);
         if (mockedTypeSymbol == null) return;
 
         // Skip first argument if it is not vararg - typically it is MockingBehavior argument
-        ArgumentSyntax[]? constructorArguments = objectCreation.ArgumentList?.Arguments.Skip(varArgsConstructorParameterIdx == 0 ? 0 : 1).ToArray();
+        ArgumentSyntax[]? constructorArguments = objectCreation.ArgumentList?.Arguments.Skip(varArgsConstructorParameterIndex == 0 ? 0 : 1).ToArray();
 
         if (!mockedTypeSymbol.IsAbstract)
         {
@@ -94,9 +94,9 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
                     .ToArray()!;
 
                 // Check all constructors of the abstract type
-                for (int i = 0; i < mockedTypeSymbol.Constructors.Length; i++)
+                for (int constructorIndex = 0; constructorIndex < mockedTypeSymbol.Constructors.Length; constructorIndex++)
                 {
-                    IMethodSymbol constructor = mockedTypeSymbol.Constructors[i];
+                    IMethodSymbol constructor = mockedTypeSymbol.Constructors[constructorIndex];
                     if (AreParametersMatching(constructor.Parameters, argumentTypes))
                     {
                         return; // Found a matching constructor
@@ -131,9 +131,9 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         }
 
         // Check if each parameter type matches in order
-        for (int i = 0; i < constructorParameters.Length; i++)
+        for (int constructorParameterIndex = 0; constructorParameterIndex < constructorParameters.Length; constructorParameterIndex++)
         {
-            if (!constructorParameters[i].Type.Equals(argumentTypes2[i], SymbolEqualityComparer.IncludeNullability))
+            if (!constructorParameters[constructorParameterIndex].Type.Equals(argumentTypes2[constructorParameterIndex], SymbolEqualityComparer.IncludeNullability))
             {
                 return false;
             }

--- a/Source/Moq.Analyzers/Helpers.cs
+++ b/Source/Moq.Analyzers/Helpers.cs
@@ -11,6 +11,7 @@ internal static class Helpers
         return MoqSetupMethodDescriptor.IsMatch(semanticModel, method, cancellationToken);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     internal static bool IsCallbackOrReturnInvocation(SemanticModel semanticModel, InvocationExpressionSyntax callbackOrReturnsInvocation)
     {
         MemberAccessExpressionSyntax? callbackOrReturnsMethod = callbackOrReturnsInvocation.Expression as MemberAccessExpressionSyntax;
@@ -68,22 +69,31 @@ internal static class Helpers
         return GetAllMatchingSymbols<IMethodSymbol>(semanticModel, mockedMethodInvocation);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     internal static IEnumerable<T> GetAllMatchingSymbols<T>(SemanticModel semanticModel, ExpressionSyntax? expression)
         where T : class
     {
-        List<T>? matchingSymbols = new List<T>();
-        if (expression != null)
+        if (expression == null)
         {
-            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(expression);
-            if (symbolInfo is { CandidateReason: CandidateReason.None, Symbol: T })
-            {
-                matchingSymbols.Add(symbolInfo.Symbol as T);
-            }
-            else if (symbolInfo.CandidateReason == CandidateReason.OverloadResolutionFailure)
-            {
-                matchingSymbols.AddRange(symbolInfo.CandidateSymbols.OfType<T>());
-            }
+            return Enumerable.Empty<T>();
         }
+
+        List<T> matchingSymbols = new();
+
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(expression);
+        if (symbolInfo is { CandidateReason: CandidateReason.None, Symbol: T })
+        {
+            matchingSymbols.Add(symbolInfo.Symbol as T);
+        }
+        else if (symbolInfo.CandidateReason == CandidateReason.OverloadResolutionFailure)
+        {
+            matchingSymbols.AddRange(symbolInfo.CandidateSymbols.OfType<T>());
+        }
+        else
+        {
+            throw new NotSupportedException("Symbol not supported.");
+        }
+
 
         return matchingSymbols;
     }

--- a/Source/Moq.Analyzers/Helpers.cs
+++ b/Source/Moq.Analyzers/Helpers.cs
@@ -95,7 +95,6 @@ internal static class Helpers
             throw new NotSupportedException("Symbol not supported.");
         }
 
-
         return matchingSymbols;
     }
 

--- a/Source/Moq.Analyzers/Helpers.cs
+++ b/Source/Moq.Analyzers/Helpers.cs
@@ -2,6 +2,7 @@
 
 namespace Moq.Analyzers;
 
+[System.Diagnostics.CodeAnalysis.SuppressMessage("Naming", "AV1708:Type name contains term that should be avoided", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
 internal static class Helpers
 {
     private static readonly MoqMethodDescriptorBase MoqSetupMethodDescriptor = new MoqSetupMethodDescriptor();

--- a/Source/Moq.Analyzers/MoqAsMethodDescriptor.cs
+++ b/Source/Moq.Analyzers/MoqAsMethodDescriptor.cs
@@ -8,6 +8,7 @@ internal class MoqAsMethodDescriptor : MoqMethodDescriptorBase
 {
     private const string MethodName = "As";
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     public override bool IsMatch(SemanticModel semanticModel, MemberAccessExpressionSyntax memberAccessSyntax, CancellationToken cancellationToken)
     {
         if (!IsFastMatch(memberAccessSyntax, MethodName.AsSpan()))

--- a/Source/Moq.Analyzers/MoqSetupMethodDescriptor.cs
+++ b/Source/Moq.Analyzers/MoqSetupMethodDescriptor.cs
@@ -8,6 +8,7 @@ internal class MoqSetupMethodDescriptor : MoqMethodDescriptorBase
 {
     private const string MethodName = "Setup";
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     public override bool IsMatch(SemanticModel semanticModel, MemberAccessExpressionSyntax memberAccessSyntax, CancellationToken cancellationToken)
     {
         if (!IsFastMatch(memberAccessSyntax, MethodName.AsSpan()))

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -65,7 +65,7 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         }
 
         if (constructorSymbol.Parameters == null || constructorSymbol.Parameters.Length == 0) return;
-        if (!constructorSymbol.Parameters.Any(x => x.IsParams)) return;
+        if (!constructorSymbol.Parameters.Any(parameterSymbol => parameterSymbol.IsParams)) return;
 
         // Find mocked type
         SeparatedSyntaxList<TypeSyntax> typeArguments = genericName.TypeArgumentList.Arguments;

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -35,6 +35,7 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ObjectCreationExpression);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         ObjectCreationExpressionSyntax? objectCreation = (ObjectCreationExpressionSyntax)context.Node;

--- a/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -33,6 +33,7 @@ public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         InvocationExpressionSyntax? setupGetOrSetInvocation = (InvocationExpressionSyntax)context.Node;

--- a/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -33,6 +33,7 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.ObjectCreationExpression);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         ObjectCreationExpressionSyntax? objectCreation = (ObjectCreationExpressionSyntax)context.Node;

--- a/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -30,6 +30,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         InvocationExpressionSyntax? setupInvocation = (InvocationExpressionSyntax)context.Node;

--- a/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/Source/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -30,6 +30,7 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
         context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
         InvocationExpressionSyntax? setupInvocation = (InvocationExpressionSyntax)context.Node;

--- a/build/targets/codeanalysis/CodeAnalysis.props
+++ b/build/targets/codeanalysis/CodeAnalysis.props
@@ -25,5 +25,25 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SonarAnalyzer.CSharp">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="CSharpGuidelinesAnalyzer">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="ExhaustiveMatching.Analyzer" />
+  </ItemGroup>
+
+  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
+    <PackageReference Include="xunit.analyzers">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 </Project>

--- a/build/targets/codeanalysis/CodeAnalysis.props
+++ b/build/targets/codeanalysis/CodeAnalysis.props
@@ -39,11 +39,4 @@
     </PackageReference>
     <PackageReference Include="ExhaustiveMatching.Analyzer" />
   </ItemGroup>
-
-  <ItemGroup Condition=" '$(IsTestProject)' == 'true' ">
-    <PackageReference Include="xunit.analyzers">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
-  </ItemGroup>
 </Project>

--- a/build/targets/codeanalysis/Packages.props
+++ b/build/targets/codeanalysis/Packages.props
@@ -1,6 +1,6 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.155" />
+    <PackageVersion Include="Meziantou.Analyzer" Version="2.0.157" />
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />

--- a/build/targets/codeanalysis/Packages.props
+++ b/build/targets/codeanalysis/Packages.props
@@ -4,5 +4,9 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
+    <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.27.0.93347" />
+    <PackageVersion Include="CSharpGuidelinesAnalyzer" Version="3.8.5" />
+    <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48" />
+    <PackageVersion Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
   </ItemGroup>
 </Project>

--- a/build/targets/tests/Packages.props
+++ b/build/targets/tests/Packages.props
@@ -9,5 +9,6 @@
     <PackageVersion Include="xunit" Version="2.8.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
     <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.2.0" />
+    <PackageVersion Include="xunit.analyzers" Version="1.14.0" />
   </ItemGroup>
 </Project>

--- a/build/targets/tests/Packages.props
+++ b/build/targets/tests/Packages.props
@@ -9,6 +9,5 @@
     <PackageVersion Include="xunit" Version="2.8.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />
     <PackageVersion Include="Meziantou.Xunit.ParallelTestFramework" Version="2.2.0" />
-    <PackageVersion Include="xunit.analyzers" Version="1.14.0" />
   </ItemGroup>
 </Project>

--- a/build/targets/tests/Tests.props
+++ b/build/targets/tests/Tests.props
@@ -8,5 +8,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="Verify.Xunit" />
+
   </ItemGroup>
 </Project>

--- a/build/targets/tests/Tests.props
+++ b/build/targets/tests/Tests.props
@@ -9,6 +9,5 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Verify.Xunit" />
-
   </ItemGroup>
 </Project>


### PR DESCRIPTION
Several changes:

1. Add several new analyzers to check for code correctness and style

- [Sonar](https://www.nuget.org/packages/SonarAnalyzer.CSharp)
- [Multithreading](https://www.nuget.org/packages/Microsoft.VisualStudio.Threading.Analyzers)
- [C# Guidelines](https://www.nuget.org/packages/CSharpGuidelinesAnalyzer)
- [Exhaustive matching](https://www.nuget.org/packages/ExhaustiveMatching.Analyzer)

2. Added suppressions for some of the new rules as they'll need more extensive refactoring to satisfy (e.g., methods have multiple responsibilities, there's too much coupling, poor encapsulation, etc.). Tracked in #90
3. Bump Meziantou.Analyzer to 2.0.157