### PR TITLE
Enable warnings as errors

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -82,6 +82,8 @@ dotnet_style_readonly_field = true:warning
 
 # Parameter preferences
 dotnet_code_quality_unused_parameters = all:suggestion
+# AV1561: Signature contains too many parameters
+dotnet_diagnostic.AV1561.severity = suggestion
 
 # Suppression preferences
 dotnet_remove_unnecessary_suppression_exclusions = none
@@ -89,6 +91,8 @@ dotnet_remove_unnecessary_suppression_exclusions = none
 # XMLDocs preferences
 # SA1600: Elements should be documented. We disable this it requires xmldocs for _all_ members. CS1591 already covers documenting public members.
 dotnet_diagnostic.SA1600.severity = silent
+# AV2305: Missing XML comment for internally visible type, member or parameter
+dotnet_diagnostic.AV2305.severity = silent
 
 #### C# Coding Conventions ####
 [*.cs]
@@ -381,7 +385,27 @@ dotnet_naming_style.s_camelcase.required_suffix =
 dotnet_naming_style.s_camelcase.word_separator =
 dotnet_naming_style.s_camelcase.capitalization = camel_case
 
+# AV1580: Method argument calls a nested method
+# Because debugger breakpoints cannot be set inside expressions, avoid overuse of nested method calls.
+# Example: string result = ConvertToXml(ApplyTransforms(ExecuteQuery(GetConfigurationSettings(source))));
+# requires extra steps to inspect intermediate method return values. On the other hard, were this expression broken into intermediate variables, setting a breakpoint on one of them would be sufficient.
+#
+# This is moved to silent because it's flagging foo.AsSpan()
+dotnet_diagnostic.AV1580.severity = silent
+
 # MA0040: Forward the CancellationToken parameter to methods that take one
 dotnet_diagnostic.MA0040.severity = error
 # Async analyzer
 dotnet_diagnostic.CA2016.severity = error
+
+#### Handling TODOs ####
+# This is a popular rule in analyzers. Everyone has an opinion and
+# some of the severity levels conflict. We don't need all of these
+# to fire, only one. Pick one and mark it as informational so we
+# don't lose track.
+# S1135: Track uses of "TODO" tags
+dotnet_diagnostic.S1135.severity = suggestion
+# AV2318: Work-tracking TODO comment should be removed
+dotnet_diagnostic.AV2318.severity = none
+# MA0026: Fix TODO comment
+dotnet_diagnostic.MA0026.severity = none

--- a/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodCodeFixTests.cs
+++ b/Source/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodCodeFixTests.cs
@@ -4,6 +4,7 @@ namespace Moq.Analyzers.Test;
 
 public class CallbackSignatureShouldMatchMockedMethodCodeFixTests
 {
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "MA0051:Method is too long", Justification = "Contains test data")]
     public static IEnumerable<object[]> TestData()
     {
         return new object[][]

--- a/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/Source/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -35,6 +35,7 @@ public class ConstructorArgumentsShouldMatchAnalyzerTests
             ["""new Mock<AbstractGenericClassDefaultCtor<object>>{|Moq1002:(42)|};"""],
             ["""new Mock<AbstractGenericClassDefaultCtor<object>>();"""],
             ["""new Mock<AbstractGenericClassDefaultCtor<object>>(MockBehavior.Default);"""],
+
             // TODO: "I think this _should_ fail, but currently passes. Tracked by #55."
             // ["""new Mock<AbstractClassWithCtor>();"""],
             ["""new Mock<AbstractClassWithCtor>{|Moq1002:("42")|};"""],

--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -7,7 +7,6 @@
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
-    <NoWarn>1701;1702;SA1600;SA1402</NoWarn>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -59,14 +59,10 @@ public class CallbackSignatureShouldMatchMockedMethodCodeFix : CodeFixProvider
     {
         SemanticModel? semanticModel = await document.GetSemanticModelAsync(cancellationToken).ConfigureAwait(false);
 
-        Debug.Assert(semanticModel != null, nameof(semanticModel) + " != null");
-
-#pragma warning disable S2583 // Conditionally executed code should be reachable
         if (semanticModel == null)
         {
             return document;
         }
-#pragma warning restore S2583 // Conditionally executed code should be reachable
 
         if (oldParameters?.Parent?.Parent?.Parent?.Parent is not InvocationExpressionSyntax callbackInvocation)
         {

--- a/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
+++ b/Source/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodCodeFix.cs
@@ -60,10 +60,12 @@ public class CallbackSignatureShouldMatchMockedMethodCodeFix : CodeFixProvider
 
         Debug.Assert(semanticModel != null, nameof(semanticModel) + " != null");
 
+#pragma warning disable S2583 // Conditionally executed code should be reachable
         if (semanticModel == null)
         {
             return document;
         }
+#pragma warning restore S2583 // Conditionally executed code should be reachable
 
         if (oldParameters?.Parent?.Parent?.Parent?.Parent is not InvocationExpressionSyntax callbackInvocation)
         {
@@ -72,9 +74,9 @@ public class CallbackSignatureShouldMatchMockedMethodCodeFix : CodeFixProvider
 
         InvocationExpressionSyntax? setupMethodInvocation = Helpers.FindSetupMethodFromCallbackInvocation(semanticModel, callbackInvocation, cancellationToken);
         Debug.Assert(setupMethodInvocation != null, nameof(setupMethodInvocation) + " != null");
-        IMethodSymbol[]? matchingMockedMethods = Helpers.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(semanticModel, setupMethodInvocation).ToArray();
+        IMethodSymbol[] matchingMockedMethods = Helpers.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(semanticModel, setupMethodInvocation).ToArray();
 
-        if (matchingMockedMethods.Length != 1 || oldParameters == null)
+        if (matchingMockedMethods.Length != 1)
         {
             return document;
         }

--- a/Source/Moq.Analyzers/Helpers.cs
+++ b/Source/Moq.Analyzers/Helpers.cs
@@ -18,14 +18,10 @@ internal static class Helpers
     {
         MemberAccessExpressionSyntax? callbackOrReturnsMethod = callbackOrReturnsInvocation.Expression as MemberAccessExpressionSyntax;
 
-        Debug.Assert(callbackOrReturnsMethod != null, nameof(callbackOrReturnsMethod) + " != null");
-
-#pragma warning disable S2583 // Conditionally executed code should be reachable
         if (callbackOrReturnsMethod == null)
         {
             return false;
         }
-#pragma warning restore S2583 // Conditionally executed code should be reachable
 
         string methodName = callbackOrReturnsMethod.Name.ToString();
 

--- a/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/Source/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -53,7 +53,13 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
 
         // Full check
         SymbolInfo constructorSymbolInfo = context.SemanticModel.GetSymbolInfo(objectCreation, context.CancellationToken);
-        if (constructorSymbolInfo.Symbol is not IMethodSymbol constructorSymbol || constructorSymbol.ContainingType == null || constructorSymbol.ContainingType.ConstructedFrom == null) return;
+        if (constructorSymbolInfo.Symbol is not IMethodSymbol constructorSymbol
+            || constructorSymbol.ContainingType == null
+            || constructorSymbol.ContainingType.ConstructedFrom == null)
+        {
+            return;
+        }
+
         if (constructorSymbol.MethodKind != MethodKind.Constructor) return;
         if (!string.Equals(
                 constructorSymbol.ContainingType.ConstructedFrom.ToDisplayString(),
@@ -63,7 +69,7 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (constructorSymbol.Parameters == null || constructorSymbol.Parameters.Length == 0) return;
+        if (constructorSymbol.Parameters.Length == 0) return;
         if (!constructorSymbol.Parameters.Any(x => x.IsParams)) return;
 
         // Find mocked type

--- a/build/targets/codeanalysis/CodeAnalysis.props
+++ b/build/targets/codeanalysis/CodeAnalysis.props
@@ -5,6 +5,8 @@
     <AnalysisMode>preview</AnalysisMode>
     <WarningLevel>9999</WarningLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/targets/codeanalysis/CodeAnalysis.props
+++ b/build/targets/codeanalysis/CodeAnalysis.props
@@ -5,8 +5,8 @@
     <AnalysisMode>preview</AnalysisMode>
     <WarningLevel>9999</WarningLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
-    <MSBuildTreatWarningsAsErrors>true</MSBuildTreatWarningsAsErrors>
+    <TreatWarningsAsErrors Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">true</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Updated `.editorconfig` to set policy on some duplicate warnings for TODO. Borrowed from #89 to make merging easier
- Updated cases where nullability was incorrect (something could be passed as null but wasn't, something was marked as nullable but wasn't). Where possible added asserts so we can catch cases when they arise.
- Removed `<NoWarn>` from `Moq.Analyzers.csproj`
- Added `<TreatWarningsAsErrors>` and `MSBuildTreatWarningsAsErrors` elements to `CodeAnalysis.props`
  - Set each to `true` when MSBuild property `$(ContinuousIntegrationBuild)` is `true` from `DotNet.ReproducibleBuilds` package

