### PR TITLE
Add auto labelers for Issues and PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,17 @@
+# Add 'build' label to any change in the 'build' directory
+build:
+  - build/**/*
+
+# Add 'dependencies' label to any change in one of the packages files
+dependencies:
+  - build/**/Packages.props
+  - Directory.Packages.props
+
+# Add '.NET' label to any change to a '.cs' file under Moq.Analyzers
+.NET
+  - 'Source/Moq.Analyzers/**/*.cs'
+
+# Add 'documentation' label to any change within the 'docs' directory or any '.md' file
+documentation:
+  - docs/**/*
+  - '**/*.md'

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -1,0 +1,50 @@
+# This workflow will read information about an issue and attempt to label it initially for triage and sorting
+
+name: Label issues
+on:
+  issues:
+    types:
+      - reopened
+      - opened
+
+jobs:
+  label_issues:
+    name: "Issue: add labels"
+    if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GH_ACTIONS_PR_WRITE }}
+          script: |
+            // Get the issue body and title
+            const body = context.payload.issue.body
+            let title = context.payload.issue.title
+            
+            // Define the labels array
+            let labels = ["triage"]
+            
+            // Check if the body or the title contains the word 'PowerShell' (case-insensitive)
+            if ((body != null && body.match(/powershell/i)) || (title != null && title.match(/powershell/i))) {
+              // Add the 'powershell' label to the array
+              labels.push("powershell")
+            }
+            
+            // Check if the body or the title contains the words 'dotnet', '.net', 'c#' or 'csharp' (case-insensitive)
+            if ((body != null && body.match(/.net/i)) || (title != null && title.match(/.net/i)) ||
+                (body != null && body.match(/dotnet/i)) || (title != null && title.match(/dotnet/i)) ||
+                (body != null && body.match(/C#/i)) || (title != null && title.match(/C#/i)) ||
+                (body != null && body.match(/csharp/i)) || (title != null && title.match(/csharp/i))) {
+              // Add the '.NET' label to the array
+              labels.push(".NET")
+            }
+
+            // Add the labels to the issue
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: labels
+            });

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -1,0 +1,21 @@
+# This workflow will triage pull requests and apply a label based on the
+# paths that are modified in the pull request.
+#
+# To use this workflow, you will need to set up a .github/labeler.yml
+# file with configuration.  For more information, see:
+# https://github.com/actions/labeler
+
+name: Label PR
+on: [pull_request_target]
+
+jobs:
+    add_label:
+        runs-on: ubuntu-latest
+        permissions:
+            contents: read
+            pull-requests: write
+
+        steps:
+            - uses: actions/labeler@v4
+              with:
+                  repo-token: "${{ secrets.GH_ACTIONS_PR_WRITE }}"


### PR DESCRIPTION
Add automatic labeling for issues and PRs to cut down on administrative work. Will allow for more consistent reporting, especially when generating patch notes from PRs.