### PR TITLE
Update ConstructorArgumentsShouldMatchAnalyzer test cases to make sure all positive and negative cases are covered

### DIFF
--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -9,51 +9,54 @@ public class ConstructorArgumentsShouldMatchAnalyzerTests
         return new object[][]
         {
             ["""new Mock<Foo>{|Moq1002:(MockBehavior.Default)|};"""],
-            ["""new Mock<Foo>{|Moq1002:(MockBehavior.Strict)|};"""],
-            ["""new Mock<Foo>{|Moq1002:(MockBehavior.Loose)|};"""],
             ["""new Mock<Foo>("3");"""],
-            ["""new Mock<Foo>("4");"""],
             ["""new Mock<Foo>(MockBehavior.Default, "5");"""],
-            ["""new Mock<Foo>(MockBehavior.Default, "6");"""],
             ["""new Mock<Foo>(false, 0);"""],
             ["""new Mock<Foo>(MockBehavior.Default, true, 1);"""],
             ["""new Mock<Foo>(DateTime.Now, DateTime.Now);"""],
             ["""new Mock<Foo>(MockBehavior.Default, DateTime.Now, DateTime.Now);"""],
-            ["""new Mock<Foo>(new List<string>(), "7");"""],
+            ["""new Mock<Foo>(MockBehavior.Default, new List<string>());"""],
             ["""new Mock<Foo>(new List<string>());"""],
             ["""new Mock<Foo>(MockBehavior.Default, new List<string>(), "8");"""],
-            ["""new Mock<Foo>(MockBehavior.Default, new List<string>());"""],
+            ["""new Mock<Foo>(new List<string>(), "7");"""],
             ["""new Mock<Foo>{|Moq1002:(1, true)|};"""],
-            ["""new Mock<Foo>{|Moq1002:(2, true)|};"""],
+            ["""new Mock<Foo>{|Moq1002:(MockBehavior.Default, 2, true)|};"""],
             ["""new Mock<Foo>{|Moq1002:("1", 3)|};"""],
+            ["""new Mock<Foo>{|Moq1002:(MockBehavior.Default, "2", 6)|};"""],
             ["""new Mock<Foo>{|Moq1002:(new int[] { 1, 2, 3 })|};"""],
-            ["""new Mock<Foo>{|Moq1002:(MockBehavior.Strict, 4, true)|};"""],
-            ["""new Mock<Foo>{|Moq1002:(MockBehavior.Loose, 5, true)|};"""],
-            ["""new Mock<Foo>{|Moq1002:(MockBehavior.Loose, "2", 6)|};"""],
-            ["""new Mock<AbstractGenericClassWithCtor<object>>{|Moq1002:("42")|};"""],
-            ["""new Mock<AbstractGenericClassWithCtor<object>>{|Moq1002:("42", 42)|};"""],
-            ["""new Mock<AbstractGenericClassDefaultCtor<object>>{|Moq1002:(42)|};"""],
-            ["""new Mock<AbstractGenericClassDefaultCtor<object>>();"""],
+            ["""new Mock<Foo>{|Moq1002:(MockBehavior.Default, 4, true)|};"""],
+
             ["""new Mock<AbstractGenericClassDefaultCtor<object>>(MockBehavior.Default);"""],
-            ["""new Mock<AbstractClassWithCtor>{|Moq1002:()|};"""],
-            ["""new Mock<AbstractClassWithCtor>{|Moq1002:(MockBehavior.Strict)|};"""],
-            ["""new Mock<AbstractClassWithCtor>{|Moq1002:(MockBehavior.Loose)|};"""],
+            ["""new Mock<AbstractGenericClassDefaultCtor<object>>();"""],
+            ["""new Mock<AbstractGenericClassDefaultCtor<object>>{|Moq1002:(42)|};"""],
+
+            ["""new Mock<AbstractClassDefaultCtor>(MockBehavior.Default);"""],
+            ["""new Mock<AbstractClassDefaultCtor>();"""],
+            ["""new Mock<AbstractClassDefaultCtor>{|Moq1002:(MockBehavior.Default, 42)|};"""],
+            ["""new Mock<AbstractClassDefaultCtor>{|Moq1002:(42)|};"""],
+
+            ["""new Mock<AbstractClassWithDefaultParamCtor>(MockBehavior.Default);"""],
             ["""new Mock<AbstractClassWithDefaultParamCtor>();"""],
-            ["""new Mock<AbstractClassWithDefaultParamCtor>(MockBehavior.Strict);"""],
-            ["""new Mock<AbstractClassWithDefaultParamCtor>(MockBehavior.Loose);"""],
-            ["""new Mock<AbstractGenericClassWithCtor<object>>{|Moq1002:()|};"""],
-            ["""new Mock<AbstractGenericClassWithCtor<object>>{|Moq1002:(MockBehavior.Strict)|};"""],
-            ["""new Mock<AbstractGenericClassWithCtor<object>>{|Moq1002:(MockBehavior.Loose)|};"""],
+            ["""new Mock<AbstractClassWithDefaultParamCtor>(MockBehavior.Default, 42);"""],
+            ["""new Mock<AbstractClassWithDefaultParamCtor>(42);"""],
+            ["""new Mock<AbstractClassWithDefaultParamCtor>{|Moq1002:(MockBehavior.Default, "42")|};"""],
+            ["""new Mock<AbstractClassWithDefaultParamCtor>{|Moq1002:("42")|};"""],
+
+            ["""new Mock<AbstractClassWithCtor>(MockBehavior.Default, 42);"""],
+            ["""new Mock<AbstractClassWithCtor>(42);"""],
+            ["""new Mock<AbstractClassWithCtor>(MockBehavior.Default, 42, "42");"""],
+            ["""new Mock<AbstractClassWithCtor>(42, "42");"""],
             ["""new Mock<AbstractClassWithCtor>{|Moq1002:("42")|};"""],
             ["""new Mock<AbstractClassWithCtor>{|Moq1002:("42", 42)|};"""],
-            ["""new Mock<AbstractClassDefaultCtor>{|Moq1002:(42)|};"""],
-            ["""new Mock<AbstractClassDefaultCtor>();"""],
-            ["""new Mock<AbstractClassWithCtor>(42);"""],
-            ["""new Mock<AbstractClassWithCtor>(MockBehavior.Default, 42);"""],
-            ["""new Mock<AbstractClassWithCtor>(42, "42");"""],
-            ["""new Mock<AbstractClassWithCtor>(MockBehavior.Default, 42, "42");"""],
-            ["""new Mock<AbstractGenericClassWithCtor<object>>(42);"""],
+            ["""new Mock<AbstractClassWithCtor>{|Moq1002:(MockBehavior.Default)|};"""],
+            ["""new Mock<AbstractClassWithCtor>{|Moq1002:()|};"""],
+
             ["""new Mock<AbstractGenericClassWithCtor<object>>(MockBehavior.Default, 42);"""],
+            ["""new Mock<AbstractGenericClassWithCtor<object>>(42);"""],
+            ["""new Mock<AbstractGenericClassWithCtor<object>>{|Moq1002:("42")|};"""],
+            ["""new Mock<AbstractGenericClassWithCtor<object>>{|Moq1002:("42", 42)|};"""],
+            ["""new Mock<AbstractGenericClassWithCtor<object>>{|Moq1002:()|};"""],
+            ["""new Mock<AbstractGenericClassWithCtor<object>>{|Moq1002:(MockBehavior.Default)|};"""],
         }.WithNamespaces().WithReferenceAssemblyGroups();
     }
 
@@ -75,12 +78,10 @@ public class ConstructorArgumentsShouldMatchAnalyzerTests
 
                 internal abstract class AbstractClassDefaultCtor
                 {
-                    protected AbstractClassDefaultCtor() { }
                 }
 
                 internal abstract class AbstractGenericClassDefaultCtor<T>
                 {
-                    protected AbstractGenericClassDefaultCtor() { }
                 }
 
                 internal abstract class AbstractClassWithDefaultParamCtor


### PR DESCRIPTION
This is comprehensive and did not change the code coverage numbers.

Resolves #123

There are still blocks that are not covered:

https://github.com/rjmurillo/moq.analyzers/blob/e3e5dec23cf7660fc531006755cff62748d3c22b/src/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs#L208-L213

The `return null` cases

https://github.com/rjmurillo/moq.analyzers/blob/e3e5dec23cf7660fc531006755cff62748d3c22b/src/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs#L166-L175