### PR TITLE
Enable TreatWarningsAsErrors

### DIFF
--- a/build/targets/codeanalysis/CodeAnalysis.props
+++ b/build/targets/codeanalysis/CodeAnalysis.props
@@ -5,8 +5,6 @@
     <AnalysisMode>preview</AnalysisMode>
     <WarningLevel>9999</WarningLevel>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
-    <TreatWarningsAsErrors Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">true</TreatWarningsAsErrors>
-    <MSBuildTreatWarningsAsErrors Condition=" '$(ContinuousIntegrationBuild)' == 'true' ">true</MSBuildTreatWarningsAsErrors>
   </PropertyGroup>
 
   <ItemGroup>

--- a/build/targets/codeanalysis/CodeAnalysis.targets
+++ b/build/targets/codeanalysis/CodeAnalysis.targets
@@ -1,2 +1,7 @@
 <Project>
+  <PropertyGroup Label="Computed properties">
+    <PedanticMode Condition=" '$(PedanticMode)' == '' ">$([MSBuild]::ValueOrDefault('$(ContinuousIntegrationBuild)', 'false'))</PedanticMode>
+    <TreatWarningsAsErrors>$(PedanticMode)</TreatWarningsAsErrors>
+    <MSBuildTreatWarningsAsErrors>$(PedanticMode)</MSBuildTreatWarningsAsErrors>
+  </PropertyGroup>
 </Project>

--- a/src/tools/PerfDiff/Logging/SimpleConsoleLogger.cs
+++ b/src/tools/PerfDiff/Logging/SimpleConsoleLogger.cs
@@ -66,6 +66,7 @@ namespace PerfDiff.Logging
         }
 
         public IDisposable BeginScope<TState>(TState state)
+            where TState : notnull
         {
             return NullScope.Instance;
         }

--- a/tests/.editorconfig
+++ b/tests/.editorconfig
@@ -13,6 +13,16 @@ dotnet_diagnostic.CS1591.severity = suggestion
 # CS1712: Type parameter 'type parameter' has no matching typeparam tag in the XML comment on 'type' (but other type parameters do)
 dotnet_diagnostic.CS1712.severity = suggestion
 
+# SA1601: Partial elements should be documented
+dotnet_diagnostic.SA1601.severity = suggestion
+
+#### Code quality ####
+
+# MA0051: Method is too long
+dotnet_diagnostic.MA0051.severity = suggestion
+
+#### Naming conventions ####
+
 # VSTHRD200: Use "Async" suffix for async methods
 # AV1755: Postfix asynchronous methods with Async or TaskAsync
 # Just about every test method is async, doesn't provide any real value and clustters up test window

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.DefaultParam.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.DefaultParam.cs
@@ -1,6 +1,7 @@
 ﻿using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.ConstructorArgumentsShouldMatchAnalyzer>;
 
 namespace Moq.Analyzers.Test;
+
 public partial class ConstructorArgumentsShouldMatchAnalyzerTests
 {
     public static IEnumerable<object[]> ClassWithDefaultParamCtorTestData()

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Delegates.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Delegates.cs
@@ -1,6 +1,7 @@
 ﻿using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.ConstructorArgumentsShouldMatchAnalyzer>;
 
 namespace Moq.Analyzers.Test;
+
 public partial class ConstructorArgumentsShouldMatchAnalyzerTests
 {
     public static IEnumerable<object[]> DelegateTestData()


### PR DESCRIPTION
#91 intended to enable warnings as errors in CI. However, `$(ContinuousIntegrationBuild)` is set by `DotNet.ReproducibleBuilds`, and that package's .props file is imported _after_ our own Directory.Build.props. As a result, the properties were evaluated before they were set.

This change moves them into the .targets file as "computed properties" in order for them to pick up the configuration from .props files. This aligns with the [documented guidance](https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-your-build?view=vs-2022#choose-between-adding-properties-to-a-props-or-targets-file) "Set dependent properties in .targets files, because they pick up customizations from individual projects.". I've also filed https://github.com/dotnet/reproducible-builds/issues/45 to see if we can make the reproducible-builds package more intuitive.

Lastly, this cleans up existing warnings:

- Fixes whitespace issues
- Suppresses StyleCop warnings about documenting public members in tests, which already had the built-in rules suppressed
- Reorders static members to be above instance members
- Adds a single suppression for a long method to keep the change small