### PR TITLE
Add composite analyzer to test all analyzers

### DIFF
--- a/tests/Moq.Analyzers.Test/CompositeAnalyzer.cs
+++ b/tests/Moq.Analyzers.Test/CompositeAnalyzer.cs
@@ -1,0 +1,52 @@
+﻿using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+namespace Moq.Analyzers.Test;
+
+/// <summary>
+/// A "meta" analyzer that aggregates all the individual analyzers into a single one.
+/// </summary>
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+public class CompositeAnalyzer : DiagnosticAnalyzer
+{
+    private readonly ImmutableArray<DiagnosticAnalyzer> _analyzers;
+    private readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics;
+
+    /// <summary>Initializes a new instance of the <see cref="CompositeAnalyzer" /> class.</summary>
+    public CompositeAnalyzer()
+    {
+        _analyzers = [.. DiagnosticAnalyzers()];
+        _supportedDiagnostics = [.. _analyzers.SelectMany(diagnosticAnalyzer => diagnosticAnalyzer.SupportedDiagnostics)];
+    }
+
+    /// <inheritdoc />
+    public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => _supportedDiagnostics;
+
+    /// <inheritdoc />
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1026:Enable concurrent execution", Justification = "Delegated off to children")]
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("MicrosoftCodeAnalysisCorrectness", "RS1025:Configure generated code analysis", Justification = "Delegated off to children")]
+    public override void Initialize(AnalysisContext context)
+    {
+        foreach (DiagnosticAnalyzer analyzer in _analyzers)
+        {
+            analyzer.Initialize(context);
+        }
+    }
+
+    private static IEnumerable<DiagnosticAnalyzer> DiagnosticAnalyzers()
+    {
+        Type diagnosticAnalyzerType = typeof(DiagnosticAnalyzer);
+        IEnumerable<Type> diagnosticAnalyzerTypes = typeof(ConstructorArgumentsShouldMatchAnalyzer)
+                .Assembly
+                .GetTypes()
+                .Where(type => diagnosticAnalyzerType.IsAssignableFrom(type) && !type.IsAbstract && type.IsClass)
+            ;
+
+        return diagnosticAnalyzerTypes
+                .Select(type => (DiagnosticAnalyzer?)Activator.CreateInstance(type))
+                .Where(analyzer => analyzer != null)
+                .Cast<DiagnosticAnalyzer>()
+            ;
+    }
+}

--- a/tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -4,6 +4,8 @@
     <TargetFramework>net8.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
+    <!-- The CompositeAnalyzer triggers RS1036 -->
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">


### PR DESCRIPTION
Adds new type `CompositeAnalyzer` that inherits from `DiagnosticAnalyzer`. This new analyzer uses reflection to load all types in the `Moq.Analyzers` assembly that derive from `DiagnosticAnalyzer`, are not abstract, and are classes.

The intended use is for diagnostic purposes

```csharp
using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.Test.CompositeAnalyzer>;

namespace Moq.Analyzers.Test;

public class FooAnalyzerTests
{
    public static IEnumerable<object[]> TestData()
    {
        return new object[][]
        {
            ["""new Mock<TestClass>(MockBehavior.Strict).Object.TaskAsync();"""],
        }.WithNamespaces().WithReferenceAssemblyGroups();
    }

    [Theory]
    [MemberData(nameof(TestData))]
    public async Task Bar(string referenceAssemblyGroup, string @namespace, string mock)
    {
        await Verifier.VerifyAnalyzerAsync(
            $$"""
              {{@namespace}}

              public class TestClass
              {
                  public virtual Task TaskAsync() => Task.CompletedTask;
              }

              internal class UnitTest
              {
                  private void Test()
                  {
                      {{mock}}
                  }
              }
              """,
            referenceAssemblyGroup);
    }
}

```