### PR TITLE
Remove Microsoft.CodeAnalysis.CSharp.Analyzer.Testing

### DIFF
--- a/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/Source/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -19,7 +19,6 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Verify.Nupkg" />

--- a/build/targets/tests/Packages.props
+++ b/build/targets/tests/Packages.props
@@ -1,7 +1,6 @@
 <Project>
   <ItemGroup>
     <PackageVersion Include="ReportGenerator" Version="5.3.6" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Analyzer.Testing" Version="1.1.2-beta1.24273.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2-beta1.24273.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
     <PackageVersion Include="Verify.Nupkg" Version="1.1.5" />


### PR DESCRIPTION
 Remove `Microsoft.CodeAnalysis.CSharp.Analyzer.Testing` because it is duplicative with `Microsoft.CodeAnalysis.CSharp.CodeFix.Testing`. This is common when building analyzers that contain code fixes. From a testing perspective, an analyzer test is just a code fix test with an "empty" or "null pattern" code fixer.

This also unblocks #97, as the two packages otherwise need upgrading together. However, cleaning up our dependencies is preferred to creating a group in dependabot.