### PR TITLE
Add extension method to create Diagnostic

### DIFF
--- a/src/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/src/Moq.Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -80,7 +80,7 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
             NameSyntax? memberName = context.Operation.Syntax.DescendantNodes().OfType<MemberAccessExpressionSyntax>().Select(mae => mae.Name).DefaultIfNotSingle();
             Location location = memberName?.GetLocation() ?? invocationOperation.Syntax.GetLocation();
 
-            context.ReportDiagnostic(Diagnostic.Create(Rule, location));
+            context.ReportDiagnostic(location.CreateDiagnostic(Rule));
         }
     }
 }

--- a/src/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/src/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -85,7 +85,7 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
 
                 if (!string.Equals(mockedMethodTypeName, lambdaParameterTypeName, StringComparison.Ordinal))
                 {
-                    Diagnostic diagnostic = Diagnostic.Create(Rule, callbackLambda.ParameterList.GetLocation());
+                    Diagnostic diagnostic = callbackLambda.ParameterList.CreateDiagnostic(Rule);
                     context.ReportDiagnostic(diagnostic);
                 }
             }

--- a/src/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -124,7 +124,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         if (constructorArguments != null
             && IsConstructorMismatch(context, objectCreation, genericName, constructorArguments))
         {
-            Diagnostic diagnostic = Diagnostic.Create(Rule, objectCreation.ArgumentList?.GetLocation());
+            Diagnostic diagnostic = objectCreation.ArgumentList.CreateDiagnostic(Rule);
             context.ReportDiagnostic(diagnostic);
         }
     }
@@ -159,7 +159,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 
         Debug.Assert(objectCreation.ArgumentList != null, "objectCreation.ArgumentList != null");
 
-        Diagnostic diagnostic = Diagnostic.Create(Rule, objectCreation.ArgumentList?.GetLocation());
+        Diagnostic diagnostic = objectCreation.ArgumentList.CreateDiagnostic(Rule);
         context.ReportDiagnostic(diagnostic);
     }
 

--- a/src/Moq.Analyzers/DiagnosticExtensions.cs
+++ b/src/Moq.Analyzers/DiagnosticExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace Moq.Analyzers;
+
+internal static class DiagnosticExtensions
+{
+    /// <summary>
+    /// Create a <see cref="Diagnostic"/> with the given <paramref name="descriptor"/> at the <paramref name="node"/>'s location.
+    /// </summary>
+    /// <param name="node">The <see cref="SyntaxNode"/> to use for a <see cref="Location"/> for a diagnostic.</param>
+    /// <param name="descriptor">The <see cref="DiagnosticDescriptor"/> to use when creating the diagnostic.</param>
+    /// <returns>A <see cref="Diagnostic"/> with the given <paramref name="descriptor"/> at the <paramref name="node"/>'s location.</returns>
+    public static Diagnostic CreateDiagnostic(this SyntaxNode? node, DiagnosticDescriptor descriptor) =>
+        Diagnostic.Create(descriptor, node?.GetLocation());
+
+    /// <summary>
+    /// Create a <see cref="Diagnostic"/> with the given <paramref name="descriptor"/> at the <paramref name="location"/>.
+    /// </summary>
+    /// <param name="location">The <see cref="Location"/> to use for a diagnostic.</param>
+    /// <param name="descriptor">The <see cref="DiagnosticDescriptor"/> to use when creating the diagnostic.</param>
+    /// <returns>A <see cref="Diagnostic"/> with the given <paramref name="descriptor"/> at the <paramref name="location"/>.</returns>
+    public static Diagnostic CreateDiagnostic(this Location? location, DiagnosticDescriptor descriptor) =>
+        Diagnostic.Create(descriptor, location);
+}

--- a/src/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
+++ b/src/Moq.Analyzers/NoConstructorArgumentsForInterfaceMockAnalyzer.cs
@@ -84,7 +84,7 @@ public class NoConstructorArgumentsForInterfaceMockAnalyzer : DiagnosticAnalyzer
         {
             Debug.Assert(objectCreation.ArgumentList != null, "objectCreation.ArgumentList != null");
 
-            Diagnostic diagnostic = Diagnostic.Create(Rule, objectCreation.ArgumentList?.GetLocation());
+            Diagnostic diagnostic = objectCreation.ArgumentList.CreateDiagnostic(Rule);
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/src/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/src/Moq.Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -48,7 +48,7 @@ public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
         ISymbol? mockedMethodSymbol = context.SemanticModel.GetSymbolInfo(mockedMethodCall, context.CancellationToken).Symbol;
         if (mockedMethodSymbol == null) return;
 
-        Diagnostic diagnostic = Diagnostic.Create(Rule, mockedMethodCall.GetLocation());
+        Diagnostic diagnostic = mockedMethodCall.CreateDiagnostic(Rule);
         context.ReportDiagnostic(diagnostic);
     }
 }


### PR DESCRIPTION
Borrowing a technique from the roslyn-analyzers repo. Creating a set of extension methods to create a Diagnostic given a `SyntaxNode` or a `Location`. Simplifies reading the code slightly.