### PR TITLE
Update to latest version of DotNet.ReproducibleBuilds

### DIFF
--- a/build/targets/reproducible/Packages.props
+++ b/build/targets/reproducible/Packages.props
@@ -1,5 +1,5 @@
 <Project>
   <ItemGroup>
-    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.1.1" />
+    <PackageVersion Include="DotNet.ReproducibleBuilds" Version="1.2.4" />
   </ItemGroup>
 </Project>

--- a/build/targets/reproducible/Reproducible.targets
+++ b/build/targets/reproducible/Reproducible.targets
@@ -1,2 +1,19 @@
 <Project>
+  <Target Name="SetRepositoryBranch" BeforeTargets="GenerateNuspec">
+    <!--
+      DotNet.ReproducibleBuilds tries to set the `$(RepositoryBranch)` for SourceLink, but only in CI scenarios.
+      This results in a difference in nuspec between local and CI tests (which breaks the Verify.Nupkg tests).
+
+      To prevent the difference in behavior, set a default value directly from git.
+
+      Filed https://github.com/dotnet/sourcelink/issues/1243 to see if this could be moved into the base SourceLink
+      package.
+    -->
+    <Exec
+      Condition="'$(RepositoryBranch)' == ''"
+      ConsoleToMSBuild="true"
+      Command="git rev-parse --abbrev-ref HEAD">
+        <Output TaskParameter="ConsoleOutput" PropertyName="RepositoryBranch" />
+    </Exec>
+  </Target>
 </Project>

--- a/build/targets/tests/Packages.props
+++ b/build/targets/tests/Packages.props
@@ -3,7 +3,7 @@
     <PackageVersion Include="ReportGenerator" Version="5.3.6" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.2-beta1.24314.1" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.10.0" />
-    <PackageVersion Include="Verify.Nupkg" Version="1.1.5" />
+    <PackageVersion Include="Verify.Nupkg" Version="1.1.6" />
     <PackageVersion Include="Verify.Xunit" Version="25.0.4" />
     <PackageVersion Include="xunit" Version="2.8.1" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="2.8.1" />

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "latestFeature"
   },
   "msbuild-sdks": {
-    "DotNet.ReproducibleBuilds.Isolated": "1.1.1"
+    "DotNet.ReproducibleBuilds.Isolated": "1.2.4"
   }
 }

--- a/tests/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
+++ b/tests/Moq.Analyzers.Test/PackageTests.Baseline#manifest.verified.nuspec
@@ -12,6 +12,6 @@
     <releaseNotes>A changelog is available at https://github.com/rjmurillo/moq.analyzers/releases</releaseNotes>
     <copyright>2017 Andrey Lipatkin</copyright>
     <tags>moq, tdd, mocking, mocks, unittesting, agile, unittest, mock, test, analyzers</tags>
-    <repository type="git" url="https://github.com/********/moq.analyzers.git" commit="****************************************" />
+    <repository type="git" url="https://github.com/********/moq.analyzers.git" branch="********" commit="****************************************" />
   </metadata>
 </package>


### PR DESCRIPTION
Update to the latest version of `DotNet.ReproducibleBuilds`. Doing so exposes a difference in how SourceLink is invoked between local and CI scenarios. I make local build work like CI by adding a RepositoryBranch if one isn't supplied (bug filed against the SourceLink repo to do the fallback directly). This then requires pulling in a newer version of `Verify.Nupkg` in order to scrub the new `branch` attribute.