### PR TITLE
Update main.yml to add codacy test coverage

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -93,6 +93,7 @@ jobs:
       uses: 5monkeys/cobertura-action@v14
       with:
         path: artifacts/TestResults/coverage/*.xml
+        minimum_coverage: 75
 
     - name: Upload coverage data to Codacy      
       if: ${{ runner.os == 'Linux' && env.IS_COVERAGE_ALLOWED == 'true' && env.IS_MASTER_BRANCH == 'true' }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -26,6 +26,10 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    env:
+      IS_COVERAGE_ALLOWED: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
+      IS_MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' }}
+
     steps:
     - uses: actions/checkout@v4
       with:
@@ -105,6 +109,9 @@ jobs:
       with:
         category: "/language:csharp"
 
-    - name: Upload coverage data to codacy
-      run: bash <(curl -Ls https://coverage.codacy.com/get.sh)
-      if: runner.os == 'Linux'
+    - name: Upload coverage data to codacy      
+      if: ${{ runner.os == 'Linux' && env.IS_COVERAGE_ALLOWED == 'true' && env.IS_MASTER_BRANCH == 'true' }}
+      uses: codacy/codacy-coverage-reporter-action@master
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: ${{ github.workspace }}/artifacts/TestResults/coverage/Cobertura.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -85,9 +85,16 @@ jobs:
         name: .NET Code Coverage Reports (${{ matrix.os }})
         path: "artifacts/TestResults/coverage/**"
 
-    - name: Publish coverage summary
+    - name: Publish coverage summary to GitHub
       run: cat artifacts/TestResults/coverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
       shell: bash
+
+    - name: Upload coverage data to Codacy      
+      if: ${{ runner.os == 'Linux' && env.IS_COVERAGE_ALLOWED == 'true' && env.IS_MASTER_BRANCH == 'true' }}
+      uses: codacy/codacy-coverage-reporter-action@v1.3.0
+      with:
+        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+        coverage-reports: ${{ github.workspace }}/artifacts/TestResults/coverage/Cobertura.xml
 
     - name: Upload binlogs
       uses: actions/upload-artifact@v4
@@ -108,10 +115,3 @@ jobs:
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:csharp"
-
-    - name: Upload coverage data to codacy      
-      if: ${{ runner.os == 'Linux' && env.IS_COVERAGE_ALLOWED == 'true' && env.IS_MASTER_BRANCH == 'true' }}
-      uses: codacy/codacy-coverage-reporter-action@v1.3.0
-      with:
-        project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-        coverage-reports: ${{ github.workspace }}/artifacts/TestResults/coverage/Cobertura.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,3 +104,7 @@ jobs:
       uses: github/codeql-action/analyze@v3
       with:
         category: "/language:csharp"
+
+    - name: Upload coverage data to codacy
+      run: bash <(curl -Ls https://coverage.codacy.com/get.sh)
+      if: runner.os == 'Linux'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,6 +89,11 @@ jobs:
       run: cat artifacts/TestResults/coverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
       shell: bash
 
+    - name: cobertura-report
+      uses: 5monkeys/cobertura-action@v14
+      with:
+        path: artifacts/TestResults/coverage/*.xml
+
     - name: Upload coverage data to Codacy      
       if: ${{ runner.os == 'Linux' && env.IS_COVERAGE_ALLOWED == 'true' && env.IS_MASTER_BRANCH == 'true' }}
       uses: codacy/codacy-coverage-reporter-action@v1.3.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -111,7 +111,7 @@ jobs:
 
     - name: Upload coverage data to codacy      
       if: ${{ runner.os == 'Linux' && env.IS_COVERAGE_ALLOWED == 'true' && env.IS_MASTER_BRANCH == 'true' }}
-      uses: codacy/codacy-coverage-reporter-action@master
+      uses: codacy/codacy-coverage-reporter-action@v1.3.0
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: ${{ github.workspace }}/artifacts/TestResults/coverage/Cobertura.xml

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,14 +89,8 @@ jobs:
       run: cat artifacts/TestResults/coverage/SummaryGithub.md >> $GITHUB_STEP_SUMMARY
       shell: bash
 
-    - name: cobertura-report
-      uses: 5monkeys/cobertura-action@v14
-      with:
-        path: artifacts/TestResults/coverage/*.xml
-        minimum_coverage: 75
-
     - name: Upload coverage data to Codacy      
-      if: ${{ runner.os == 'Linux' && env.IS_COVERAGE_ALLOWED == 'true' && env.IS_MASTER_BRANCH == 'true' }}
+      if: ${{ runner.os == 'Linux' && env.IS_COVERAGE_ALLOWED == 'true' }}
       uses: codacy/codacy-coverage-reporter-action@v1.3.0
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,6 @@ jobs:
 
     env:
       IS_COVERAGE_ALLOWED: ${{ secrets.CODACY_PROJECT_TOKEN != '' }}
-      IS_MAIN_BRANCH: ${{ github.ref == 'refs/heads/main' }}
 
     steps:
     - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -3,7 +3,8 @@
 [![NuGet Version](https://img.shields.io/nuget/v/Moq.Analyzers?style=flat&logo=nuget&color=blue)](https://www.nuget.org/packages/Moq.Analyzers)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Moq.Analyzers?style=flat&logo=nuget)](https://www.nuget.org/packages/Moq.Analyzers)
 [![Main build](https://github.com/rjmurillo/moq.analyzers/actions/workflows/main.yml/badge.svg)](https://github.com/rjmurillo/moq.analyzers/actions/workflows/main.yml)
-[![Codacy Badge](https://app.codacy.com/project/badge/Grade/fc7c184dcb1843d4b1ae1b926fb82d5a)](https://app.codacy.com/gh/rjmurillo/moq.analyzers/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Codacy Grade Badge](https://app.codacy.com/project/badge/Grade/fc7c184dcb1843d4b1ae1b926fb82d5a)](https://app.codacy.com/gh/rjmurillo/moq.analyzers/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
+[![Codacy Coverage Badge](https://app.codacy.com/project/badge/Coverage/fc7c184dcb1843d4b1ae1b926fb82d5a)](https://app.codacy.com/gh/rjmurillo/moq.analyzers/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 
 **Moq.Analyzers** is a Roslyn analyzer that helps you to write unit tests using the popular
 [Moq](https://github.com/devlooped/moq) framework. Moq.Analyzers protects you from common mistakes and warns you if

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 [![NuGet Version](https://img.shields.io/nuget/v/Moq.Analyzers?style=flat&logo=nuget&color=blue)](https://www.nuget.org/packages/Moq.Analyzers)
 [![NuGet Downloads](https://img.shields.io/nuget/dt/Moq.Analyzers?style=flat&logo=nuget)](https://www.nuget.org/packages/Moq.Analyzers)
 [![Main build](https://github.com/rjmurillo/moq.analyzers/actions/workflows/main.yml/badge.svg)](https://github.com/rjmurillo/moq.analyzers/actions/workflows/main.yml)
+[![Codacy Badge](https://app.codacy.com/project/badge/Grade/fc7c184dcb1843d4b1ae1b926fb82d5a)](https://app.codacy.com/gh/rjmurillo/moq.analyzers/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
 
 **Moq.Analyzers** is a Roslyn analyzer that helps you to write unit tests using the popular
 [Moq](https://github.com/devlooped/moq) framework. Moq.Analyzers protects you from common mistakes and warns you if


### PR DESCRIPTION
Updates to build to enable integration with Codacy

- Rename "Publish coverage summary" to "Publish coverage summary to GitHub" when posting SummaryGithub.md
- Add new step to upload Cobertura code coverage information to Codacy
- Add Codacy coverage and grade badges to README.md