### PR TITLE
Add SquiggleCop to baseline analyzer settings

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -15,6 +15,13 @@
         "dotnet-verify"
       ],
       "rollForward": false
+    },
+    "squigglecop.tool": {
+      "version": "1.0.8",
+      "commands": [
+        "dotnet-squigglecop"
+      ],
+      "rollForward": false
     }
   }
 }

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -74,6 +74,13 @@ jobs:
         path: |
           **/*.received.*
 
+    - name: Upload SARIF files
+      uses: actions/upload-artifact@v4
+      if: success() || failure()
+      with:
+        name: SARIF files (${{ matrix.os }})
+        path: ./artifacts/obj/**/*.sarif
+
     - name: Upload Test Report
       uses: actions/upload-artifact@v4
       if: success() || failure()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,7 @@ permissions:
 jobs:
   build:
     strategy:
+      fail-fast: false # Run all OSes, even if one fails, to help narrow down issues that only impact some platforms
       matrix:
         os: [windows-2022, ubuntu-22.04]
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,3 +5,14 @@ We welcome contributions. If you want to contribute to existing issues, check th
 [good first issue](https://github.com/rjmurillo/moq.analyzers/labels/good%20first%20issue) items in the backlog.
 
 If you have new ideas or want to complain about bugs, feel free to [create a new issue](https://github.com/rjmurillo/moq.analyzers/issues/new).
+
+## Updating SquiggleCop baselines
+
+To update SquiggleCop baselines, run this command and review and commit the results:
+
+```powershell
+dotnet clean && dotnet build /p:PedanticMode=true /p:SquiggleCop_AutoBaseline=true
+```
+
+`$(PedanticMode)` turns on the CI configuration (e.g. `TreatWarningsAsErrors`) and `$(SquiggleCop_AutoBaseline)`
+automatically accepts the new baseline.

--- a/build/targets/codeanalysis/CodeAnalysis.props
+++ b/build/targets/codeanalysis/CodeAnalysis.props
@@ -30,6 +30,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="SquiggleCop.Tasks">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
     <PackageReference Include="Microsoft.VisualStudio.Threading.Analyzers">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/build/targets/codeanalysis/CodeAnalysis.targets
+++ b/build/targets/codeanalysis/CodeAnalysis.targets
@@ -3,5 +3,22 @@
     <PedanticMode Condition=" '$(PedanticMode)' == '' ">$([MSBuild]::ValueOrDefault('$(ContinuousIntegrationBuild)', 'false'))</PedanticMode>
     <TreatWarningsAsErrors>$(PedanticMode)</TreatWarningsAsErrors>
     <MSBuildTreatWarningsAsErrors>$(PedanticMode)</MSBuildTreatWarningsAsErrors>
+    <SquiggleCop_Enabled>$(PedanticMode)</SquiggleCop_Enabled>
   </PropertyGroup>
+
+  <Target Name="SetErrorLog" BeforeTargets="CoreCompile">
+    <!--
+      ErrorLog is needed for SquiggleCop.
+
+      The value is set in a Target and not directly as a property because `$(IntermediateOutputPath)` and `$(OutputPath)`
+      are calculated properties and thus shouldn't be relied on during the initial property evaluation phase.
+      See https://github.com/dotnet/sdk/issues/41852.
+
+      We use `$(IntermediateOutputPath)` to ensure the file ends up in the `obj/` folder and not with sources to clearly
+      delineate inputs and outputs.
+    -->
+    <PropertyGroup Condition=" '$(ErrorLog)' == '' ">
+      <ErrorLog>$(IntermediateOutputPath)/$(MSBuildProjectName).sarif,version=2.1</ErrorLog>
+    </PropertyGroup>
+  </Target>
 </Project>

--- a/build/targets/codeanalysis/Packages.props
+++ b/build/targets/codeanalysis/Packages.props
@@ -5,6 +5,7 @@
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.30.0.95878" />    
+    <PackageVersion Include="SquiggleCop.Tasks" Version="1.0.1" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48" />
     <PackageVersion Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
   </ItemGroup>

--- a/build/targets/codeanalysis/Packages.props
+++ b/build/targets/codeanalysis/Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.30.0.95878" />    
-    <PackageVersion Include="SquiggleCop.Tasks" Version="1.0.6" />
+    <PackageVersion Include="SquiggleCop.Tasks" Version="1.0.8" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48" />
     <PackageVersion Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
   </ItemGroup>

--- a/build/targets/codeanalysis/Packages.props
+++ b/build/targets/codeanalysis/Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.30.0.95878" />    
-    <PackageVersion Include="SquiggleCop.Tasks" Version="1.0.1" />
+    <PackageVersion Include="SquiggleCop.Tasks" Version="1.0.6" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48" />
     <PackageVersion Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
   </ItemGroup>

--- a/src/Moq.Analyzers/SquiggleCop.Baseline.yaml
+++ b/src/Moq.Analyzers/SquiggleCop.Baseline.yaml
@@ -1,12512 +1,1563 @@
-- Id: CA1000
-  Title: Do not declare static members on generic types
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1001
-  Title: Types that own disposable fields should be disposable
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1002
-  Title: Do not expose generic lists
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1003
-  Title: Use generic event handler instances
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1005
-  Title: Avoid excessive parameters on generic types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1008
-  Title: Enums should have zero value
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1010
-  Title: Generic interface should also be implemented
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1012
-  Title: Abstract types should not have public constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1014
-  Title: Mark assemblies with CLSCompliant
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1016
-  Title: Mark assemblies with assembly version
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1017
-  Title: Mark assemblies with ComVisible
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1018
-  Title: Mark attributes with AttributeUsageAttribute
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1019
-  Title: Define accessors for attribute arguments
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1021
-  Title: Avoid out parameters
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1024
-  Title: Use properties where appropriate
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1027
-  Title: Mark enums with FlagsAttribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1028
-  Title: Enum Storage should be Int32
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1030
-  Title: Use events where appropriate
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1031
-  Title: Do not catch general exception types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1032
-  Title: Implement standard exception constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1033
-  Title: Interface methods should be callable by child types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1034
-  Title: Nested types should not be visible
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1036
-  Title: Override methods on comparable types
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1040
-  Title: Avoid empty interfaces
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1041
-  Title: Provide ObsoleteAttribute message
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1043
-  Title: Use Integral Or String Argument For Indexers
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1044
-  Title: Properties should not be write only
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1045
-  Title: Do not pass types by reference
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1046
-  Title: Do not overload equality operator on reference types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1050
-  Title: Declare types in namespaces
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1051
-  Title: Do not declare visible instance fields
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1052
-  Title: Static holder types should be Static or NotInheritable
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1054
-  Title: URI-like parameters should not be strings
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1055
-  Title: URI-like return values should not be strings
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1056
-  Title: URI-like properties should not be strings
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1058
-  Title: Types should not extend certain base types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1060
-  Title: Move pinvokes to native methods class
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1061
-  Title: Do not hide base class methods
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1062
-  Title: Validate arguments of public methods
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1063
-  Title: Implement IDisposable Correctly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1064
-  Title: Exceptions should be public
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1065
-  Title: Do not raise exceptions in unexpected locations
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1066
-  Title: Implement IEquatable when overriding Object.Equals
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: CA1067
-  Title: Override Object.Equals(object) when implementing IEquatable<T>
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1068
-  Title: CancellationToken parameters must come last
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1069
-  Title: Enums values should not be duplicated
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1070
-  Title: Do not declare event fields as virtual
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1200
-  Title: Avoid using cref tags with a prefix
-  Category: Documentation
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1303
-  Title: Do not pass literals as localized parameters
-  Category: Globalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1304
-  Title: Specify CultureInfo
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1305
-  Title: Specify IFormatProvider
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1307
-  Title: Specify StringComparison for clarity
-  Category: Globalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1308
-  Title: Normalize strings to uppercase
-  Category: Globalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1309
-  Title: Use ordinal string comparison
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1310
-  Title: Specify StringComparison for correctness
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1311
-  Title: Specify a culture or use an invariant version
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1401
-  Title: P/Invokes should not be visible
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1416
-  Title: Validate platform compatibility
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1417
-  Title: Do not use 'OutAttribute' on string parameters for P/Invokes
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1418
-  Title: Use valid platform string
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1419
-  Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1420
-  Title: Property, type, or attribute requires runtime marshalling
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1421
-  Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1422
-  Title: Validate platform compatibility
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1501
-  Title: Avoid excessive inheritance
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1502
-  Title: Avoid excessive complexity
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1505
-  Title: Avoid unmaintainable code
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1506
-  Title: Avoid excessive class coupling
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1507
-  Title: Use nameof to express symbol names
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1508
-  Title: Avoid dead conditional code
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1509
-  Title: Invalid entry in code metrics rule specification file
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1510
-  Title: Use ArgumentNullException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1511
-  Title: Use ArgumentException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1512
-  Title: Use ArgumentOutOfRangeException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1513
-  Title: Use ObjectDisposedException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1700
-  Title: Do not name enum values 'Reserved'
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1707
-  Title: Identifiers should not contain underscores
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1708
-  Title: Identifiers should differ by more than case
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1710
-  Title: Identifiers should have correct suffix
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1711
-  Title: Identifiers should not have incorrect suffix
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1712
-  Title: Do not prefix enum values with type name
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1713
-  Title: Events should not have 'Before' or 'After' prefix
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1715
-  Title: Identifiers should have correct prefix
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1716
-  Title: Identifiers should not match keywords
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1720
-  Title: Identifier contains type name
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1721
-  Title: Property names should not match get methods
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1724
-  Title: Type names should not match namespaces
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1725
-  Title: Parameter names should match base declaration
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1727
-  Title: Use PascalCase for named placeholders
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1802
-  Title: Use literals where appropriate
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1805
-  Title: Do not initialize unnecessarily
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1806
-  Title: Do not ignore method results
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1810
-  Title: Initialize reference type static fields inline
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1812
-  Title: Avoid uninstantiated internal classes
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1813
-  Title: Avoid unsealed attributes
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1814
-  Title: Prefer jagged arrays over multidimensional
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1815
-  Title: Override equals and operator equals on value types
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1816
-  Title: Dispose methods should call SuppressFinalize
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1819
-  Title: Properties should not return arrays
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1820
-  Title: Test for empty strings using string length
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1821
-  Title: Remove empty Finalizers
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1822
-  Title: Mark members as static
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1823
-  Title: Avoid unused private fields
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1824
-  Title: Mark assemblies with NeutralResourcesLanguageAttribute
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1825
-  Title: Avoid zero-length array allocations
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1826
-  Title: Do not use Enumerable methods on indexable collections
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1827
-  Title: Do not use Count() or LongCount() when Any() can be used
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1828
-  Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1829
-  Title: Use Length/Count property instead of Count() when available
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1830
-  Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1831
-  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1832
-  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1833
-  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1834
-  Title: Consider using 'StringBuilder.Append(char)' when applicable
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1835
-  Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1836
-  Title: Prefer IsEmpty over Count
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1837
-  Title: Use 'Environment.ProcessId'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1838
-  Title: Avoid 'StringBuilder' parameters for P/Invokes
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1839
-  Title: Use 'Environment.ProcessPath'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1840
-  Title: Use 'Environment.CurrentManagedThreadId'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1841
-  Title: Prefer Dictionary.Contains methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1842
-  Title: Do not use 'WhenAll' with a single task
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1843
-  Title: Do not use 'WaitAll' with a single task
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1844
-  Title: Provide memory-based overrides of async methods when subclassing 'Stream'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1845
-  Title: Use span-based 'string.Concat'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1846
-  Title: Prefer 'AsSpan' over 'Substring'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1847
-  Title: Use char literal for a single character lookup
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1848
-  Title: Use the LoggerMessage delegates
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1849
-  Title: Call async methods when in an async method
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1850
-  Title: Prefer static 'HashData' method over 'ComputeHash'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1851
-  Title: Possible multiple enumerations of 'IEnumerable' collection
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1852
-  Title: Seal internal types
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1853
-  Title: Unnecessary call to 'Dictionary.ContainsKey(key)'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1854
-  Title: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1855
-  Title: Prefer 'Clear' over 'Fill'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1856
-  Title: Incorrect usage of ConstantExpected attribute
-  Category: Performance
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1857
-  Title: A constant is expected for the parameter
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1858
-  Title: Use 'StartsWith' instead of 'IndexOf'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1859
-  Title: Use concrete types when possible for improved performance
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1860
-  Title: Avoid using 'Enumerable.Any()' extension method
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1861
-  Title: Avoid constant arrays as arguments
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1862
-  Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1863
-  Title: Use 'CompositeFormat'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1864
-  Title: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1865
-  Title: Use char overload
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1866
-  Title: Use char overload
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1867
-  Title: Use char overload
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: CA1868
-  Title: Unnecessary call to 'Contains(item)'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1869
-  Title: Cache and reuse 'JsonSerializerOptions' instances
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1870
-  Title: Use a cached 'SearchValues' instance
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2000
-  Title: Dispose objects before losing scope
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2002
-  Title: Do not lock on objects with weak identity
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2007
-  Title: Consider calling ConfigureAwait on the awaited task
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2008
-  Title: Do not create tasks without passing a TaskScheduler
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2009
-  Title: Do not call ToImmutableCollection on an ImmutableCollection value
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2011
-  Title: Avoid infinite recursion
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2012
-  Title: Use ValueTasks correctly
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2013
-  Title: Do not use ReferenceEquals with value types
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2014
-  Title: Do not use stackalloc in loops
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2015
-  Title: Do not define finalizers for types derived from MemoryManager<T>
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2016
-  Title: Forward the 'CancellationToken' parameter to methods
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: CA2017
-  Title: Parameter count mismatch
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2018
-  Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument"
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2019
-  Title: Improper 'ThreadStatic' field initialization
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2020
-  Title: Prevent behavioral change
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2021
-  Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2100
-  Title: Review SQL queries for security vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2101
-  Title: Specify marshaling for P/Invoke string arguments
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2119
-  Title: Seal methods that satisfy private interfaces
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2153
-  Title: Do Not Catch Corrupted State Exceptions
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2200
-  Title: Rethrow to preserve stack details
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2201
-  Title: Do not raise reserved exception types
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA2207
-  Title: Initialize value type static fields inline
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2208
-  Title: Instantiate argument exceptions correctly
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2211
-  Title: Non-constant fields should not be visible
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2213
-  Title: Disposable fields should be disposed
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2214
-  Title: Do not call overridable methods in constructors
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2215
-  Title: Dispose methods should call base class dispose
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA2216
-  Title: Disposable types should declare finalizer
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2217
-  Title: Do not mark enums with FlagsAttribute
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2219
-  Title: Do not raise exceptions in finally clauses
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2225
-  Title: Operator overloads have named alternates
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2226
-  Title: Operators should have symmetrical overloads
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2227
-  Title: Collection properties should be read only
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2231
-  Title: Overload operator equals on overriding value type Equals
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2234
-  Title: Pass system uri objects instead of strings
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2235
-  Title: Mark all non-serializable fields
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2237
-  Title: Mark ISerializable types with serializable
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2241
-  Title: Provide correct arguments to formatting methods
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2242
-  Title: Test for NaN correctly
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2243
-  Title: Attribute string literals should parse correctly
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2244
-  Title: Do not duplicate indexed element initializations
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2245
-  Title: Do not assign a property to itself
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2246
-  Title: Assigning symbol and its member in the same statement
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2247
-  Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2248
-  Title: Provide correct 'enum' argument to 'Enum.HasFlag'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2249
-  Title: Consider using 'string.Contains' instead of 'string.IndexOf'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2250
-  Title: Use 'ThrowIfCancellationRequested'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2251
-  Title: Use 'string.Equals'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA2252
-  Title: This API requires opting into preview features
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2253
-  Title: Named placeholders should not be numeric values
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2254
-  Title: Template should be a static expression
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2255
-  Title: The 'ModuleInitializer' attribute should not be used in libraries
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2256
-  Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2257
-  Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2258
-  Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2259
-  Title: "'ThreadStatic' only affects static fields"
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2260
-  Title: Use correct type parameter
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2261
-  Title: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2300
-  Title: Do not use insecure deserializer BinaryFormatter
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2301
-  Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2302
-  Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2305
-  Title: Do not use insecure deserializer LosFormatter
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2310
-  Title: Do not use insecure deserializer NetDataContractSerializer
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2311
-  Title: Do not deserialize without first setting NetDataContractSerializer.Binder
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2312
-  Title: Ensure NetDataContractSerializer.Binder is set before deserializing
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2315
-  Title: Do not use insecure deserializer ObjectStateFormatter
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2321
-  Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2322
-  Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2326
-  Title: Do not use TypeNameHandling values other than None
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2327
-  Title: Do not use insecure JsonSerializerSettings
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2328
-  Title: Ensure that JsonSerializerSettings are secure
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2329
-  Title: Do not deserialize with JsonSerializer using an insecure configuration
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2330
-  Title: Ensure that JsonSerializer has a secure configuration when deserializing
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2350
-  Title: Do not use DataTable.ReadXml() with untrusted data
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2351
-  Title: Do not use DataSet.ReadXml() with untrusted data
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2352
-  Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2353
-  Title: Unsafe DataSet or DataTable in serializable type
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2354
-  Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2355
-  Title: Unsafe DataSet or DataTable type found in deserializable object graph
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2356
-  Title: Unsafe DataSet or DataTable type in web deserializable object graph
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2361
-  Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2362
-  Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3001
-  Title: Review code for SQL injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3002
-  Title: Review code for XSS vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3003
-  Title: Review code for file path injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3004
-  Title: Review code for information disclosure vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3005
-  Title: Review code for LDAP injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3006
-  Title: Review code for process command injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3007
-  Title: Review code for open redirect vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3008
-  Title: Review code for XPath injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3009
-  Title: Review code for XML injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3010
-  Title: Review code for XAML injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3011
-  Title: Review code for DLL injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3012
-  Title: Review code for regex injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3061
-  Title: Do Not Add Schema By URL
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3075
-  Title: Insecure DTD processing in XML
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3076
-  Title: Insecure XSLT script processing
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3077
-  Title: Insecure Processing in API Design, XmlDocument and XmlTextReader
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3147
-  Title: Mark Verb Handlers With Validate Antiforgery Token
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5350
-  Title: Do Not Use Weak Cryptographic Algorithms
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5351
-  Title: Do Not Use Broken Cryptographic Algorithms
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5358
-  Title: Review cipher mode usage with cryptography experts
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5359
-  Title: Do Not Disable Certificate Validation
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5360
-  Title: Do Not Call Dangerous Methods In Deserialization
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5361
-  Title: Do Not Disable SChannel Use of Strong Crypto
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5362
-  Title: Potential reference cycle in deserialized object graph
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5363
-  Title: Do Not Disable Request Validation
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5364
-  Title: Do Not Use Deprecated Security Protocols
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5365
-  Title: Do Not Disable HTTP Header Checking
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5366
-  Title: Use XmlReader for 'DataSet.ReadXml()'
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5367
-  Title: Do Not Serialize Types With Pointer Fields
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5368
-  Title: Set ViewStateUserKey For Classes Derived From Page
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5369
-  Title: Use XmlReader for 'XmlSerializer.Deserialize()'
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5370
-  Title: Use XmlReader for XmlValidatingReader constructor
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5371
-  Title: Use XmlReader for 'XmlSchema.Read()'
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5372
-  Title: Use XmlReader for XPathDocument constructor
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5373
-  Title: Do not use obsolete key derivation function
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5374
-  Title: Do Not Use XslTransform
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5375
-  Title: Do Not Use Account Shared Access Signature
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5376
-  Title: Use SharedAccessProtocol HttpsOnly
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5377
-  Title: Use Container Level Access Policy
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5378
-  Title: Do not disable ServicePointManagerSecurityProtocols
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5379
-  Title: Ensure Key Derivation Function algorithm is sufficiently strong
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5380
-  Title: Do Not Add Certificates To Root Store
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5381
-  Title: Ensure Certificates Are Not Added To Root Store
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5382
-  Title: Use Secure Cookies In ASP.NET Core
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5383
-  Title: Ensure Use Secure Cookies In ASP.NET Core
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5384
-  Title: Do Not Use Digital Signature Algorithm (DSA)
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5385
-  Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5386
-  Title: Avoid hardcoding SecurityProtocolType value
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5387
-  Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5388
-  Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5389
-  Title: Do Not Add Archive Item's Path To The Target File System Path
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5390
-  Title: Do not hard-code encryption key
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5391
-  Title: Use antiforgery tokens in ASP.NET Core MVC controllers
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5392
-  Title: Use DefaultDllImportSearchPaths attribute for P/Invokes
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5393
-  Title: Do not use unsafe DllImportSearchPath value
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5394
-  Title: Do not use insecure randomness
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5395
-  Title: Miss HttpVerb attribute for action methods
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5396
-  Title: Set HttpOnly to true for HttpCookie
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5397
-  Title: Do not use deprecated SslProtocols values
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5398
-  Title: Avoid hardcoded SslProtocols values
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5399
-  Title: HttpClients should enable certificate revocation list checks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5400
-  Title: Ensure HttpClient certificate revocation list check is not disabled
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5401
-  Title: Do not use CreateEncryptor with non-default IV
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5402
-  Title: 'Use CreateEncryptor with the default IV '
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5403
-  Title: Do not hard-code certificate
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5404
-  Title: Do not disable token validation checks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5405
-  Title: Do not always skip token validation in delegates
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: EM0001
-  Title: Switch on Enum Not Exhaustive
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0002
-  Title: Switch on Nullable Enum Not Exhaustive
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0003
-  Title: Switch on Closed Type Not Exhaustive
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0011
-  Title: Concrete Subtype of a Closed Type Must Be a Case
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0012
-  Title: Closed Type Case Must Be a Direct Subtype
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0013
-  Title: Closed Type Case Must Be a Subtype
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0014
-  Title: Concrete Subtype of a Closed Type Must Be a Covered
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0015
-  Title: Open Interface Subtype of a Closed Type Must Be a Case
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0100
-  Title: When Guards Not Supported
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0101
-  Title: Case Pattern Not Supported
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0102
-  Title: Open Type Not Supported
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0103
-  Title: Match Must Be On Case Type
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0104
-  Title: Duplicate Closed Attribute
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0105
-  Title: Duplicate Case Type
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EnableGenerateDocumentationFile
-  Title: Set MSBuild property 'GenerateDocumentationFile' to 'true'
-  Category: Style
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: IDE0004
-  Title: Remove Unnecessary Cast
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0005
-  Title: Using directive is unnecessary.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0005_gen
-  Title: Using directive is unnecessary.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0007
-  Title: Use implicit type
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0008
-  Title: Use explicit type
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0009
-  Title: Member access should be qualified.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0010
-  Title: Add missing cases
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0011
-  Title: Add braces
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0016
-  Title: Use 'throw' expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0017
-  Title: Simplify object initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0018
-  Title: Inline variable declaration
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0019
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0020
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0021
-  Title: Use expression body for constructor
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0022
-  Title: Use expression body for method
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0023
-  Title: Use expression body for conversion operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0024
-  Title: Use expression body for operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0025
-  Title: Use expression body for property
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0026
-  Title: Use expression body for indexer
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0027
-  Title: Use expression body for accessor
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0028
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0029
-  Title: Use coalesce expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0030
-  Title: Use coalesce expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0031
-  Title: Use null propagation
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0032
-  Title: Use auto property
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0033
-  Title: Use explicitly provided tuple name
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0034
-  Title: Simplify 'default' expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0035
-  Title: Unreachable code detected
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0036
-  Title: Order modifiers
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0037
-  Title: Use inferred member name
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0039
-  Title: Use local function
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0040
-  Title: Add accessibility modifiers
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0041
-  Title: Use 'is null' check
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0042
-  Title: Deconstruct variable declaration
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0043
-  Title: Invalid format string
-  Category: Compiler
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0044
-  Title: Add readonly modifier
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0045
-  Title: Convert to conditional expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0046
-  Title: Convert to conditional expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0047
-  Title: Remove unnecessary parentheses
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0048
-  Title: Add parentheses for clarity
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0051
-  Title: Remove unused private members
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0052
-  Title: Remove unread private members
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0053
-  Title: Use expression body for lambda expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0054
-  Title: Use compound assignment
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0055
-  Title: Fix formatting
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0056
-  Title: Use index operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0057
-  Title: Use range operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0058
-  Title: Expression value is never used
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0059
-  Title: Unnecessary assignment of a value
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0060
-  Title: Remove unused parameter
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0061
-  Title: Use expression body for local function
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0062
-  Title: Make local function 'static'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0063
-  Title: Use simple 'using' statement
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0064
-  Title: Make readonly fields writable
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0065
-  Title: Misplaced using directive
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0066
-  Title: Convert switch statement to expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0070
-  Title: Use 'System.HashCode'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0071
-  Title: Simplify interpolation
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0072
-  Title: Add missing cases
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0073
-  Title: The file header does not match the required text
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0074
-  Title: Use compound assignment
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0075
-  Title: Simplify conditional expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0076
-  Title: Invalid global 'SuppressMessageAttribute'
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0077
-  Title: Avoid legacy format target in 'SuppressMessageAttribute'
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0078
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0080
-  Title: Remove unnecessary suppression operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0082
-  Title: "'typeof' can be converted to 'nameof'"
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0083
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0090
-  Title: Use 'new(...)'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0100
-  Title: Remove redundant equality
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0110
-  Title: Remove unnecessary discard
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0120
-  Title: Simplify LINQ expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0130
-  Title: Namespace does not match folder structure
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0150
-  Title: Prefer 'null' check over type check
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0160
-  Title: Convert to block scoped namespace
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0161
-  Title: Convert to file-scoped namespace
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0170
-  Title: Property pattern can be simplified
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0180
-  Title: Use tuple to swap values
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0200
-  Title: Remove unnecessary lambda expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0210
-  Title: Convert to top-level statements
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0211
-  Title: Convert to 'Program.Main' style program
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0220
-  Title: Add explicit cast
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0230
-  Title: Use UTF-8 string literal
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0240
-  Title: Remove redundant nullable directive
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0241
-  Title: Remove unnecessary nullable directive
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0250
-  Title: Make struct 'readonly'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0251
-  Title: Make member 'readonly'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0260
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0270
-  Title: Use coalesce expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0280
-  Title: Use 'nameof'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0290
-  Title: Use primary constructor
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0300
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0301
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0302
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0303
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0304
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0305
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0320
-  Title: Make anonymous function static
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE1005
-  Title: Delegate invocation can be simplified.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE1006
-  Title: Naming Styles
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE2000
-  Title: Avoid multiple blank lines
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2001
-  Title: Embedded statements must be on their own line
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2002
-  Title: Consecutive braces must not have blank line between them
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2003
-  Title: Blank line required between block and subsequent statement
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2004
-  Title: Blank line not allowed after constructor initializer colon
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2005
-  Title: Blank line not allowed after conditional expression token
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2006
-  Title: Blank line not allowed after arrow expression clause token
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0001
-  Title: StringComparison is missing
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0002
-  Title: IEqualityComparer<string> or IComparer<string> is missing
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0003
-  Title: Add parameter name to improve readability
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0004
-  Title: Use Task.ConfigureAwait
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0005
-  Title: Use Array.Empty<T>()
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0006
-  Title: Use String.Equals instead of equality operator
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0007
-  Title: Add a comma after the last value
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0008
-  Title: Add StructLayoutAttribute
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0009
-  Title: Add regex evaluation timeout
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0010
-  Title: Mark attributes with AttributeUsageAttribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0011
-  Title: IFormatProvider is missing
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0012
-  Title: Do not raise reserved exception type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0013
-  Title: Types should not extend System.ApplicationException
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0014
-  Title: Do not raise System.ApplicationException type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0015
-  Title: Specify the parameter name in ArgumentException
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0016
-  Title: Prefer using collection abstraction instead of implementation
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0017
-  Title: Abstract types should not have public or internal constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0018
-  Title: Do not declare static members on generic types (deprecated; use CA1000 instead)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0019
-  Title: Use EventArgs.Empty
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0020
-  Title: Use direct methods instead of LINQ methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0021
-  Title: Use StringComparer.GetHashCode instead of string.GetHashCode
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0022
-  Title: Return Task.FromResult instead of returning null
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0023
-  Title: Add RegexOptions.ExplicitCapture
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0024
-  Title: Use an explicit StringComparer when possible
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0025
-  Title: Implement the functionality instead of throwing NotImplementedException
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0026
-  Title: Fix TODO comment
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - None
-  IsEverSuppressed: true
-- Id: MA0027
-  Title: Prefer rethrowing an exception implicitly
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0028
-  Title: Optimize StringBuilder usage
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0029
-  Title: Combine LINQ methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0030
-  Title: Remove useless OrderBy call
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0031
-  Title: Optimize Enumerable.Count() usage
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0032
-  Title: Use an overload with a CancellationToken argument
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0033
-  Title: Do not tag instance fields with ThreadStaticAttribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0035
-  Title: Do not use dangerous threading methods
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0036
-  Title: Make class static
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0037
-  Title: Remove empty statement
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0038
-  Title: Make method static (deprecated, use CA1822 instead)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0039
-  Title: Do not write your own certificate validation method
-  Category: Security
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0040
-  Title: Forward the CancellationToken parameter to methods that take one
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: MA0041
-  Title: Make property static (deprecated, use CA1822 instead)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0042
-  Title: Do not use blocking calls in an async method
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0043
-  Title: Use nameof operator in ArgumentException
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0044
-  Title: Remove useless ToString call
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0045
-  Title: Do not use blocking calls in a sync method (need to make calling method async)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0046
-  Title: Use EventHandler<T> to declare events
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0047
-  Title: Declare types in namespaces
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0048
-  Title: File name must match type name
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0049
-  Title: Type name should not match containing namespace
-  Category: Design
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0050
-  Title: Validate arguments correctly in iterator methods
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0051
-  Title: Method is too long
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: true
-- Id: MA0052
-  Title: Replace constant Enum.ToString with nameof
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0053
-  Title: Make class sealed
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0054
-  Title: Embed the caught exception as innerException
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0055
-  Title: Do not use finalizer
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0056
-  Title: Do not call overridable members in constructor
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0057
-  Title: Class name should end with 'Attribute'
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0058
-  Title: Class name should end with 'Exception'
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0059
-  Title: Class name should end with 'EventArgs'
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0060
-  Title: The value returned by Stream.Read/Stream.ReadAsync is not used
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0061
-  Title: Method overrides should not change default values
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0062
-  Title: Non-flags enums should not be marked with "FlagsAttribute"
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0063
-  Title: Use Where before OrderBy
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0064
-  Title: Avoid locking on publicly accessible instance
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0065
-  Title: Default ValueType.Equals or HashCode is used for struct equality
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0066
-  Title: Hash table unfriendly type is used in a hash table
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0067
-  Title: Use Guid.Empty
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0068
-  Title: Invalid parameter name for nullable attribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0069
-  Title: Non-constant static fields should not be visible
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0070
-  Title: Obsolete attributes should include explanations
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0071
-  Title: Avoid using redundant else
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0072
-  Title: Do not throw from a finally block
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0073
-  Title: Avoid comparison with bool constant
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0074
-  Title: Avoid implicit culture-sensitive methods
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0075
-  Title: Do not use implicit culture-sensitive ToString
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0076
-  Title: Do not use implicit culture-sensitive ToString in interpolated strings
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0077
-  Title: A class that provides Equals(T) should implement IEquatable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0078
-  Title: Use 'Cast' instead of 'Select' to cast
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0079
-  Title: Forward the CancellationToken using .WithCancellation()
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0080
-  Title: Use a cancellation token using .WithCancellation()
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0081
-  Title: Method overrides should not omit params keyword
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0082
-  Title: NaN should not be used in comparisons
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0083
-  Title: ConstructorArgument parameters should exist in constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0084
-  Title: Local variables should not hide other symbols
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0085
-  Title: Anonymous delegates should not be used to unsubscribe from Events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0086
-  Title: Do not throw from a finalizer
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0087
-  Title: Parameters with [DefaultParameterValue] attributes should also be marked [Optional]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0088
-  Title: Use [DefaultParameterValue] instead of [DefaultValue]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0089
-  Title: Optimize string method usage
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0090
-  Title: Remove empty else/finally block
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0091
-  Title: Sender should be 'this' for instance events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0092
-  Title: Sender should be 'null' for static events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0093
-  Title: EventArgs should not be null
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0094
-  Title: A class that provides CompareTo(T) should implement IComparable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0095
-  Title: A class that implements IEquatable<T> should override Equals(object)
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0096
-  Title: A class that implements IComparable<T> should also implement IEquatable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0097
-  Title: A class that implements IComparable<T> or IComparable should override comparison operators
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0098
-  Title: Use indexer instead of LINQ methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0099
-  Title: Use Explicit enum value instead of 0
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0100
-  Title: Await task before disposing of resources
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0101
-  Title: String contains an implicit end of line character
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: MA0102
-  Title: Make member readonly
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0103
-  Title: Use SequenceEqual instead of equality operator
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0104
-  Title: Do not create a type with a name from the BCL
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0105
-  Title: Use the lambda parameters instead of using a closure
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0106
-  Title: Avoid closure by using an overload with the 'factoryArgument' parameter
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0107
-  Title: Do not use culture-sensitive object.ToString
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0108
-  Title: Remove redundant argument value
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0109
-  Title: Consider adding an overload with a Span<T> or Memory<T>
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0110
-  Title: Use the Regex source generator
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0111
-  Title: Use string.Create instead of FormattableString
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0112
-  Title: Use 'Count > 0' instead of 'Any()'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0113
-  Title: Use DateTime.UnixEpoch
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0114
-  Title: Use DateTimeOffset.UnixEpoch
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0115
-  Title: Unknown component parameter
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0116
-  Title: Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0117
-  Title: Parameters with [EditorRequired] attributes should also be marked as [Parameter]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0118
-  Title: '[JSInvokable] methods must be public'
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0119
-  Title: JSRuntime must not be used in OnInitialized or OnInitializedAsync
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0120
-  Title: Use InvokeVoidAsync when the returned value is not used
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0121
-  Title: Do not overwrite parameter value
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0122
-  Title: Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0123
-  Title: Sequence number must be a constant
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0124
-  Title: Log parameter type is not valid
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0125
-  Title: The list of log parameter types contains an invalid type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0126
-  Title: The list of log parameter types contains a duplicate
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0127
-  Title: Use String.Equals instead of is pattern
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0128
-  Title: Use 'is' operator instead of SequenceEqual
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0129
-  Title: Await task in using statement
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0130
-  Title: GetType() should not be used on System.Type instances
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0131
-  Title: ArgumentNullException.ThrowIfNull should not be used with non-nullable types
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0132
-  Title: Do not convert implicitly to DateTimeOffset
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0133
-  Title: Use DateTimeOffset instead of relying on the implicit conversion
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0134
-  Title: Observe result of async calls
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0135
-  Title: The log parameter has no configured type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0136
-  Title: Raw String contains an implicit end of line character
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: MA0137
-  Title: Use 'Async' suffix when a method returns an awaitable type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0138
-  Title: Do not use 'Async' suffix when a method does not return an awaitable type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0139
-  Title: Log parameter type is not valid
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0140
-  Title: Both if and else branch have identical code
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0141
-  Title: Use pattern matching instead of inequality operators for null check
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0142
-  Title: Use pattern matching instead of equality operators for null check
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0143
-  Title: Primary constructor parameters should be readonly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0144
-  Title: Use System.OperatingSystem to check the current OS
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0145
-  Title: Signature for [UnsafeAccessorAttribute] method is not valid
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0146
-  Title: Name must be set explicitly on local functions
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0147
-  Title: Avoid async void method for delegate
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0148
-  Title: Use pattern matching instead of equality operators for discrete value
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0149
-  Title: Use pattern matching instead of inequality operators for discrete value
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0150
-  Title: Do not call the default object.ToString explicitly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0151
-  Title: DebuggerDisplay must contain valid members
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0152
-  Title: Use Unwrap instead of using await twice
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0153
-  Title: Do not log symbols decorated with DataClassificationAttribute directly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0154
-  Title: Use langword in XML comment
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0155
-  Title: Do not use async void methods
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0156
-  Title: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0157
-  Title: Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0158
-  Title: Use System.Threading.Lock
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0159
-  Title: Use 'Order' instead of 'OrderBy'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0160
-  Title: Use ContainsKey instead of TryGetValue
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: POLYSP0003
-  Title: Unsupported C# language version
-  Category: Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1001
-  Title: Add braces (when expression spans over multiple lines)
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1002
-  Title: Remove braces
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1002FadeOut
-  Title: Remove braces
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1003
-  Title: Add braces to if-else (when expression spans over multiple lines)
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1004
-  Title: Remove braces from if-else
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1004FadeOut
-  Title: Remove braces from if-else
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1005
-  Title: Simplify nested using statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1005FadeOut
-  Title: Simplify nested using statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1006
-  Title: Merge 'else' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1006FadeOut
-  Title: Merge 'else' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1007
-  Title: Add braces
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1008
-  Title: "[deprecated] Use explicit type instead of 'var' (when the type is not obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1009
-  Title: "[deprecated] Use explicit type instead of 'var' (foreach variable)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1010
-  Title: "[deprecated] Use 'var' instead of explicit type (when the type is obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1012
-  Title: "[deprecated] Use explicit type instead of 'var' (when the type is obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1013
-  Title: Use predefined type
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1014
-  Title: Use explicitly/implicitly typed array
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1015
-  Title: Use nameof operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1015FadeOut
-  Title: Use nameof operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1016
-  Title: Use block body or expression body
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1018
-  Title: Add/remove accessibility modifiers
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1019
-  Title: Order modifiers
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1020
-  Title: Simplify Nullable<T> to T?
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1021
-  Title: Convert lambda expression body to expression body
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1021FadeOut
-  Title: Convert lambda expression body to expression body
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1031
-  Title: Remove unnecessary braces in switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1031FadeOut
-  Title: Remove unnecessary braces in switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1032
-  Title: Remove redundant parentheses
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1032FadeOut
-  Title: Remove redundant parentheses
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1033
-  Title: Remove redundant boolean literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1034
-  Title: Remove redundant 'sealed' modifier
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1035
-  Title: '[deprecated] Remove redundant comma in initializer'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1036
-  Title: Remove unnecessary blank line
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1037
-  Title: Remove trailing white-space
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1038
-  Title: '[deprecated] Remove empty statement'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1039
-  Title: Remove argument list from attribute
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1040
-  Title: "[deprecated] Remove empty 'else' clause"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1041
-  Title: '[deprecated] Remove empty initializer'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1042
-  Title: Remove enum default underlying type
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1043
-  Title: Remove 'partial' modifier from type with a single part
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1044
-  Title: Remove original exception from throw statement
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1046
-  Title: Asynchronous method name should end with 'Async'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1047
-  Title: Non-asynchronous method name should not end with 'Async'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1047FadeOut
-  Title: Non-asynchronous method name should not end with 'Async'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1048
-  Title: Use lambda expression instead of anonymous method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1048FadeOut
-  Title: Use lambda expression instead of anonymous method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1049
-  Title: Simplify boolean comparison
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1049FadeOut
-  Title: Simplify boolean comparison
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1050
-  Title: Include/omit parentheses when creating new object
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1051
-  Title: Add/remove parentheses from condition in conditional operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1052
-  Title: Declare each attribute separately
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1055
-  Title: Unnecessary semicolon at the end of declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1056
-  Title: Avoid usage of using alias directive
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1058
-  Title: Use compound assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1058FadeOut
-  Title: Use compound assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1059
-  Title: Avoid locking on publicly accessible instance
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1060
-  Title: Declare each type in separate file
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1061
-  Title: Merge 'if' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1061FadeOut
-  Title: Merge 'if' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1063
-  Title: '[deprecated] Avoid usage of do statement to create an infinite loop'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1064
-  Title: '[deprecated] Avoid usage of for statement to create an infinite loop'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1065
-  Title: '[deprecated] Avoid usage of while statement to create an infinite loop'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1066
-  Title: "[deprecated] Remove empty 'finally' clause"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1066FadeOut
-  Title: "[deprecated] Remove empty 'finally' clause"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1068
-  Title: Simplify logical negation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1069
-  Title: Remove unnecessary case label
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1070
-  Title: Remove redundant default switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1071
-  Title: Remove redundant base constructor call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1072
-  Title: '[deprecated] Remove empty namespace declaration'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1073
-  Title: Convert 'if' to 'return' statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1073FadeOut
-  Title: Convert 'if' to 'return' statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1074
-  Title: Remove redundant constructor
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1075
-  Title: Avoid empty catch clause that catches System.Exception
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1077
-  Title: Optimize LINQ method call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1078
-  Title: Use "" or 'string.Empty'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1079
-  Title: Throwing of new NotImplementedException
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1080
-  Title: Use 'Count/Length' property instead of 'Any' method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1081
-  Title: Split variable declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1084
-  Title: Use coalesce expression instead of conditional expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1085
-  Title: Use auto-implemented property
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1085FadeOut
-  Title: Use auto-implemented property
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1089
-  Title: Use --/++ operator instead of assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1089FadeOut
-  Title: Use --/++ operator instead of assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1090
-  Title: Add/remove 'ConfigureAwait(false)' call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1091
-  Title: '[deprecated] Remove empty region'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1091FadeOut
-  Title: '[deprecated] Remove empty region'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1093
-  Title: File contains no code
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1094
-  Title: Declare using directive on top level
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1096
-  Title: Use 'HasFlag' method or bitwise operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1097
-  Title: Remove redundant 'ToString' call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1098
-  Title: Constant values should be placed on right side of comparisons
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1099
-  Title: Default label should be the last label in a switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1100
-  Title: '[deprecated] Format documentation summary on a single line'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1101
-  Title: '[deprecated] Format documentation summary on multiple lines'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1102
-  Title: Make class static
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1103
-  Title: Convert 'if' to assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1104
-  Title: Simplify conditional expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1105
-  Title: Unnecessary interpolation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1106
-  Title: '[deprecated] Remove empty destructor'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1107
-  Title: Remove redundant 'ToCharArray' call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1108
-  Title: Add 'static' modifier to all partial class declarations
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1110
-  Title: Declare type inside namespace
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1111
-  Title: Add braces to switch section with multiple statements
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1112
-  Title: Combine 'Enumerable.Where' method chain
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1112FadeOut
-  Title: Combine 'Enumerable.Where' method chain
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1113
-  Title: Use 'string.IsNullOrEmpty' method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1114
-  Title: Remove redundant delegate creation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1114FadeOut
-  Title: Remove redundant delegate creation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1118
-  Title: Mark local variable as const
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1123
-  Title: Add parentheses when necessary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1124
-  Title: Inline local variable
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1124FadeOut
-  Title: Inline local variable
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1126
-  Title: Add braces to if-else
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1128
-  Title: Use coalesce expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1129
-  Title: Remove redundant field initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1130
-  Title: Bitwise operation on enum without Flags attribute
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1132
-  Title: Remove redundant overriding member
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1133
-  Title: Remove redundant Dispose/Close call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1134
-  Title: Remove redundant statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1135
-  Title: Declare enum member with zero value (when enum has FlagsAttribute)
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1136
-  Title: Merge switch sections with equivalent content
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1138
-  Title: Add summary to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1139
-  Title: Add summary element to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1140
-  Title: Add exception to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1141
-  Title: Add 'param' element to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1142
-  Title: Add 'typeparam' element to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1143
-  Title: Simplify coalesce expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1145
-  Title: Remove redundant 'as' operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1146
-  Title: Use conditional access
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1151
-  Title: Remove redundant cast
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1154
-  Title: Sort enum members
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1155
-  Title: Use StringComparison when comparing strings
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1156
-  Title: Use string.Length instead of comparison with empty string
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1157
-  Title: Composite enum value contains undefined flag
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1158
-  Title: Static member in generic type should use a type parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1159
-  Title: Use EventHandler<T>
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1160
-  Title: Abstract type should not have public constructors
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1161
-  Title: Enum should declare explicit values
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1162
-  Title: Avoid chain of assignments
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1163
-  Title: Unused parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1164
-  Title: Unused type parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1165
-  Title: Unconstrained type parameter checked for null
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1166
-  Title: Value type object is never equal to null
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1168
-  Title: Parameter name differs from base name
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1169
-  Title: Make field read-only
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1170
-  Title: Use read-only auto-implemented property
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1171
-  Title: Simplify lazy initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1172
-  Title: Use 'is' operator instead of 'as' operator
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1173
-  Title: Use coalesce expression instead of 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1174
-  Title: Remove redundant async/await
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1174FadeOut
-  Title: Remove redundant async/await
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1175
-  Title: Unused 'this' parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1176
-  Title: "[deprecated] Use 'var' instead of explicit type (when the type is not obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1177
-  Title: "[deprecated] Use 'var' instead of explicit type (in foreach)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1179
-  Title: Unnecessary assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1180
-  Title: Inline lazy initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1181
-  Title: Convert comment to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1182
-  Title: Remove redundant base interface
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1186
-  Title: Use Regex instance instead of static method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1187
-  Title: Use constant instead of field
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1188
-  Title: Remove redundant auto-property initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1189
-  Title: Add or remove region name
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1190
-  Title: Join string expressions
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1191
-  Title: Declare enum value as combination of names
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1192
-  Title: Unnecessary usage of verbatim string literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1193
-  Title: Overriding member should not change 'params' modifier
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1194
-  Title: Implement exception constructors
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1195
-  Title: Use ^ operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1196
-  Title: Call extension method as instance method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1197
-  Title: Optimize StringBuilder.Append/AppendLine call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1198
-  Title: Avoid unnecessary boxing of value type
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1199
-  Title: Unnecessary null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1200
-  Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1201
-  Title: Use method chaining
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1202
-  Title: Avoid NullReferenceException
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1203
-  Title: Use AttributeUsageAttribute
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1204
-  Title: Use EventArgs.Empty
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1205
-  Title: Order named arguments according to the order of parameters
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1206
-  Title: Use conditional access instead of conditional expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1207
-  Title: Use anonymous function or method group
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1208
-  Title: Reduce 'if' nesting
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1209
-  Title: Order type parameter constraints
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1210
-  Title: Return completed task instead of returning null
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1211
-  Title: Remove unnecessary 'else'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1212
-  Title: Remove redundant assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1212FadeOut
-  Title: Remove redundant assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1213
-  Title: Remove unused member declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1214
-  Title: Unnecessary interpolated string
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1214FadeOut
-  Title: Unnecessary interpolated string
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1215
-  Title: Expression is always equal to true/false
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1216
-  Title: Unnecessary unsafe context
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1217
-  Title: Convert interpolated string to concatenation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1217FadeOut
-  Title: Convert interpolated string to concatenation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1218
-  Title: Simplify code branching
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1220
-  Title: Use pattern matching instead of combination of 'is' operator and cast operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1221
-  Title: Use pattern matching instead of combination of 'as' operator and null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1222
-  Title: Merge preprocessor directives
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1223
-  Title: Mark publicly visible type with DebuggerDisplay attribute
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1224
-  Title: Make method an extension method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1225
-  Title: Make class sealed
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1226
-  Title: Add paragraph to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1227
-  Title: Validate arguments correctly
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1228
-  Title: Unused element in a documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1229
-  Title: Use async/await when necessary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1230
-  Title: Unnecessary explicit use of enumerator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1231
-  Title: Make parameter ref read-only
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1232
-  Title: Order elements in documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1233
-  Title: Use short-circuiting operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1234
-  Title: Duplicate enum value
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1235
-  Title: Optimize method call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1236
-  Title: Use exception filter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1237
-  Title: '[deprecated] Use bit shift operator'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1238
-  Title: 'Avoid nested ?: operators'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1239
-  Title: Use 'for' statement instead of 'while' statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1240
-  Title: Operator is unnecessary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1241
-  Title: Implement non-generic counterpart
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1242
-  Title: Do not pass non-read-only struct by read-only reference
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1243
-  Title: Duplicate word in a comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1244
-  Title: Simplify 'default' expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1246
-  Title: Use element access
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1247
-  Title: Fix documentation comment tag
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1248
-  Title: Normalize null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1249
-  Title: Unnecessary null-forgiving operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1250
-  Title: Use implicit/explicit object creation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1251
-  Title: Remove unnecessary braces from record declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1252
-  Title: Normalize usage of infinite loop
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1253
-  Title: Format documentation comment summary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1254
-  Title: Normalize format of enum flag value
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1255
-  Title: Simplify argument null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1256
-  Title: Invalid argument null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1257
-  Title: Use enum field explicitly
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1258
-  Title: Unnecessary enum flag
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1259
-  Title: Remove empty syntax
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1260
-  Title: Add/remove trailing comma
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1261
-  Title: Resource can be disposed asynchronously
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1262
-  Title: Unnecessary raw string literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1263
-  Title: Invalid reference in a documentation comment
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1264
-  Title: Use 'var' or explicit type
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1265
-  Title: Remove redundant catch block
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1266
-  Title: Use raw string literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1267
-  Title: Use string interpolation instead of 'string.Concat'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1268
-  Title: Simplify numeric comparison
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RemoveUnnecessaryImportsFixable
-  Title: ''
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: ROS0002
-  Title: Analyzer option is obsolete
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: ROS0003
-  Title: Analyzer requires config option to be specified
-  Category: ''
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RS1001
-  Title: Missing diagnostic analyzer attribute
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1002
-  Title: Missing kind argument when registering an analyzer action
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1003
-  Title: Unsupported SymbolKind argument when registering a symbol analyzer action
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1004
-  Title: Recommend adding language support to diagnostic analyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1005
-  Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1006
-  Title: Invalid type argument for DiagnosticAnalyzer's Register method
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1007
-  Title: Provide localizable arguments to diagnostic descriptor constructor
-  Category: MicrosoftCodeAnalysisLocalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RS1008
-  Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1009
-  Title: Only internal implementations of this interface are allowed
-  Category: MicrosoftCodeAnalysisCompatibility
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1010
-  Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support
-  Category: Correctness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1011
-  Title: Use code actions that have a unique EquivalenceKey for FixAll occurrences support
-  Category: Correctness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1012
-  Title: Start action has no registered actions
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1013
-  Title: Start action has no registered non-end actions
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1014
-  Title: Do not ignore values returned by methods on immutable objects
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1015
-  Title: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor
-  Category: MicrosoftCodeAnalysisDocumentation
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1016
-  Title: Code fix providers should provide FixAll support
-  Category: Correctness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1017
-  Title: DiagnosticId for analyzers must be a non-null constant
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1018
-  Title: DiagnosticId for analyzers must be in specified format
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1019
-  Title: DiagnosticId must be unique across analyzers
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1020
-  Title: Category for analyzers must be from the specified values
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1021
-  Title: Invalid entry in analyzer category and diagnostic ID range specification file
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1022
-  Title: Do not use types from Workspaces assembly in an analyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1023
-  Title: Upgrade MSBuildWorkspace
-  Category: Library
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1024
-  Title: Symbols should be compared for equality
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1025
-  Title: Configure generated code analysis
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1026
-  Title: Enable concurrent execution
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1027
-  Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1028
-  Title: Provide non-null 'customTags' value to diagnostic descriptor constructor
-  Category: MicrosoftCodeAnalysisDocumentation
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RS1029
-  Title: Do not use reserved diagnostic IDs
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1030
-  Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1031
-  Title: Define diagnostic title correctly
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1032
-  Title: Define diagnostic message correctly
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1033
-  Title: Define diagnostic description correctly
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1034
-  Title: Prefer 'IsKind' for checking syntax kinds
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1035
-  Title: Do not use APIs banned for analyzers
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1036
-  Title: Specify analyzer banned API enforcement setting
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1037
-  Title: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2000
-  Title: Add analyzer diagnostic IDs to analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2001
-  Title: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2002
-  Title: Do not add removed analyzer diagnostic IDs to unshipped analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2003
-  Title: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2004
-  Title: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2005
-  Title: Remove duplicate entries for diagnostic ID in the same analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2006
-  Title: Remove duplicate entries for diagnostic ID between analyzer releases
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2007
-  Title: Invalid entry in analyzer release file
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2008
-  Title: Enable analyzer release tracking
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S100
-  Title: Methods and properties should be named in PascalCase
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S1006
-  Title: Method overrides should not change parameter defaults
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S101
-  Title: Types should be named in PascalCase
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S103
-  Title: Lines should not be too long
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S104
-  Title: Files should not have too many lines of code
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1048
-  Title: Finalizers should not throw exceptions
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S105
-  Title: Tabulation characters should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S106
-  Title: Standard outputs should not be used directly to log anything
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1066
-  Title: Mergeable "if" statements should be combined
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1067
-  Title: Expressions should not be too complex
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S107
-  Title: Methods should not have too many parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1075
-  Title: URIs should not be hardcoded
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S108
-  Title: Nested blocks of code should not be left empty
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S109
-  Title: Magic numbers should not be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S110
-  Title: Inheritance tree of classes should not be too deep
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1104
-  Title: Fields should not have public accessibility
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1109
-  Title: A close curly brace should be located at the beginning of a line
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1110
-  Title: Redundant pairs of parentheses should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1116
-  Title: Empty statements should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1117
-  Title: Local variables should not shadow class fields or properties
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1118
-  Title: Utility classes should not have public constructors
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S112
-  Title: General or reserved exceptions should never be thrown
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1121
-  Title: Assignments should not be made from within sub-expressions
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1123
-  Title: '"Obsolete" attributes should include explanations'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1125
-  Title: Boolean literals should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1128
-  Title: Unnecessary "using" should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S113
-  Title: Files should end with a newline
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1133
-  Title: Deprecated code should be removed
-  Category: Info Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1134
-  Title: Track uses of "FIXME" tags
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1135
-  Title: Track uses of "TODO" tags
-  Category: Info Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: S1144
-  Title: Unused private types or members should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1147
-  Title: Exit methods should not be called
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1151
-  Title: '"switch case" clauses should not have too many lines of code'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1155
-  Title: '"Any()" should be used to test for emptiness'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1163
-  Title: Exceptions should not be thrown in finally blocks
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1168
-  Title: Empty arrays and collections should be returned instead of null
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1172
-  Title: Unused method parameters should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1185
-  Title: Overriding members should do more than simply call the same member in the base class
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1186
-  Title: Methods should not be empty
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1192
-  Title: String literals should not be duplicated
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1199
-  Title: Nested code blocks should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1200
-  Title: Classes should not be coupled to too many other classes
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1206
-  Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S121
-  Title: Control structures should use curly braces
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1210
-  Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1215
-  Title: '"GC.Collect" should not be called'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S122
-  Title: Statements should be on separate lines
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1226
-  Title: Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1227
-  Title: break statements should not be used except for switch cases
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1244
-  Title: Floating point numbers should not be tested for equality
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S125
-  Title: Sections of code should not be commented out
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S126
-  Title: '"if ... else if" constructs should end with "else" clauses'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1264
-  Title: A "while" loop should be used instead of a "for" loop
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S127
-  Title: '"for" loop stop conditions should be invariant'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1301
-  Title: '"switch" statements should have at least 3 "case" clauses'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1309
-  Title: Track uses of in-source issue suppressions
-  Category: Info Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S131
-  Title: '"switch/Select" statements should contain a "default/Case Else" clauses'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1312
-  Title: Logger fields should be "private static readonly"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1313
-  Title: Using hardcoded IP addresses is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S134
-  Title: Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S138
-  Title: Functions should not have too many lines of code
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1449
-  Title: Culture should be specified for "string" operations
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1450
-  Title: Private fields only used as local variables in methods should become local variables
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1451
-  Title: Track lack of copyright and license headers
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1479
-  Title: '"switch" statements with many "case" clauses should have only one statement'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1481
-  Title: Unused local variables should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1541
-  Title: Methods and properties should not be too complex
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1607
-  Title: Tests should not be ignored
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1643
-  Title: Strings should not be concatenated using '+' in a loop
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1656
-  Title: Variables should not be self-assigned
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1659
-  Title: Multiple variables should not be declared on the same line
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1694
-  Title: An abstract class should have both abstract and concrete methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1696
-  Title: NullReferenceException should not be caught
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1698
-  Title: '"==" should not be used when "Equals" is overridden'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1699
-  Title: Constructors should only call non-overridable methods
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1751
-  Title: Loops with at most one iteration should be refactored
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1764
-  Title: Identical expressions should not be used on both sides of operators
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1821
-  Title: '"switch" statements should not be nested'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1848
-  Title: Objects should not be created to be dropped immediately without being used
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1854
-  Title: Unused assignments should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1858
-  Title: '"ToString()" calls should not be redundant'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1862
-  Title: Related "if/else if" statements should not have the same condition
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1871
-  Title: Two branches in a conditional structure should not have exactly the same implementation
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1905
-  Title: Redundant casts should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1939
-  Title: Inheritance list should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1940
-  Title: Boolean checks should not be inverted
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1944
-  Title: Invalid casts should be avoided
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1994
-  Title: "\"for\" loop increment clauses should modify the loops' counters"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2053
-  Title: Password hashing functions should use an unpredictable salt
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2068
-  Title: Hard-coded credentials are security-sensitive
-  Category: Blocker Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2077
-  Title: Formatting SQL queries is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2092
-  Title: Creating cookies without the "secure" flag is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2094
-  Title: Classes should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2114
-  Title: Collections should not be passed as arguments to their own methods
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2115
-  Title: A secure password should be used when connecting to a database
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2123
-  Title: Values should not be uselessly incremented
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2139
-  Title: Exceptions should be either logged or rethrown but not both
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2148
-  Title: Underscores should be used to make large numbers readable
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2156
-  Title: '"sealed" classes should not have "protected" members'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2166
-  Title: Classes named like "Exception" should extend "Exception" or a subclass
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2178
-  Title: Short-circuit logic should be used in boolean contexts
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2183
-  Title: Integral numbers should not be shifted by zero or more than their number of bits-1
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2184
-  Title: Results of integer division should not be assigned to floating point variables
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2187
-  Title: Test classes should contain at least one test case
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2190
-  Title: Loops and recursions should not be infinite
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2197
-  Title: Modulus results should not be checked for direct equality
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2198
-  Title: Unnecessary mathematical comparisons should not be made
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2201
-  Title: Methods without side effects should not have their return values ignored
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2219
-  Title: Runtime type checking should be simplified
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2221
-  Title: '"Exception" should not be caught'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2222
-  Title: Locks should be released on all paths
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2223
-  Title: Non-constant static fields should not be visible
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2225
-  Title: '"ToString()" method should not return null'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2234
-  Title: Arguments should be passed in the same order as the method parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2245
-  Title: Using pseudorandom number generators (PRNGs) is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2251
-  Title: A "for" loop update clause should move the counter in the right direction
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2252
-  Title: For-loop conditions should be true at least once
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2257
-  Title: Using non-standard cryptographic algorithms is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2259
-  Title: Null pointers should not be dereferenced
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2275
-  Title: Composite format strings should not lead to unexpected behavior at runtime
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2290
-  Title: Field-like events should not be virtual
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2291
-  Title: Overflow checking should not be disabled for "Enumerable.Sum"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2292
-  Title: Trivial properties should be auto-implemented
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2302
-  Title: '"nameof" should be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2306
-  Title: '"async" and "await" should not be used as identifiers'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2325
-  Title: Methods and properties that don't access instance data should be static
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2326
-  Title: Unused type parameters should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2327
-  Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2328
-  Title: '"GetHashCode" should not reference mutable fields'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2330
-  Title: Array covariance should not be used
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2333
-  Title: Redundant modifiers should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2339
-  Title: Public constant members should not be used
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2342
-  Title: Enumeration types should comply with a naming convention
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2344
-  Title: Enumeration type names should not have "Flags" or "Enum" suffixes
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2345
-  Title: Flags enumerations should explicitly initialize all their members
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2346
-  Title: Flags enumerations zero-value members should be named "None"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2357
-  Title: Fields should be private
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2360
-  Title: Optional parameters should not be used
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2365
-  Title: Properties should not make collection or array copies
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2368
-  Title: Public methods should not have multidimensional array parameters
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2372
-  Title: Exceptions should not be thrown from property getters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2376
-  Title: Write-only properties should not be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2386
-  Title: Mutable fields should not be "public static"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2387
-  Title: Child class fields should not shadow parent class fields
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2436
-  Title: Types and methods should not have too many generic parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2437
-  Title: Unnecessary bit operations should not be performed
-  Category: Blocker Code Smell
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: S2445
-  Title: Blocks should be synchronized on read-only fields
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2479
-  Title: Whitespace and control characters in string literals should be explicit
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2486
-  Title: Generic exceptions should not be ignored
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2551
-  Title: Shared resources should not be used for locking
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2583
-  Title: Conditionally executed code should be reachable
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2589
-  Title: Boolean expressions should not be gratuitous
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: true
-- Id: S2612
-  Title: Setting loose file permissions is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2629
-  Title: Logging templates should be constant
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2674
-  Title: The length returned from a stream read should be checked
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2681
-  Title: Multiline blocks should be enclosed in curly braces
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2688
-  Title: '"NaN" should not be used in comparisons'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2692
-  Title: '"IndexOf" checks should not be for positive numbers'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2696
-  Title: Instance members should not write to "static" fields
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2699
-  Title: Tests should include assertions
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2701
-  Title: Literal boolean values should not be used in assertions
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2737
-  Title: '"catch" clauses should do more than rethrow'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2743
-  Title: Static fields should not be used in generic types
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2755
-  Title: XML parsers should not be vulnerable to XXE attacks
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2757
-  Title: Non-existent operators like "=+" should not be used
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2760
-  Title: Sequential tests should not check the same condition
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2761
-  Title: Doubled prefix operators "!!" and "~~" should not be used
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2857
-  Title: SQL keywords should be delimited by whitespace
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2925
-  Title: '"Thread.Sleep" should not be used in tests'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2930
-  Title: '"IDisposables" should be disposed'
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2931
-  Title: Classes with "IDisposable" members should implement "IDisposable"
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2933
-  Title: Fields that are only assigned in the constructor should be "readonly"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2934
-  Title: Property assignments should not be made for "readonly" fields not constrained to reference types
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2952
-  Title: Classes should "Dispose" of members from the classes' own "Dispose" methods
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2953
-  Title: Methods named "Dispose" should implement "IDisposable.Dispose"
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2955
-  Title: Generic parameters not constrained to reference types should not be compared to "null"
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2970
-  Title: Assertions should be complete
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2971
-  Title: LINQ expressions should be simplified
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2995
-  Title: '"Object.ReferenceEquals" should not be used for value types'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2996
-  Title: '"ThreadStatic" fields should not be initialized'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2997
-  Title: '"IDisposables" created in a "using" statement should not be returned'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3005
-  Title: '"ThreadStatic" should not be used on non-static fields'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3010
-  Title: Static fields should not be updated in constructors
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3011
-  Title: Reflection should not be used to increase accessibility of classes, methods, or fields
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3052
-  Title: Members should not be initialized to default values
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3059
-  Title: Types should not have members with visibility set higher than the type's visibility
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3060
-  Title: '"is" should not be used with "this"'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3063
-  Title: '"StringBuilder" data should be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3168
-  Title: '"async" methods should not return "void"'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3169
-  Title: Multiple "OrderBy" calls should not be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3172
-  Title: Delegates should not be subtracted
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3215
-  Title: '"interface" instances should not be cast to concrete types'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3216
-  Title: '"ConfigureAwait(false)" should be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3217
-  Title: '"Explicit" conversions of "foreach" loops should not be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3218
-  Title: Inner class members should not shadow outer class "static" or type members
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3220
-  Title: Method calls should not resolve ambiguously to overloads with "params"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3234
-  Title: '"GC.SuppressFinalize" should not be invoked for types without destructors'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3235
-  Title: Redundant parentheses should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3236
-  Title: Caller information arguments should not be provided explicitly
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3237
-  Title: '"value" contextual keyword should be used'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3240
-  Title: The simplest possible condition syntax should be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3241
-  Title: Methods should not return values that are never used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3242
-  Title: Method parameters should be declared with base types
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3244
-  Title: Anonymous delegates should not be used to unsubscribe from Events
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3246
-  Title: Generic type parameters should be co/contravariant when possible
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3247
-  Title: Duplicate casts should not be made
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3249
-  Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3251
-  Title: Implementations should be provided for "partial" methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3253
-  Title: Constructor and destructor declarations should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3254
-  Title: Default parameter values should not be passed as arguments
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3256
-  Title: '"string.IsNullOrEmpty" should be used'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3257
-  Title: Declarations and initializations should be as concise as possible
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3260
-  Title: Non-derived "private" classes and records should be "sealed"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3261
-  Title: Namespaces should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3262
-  Title: '"params" should be used on overrides'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3263
-  Title: 'Static fields should appear in the order they must be initialized '
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3264
-  Title: Events should be invoked
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3265
-  Title: Non-flags enums should not be used in bitwise operations
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3267
-  Title: Loops should be simplified with "LINQ" expressions
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3329
-  Title: Cipher Block Chaining IVs should be unpredictable
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3330
-  Title: Creating cookies without the "HttpOnly" flag is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3343
-  Title: Caller information parameters should come at the end of the parameter list
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3346
-  Title: Expressions used in "Debug.Assert" should not produce side effects
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3353
-  Title: Unchanged variables should be marked as "const"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3358
-  Title: Ternary operators should not be nested
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3363
-  Title: Date and time should not be used as a type for primary keys
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3366
-  Title: '"this" should not be exposed from constructors'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3376
-  Title: Attribute, EventArgs, and Exception type names should end with the type being extended
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3397
-  Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3398
-  Title: '"private" methods called only by inner classes should be moved to those classes'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3400
-  Title: Methods should not return constants
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3415
-  Title: Assertion arguments should be passed in the correct order
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3416
-  Title: Loggers should be named for their enclosing types
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3427
-  Title: Method overloads with default parameter values should not overlap
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3431
-  Title: '"[ExpectedException]" should not be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3433
-  Title: Test method signatures should be correct
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3440
-  Title: Variables should not be checked against the values they're about to be assigned
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3441
-  Title: Redundant property names should be omitted in anonymous classes
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3442
-  Title: '"abstract" classes should not have "public" constructors'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3443
-  Title: Type should not be examined on "System.Type" instances
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3444
-  Title: Interfaces should not simply inherit from base interfaces with colliding members
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3445
-  Title: Exceptions should not be explicitly rethrown
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3447
-  Title: '"[Optional]" should not be used on "ref" or "out" parameters'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3449
-  Title: Right operands of shift operators should be integers
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3450
-  Title: Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3451
-  Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3453
-  Title: Classes should not have only "private" constructors
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3456
-  Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3457
-  Title: Composite format strings should be used correctly
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3458
-  Title: Empty "case" clauses that fall through to the "default" should be omitted
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3459
-  Title: Unassigned members should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3464
-  Title: Type inheritance should not be recursive
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3466
-  Title: Optional parameters should be passed to "base" calls
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3532
-  Title: Empty "default" clauses should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3597
-  Title: '"ServiceContract" and "OperationContract" attributes should be used together'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3598
-  Title: One-way "OperationContract" methods should have "void" return type
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3600
-  Title: '"params" should not be introduced on overrides'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3603
-  Title: 'Methods with "Pure" attribute should return a value '
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3604
-  Title: Member initializer values should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3610
-  Title: Nullable type comparison should not be redundant
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3626
-  Title: Jump statements should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3655
-  Title: Empty nullable value should not be accessed
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3717
-  Title: Track use of "NotImplementedException"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3776
-  Title: Cognitive Complexity of methods should not be too high
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3869
-  Title: '"SafeHandle.DangerousGetHandle" should not be called'
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3871
-  Title: Exception types should be "public"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3872
-  Title: Parameter names should not duplicate the names of their methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3874
-  Title: '"out" and "ref" parameters should not be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3875
-  Title: '"operator==" should not be overloaded on reference types'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3876
-  Title: Strings or integral types should be used for indexers
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3877
-  Title: Exceptions should not be thrown from unexpected methods
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3878
-  Title: Arrays should not be created for params parameters
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3880
-  Title: Finalizers should not be empty
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3881
-  Title: '"IDisposable" should be implemented correctly'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3884
-  Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used'
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3885
-  Title: '"Assembly.Load" should be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3887
-  Title: Mutable, non-private fields should not be "readonly"
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3889
-  Title: '"Thread.Resume" and "Thread.Suspend" should not be used'
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3897
-  Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3898
-  Title: Value types should implement "IEquatable<T>"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3900
-  Title: Arguments of public methods should be validated against null
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S3902
-  Title: '"Assembly.GetExecutingAssembly" should not be called'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3903
-  Title: Types should be defined in named namespaces
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3904
-  Title: Assemblies should have version information
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3906
-  Title: Event Handlers should have the correct signature
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3908
-  Title: Generic event handlers should be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3909
-  Title: Collections should implement the generic interface
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3923
-  Title: All branches in a conditional structure should not have exactly the same implementation
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3925
-  Title: '"ISerializable" should be implemented correctly'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3926
-  Title: Deserialization methods should be provided for "OptionalField" members
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3927
-  Title: Serialization event handlers should be implemented correctly
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3928
-  Title: 'Parameter names used into ArgumentException constructors should match an existing one '
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3937
-  Title: Number patterns should be regular
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3949
-  Title: Calculations should not overflow
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3956
-  Title: '"Generic.List" instances should not be part of public APIs'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3962
-  Title: '"static readonly" constants should be "const" instead'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3963
-  Title: '"static" fields should be initialized inline'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3966
-  Title: Objects should not be disposed more than once
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3967
-  Title: Multidimensional arrays should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3971
-  Title: '"GC.SuppressFinalize" should not be called'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3972
-  Title: Conditionals should start on new lines
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3973
-  Title: A conditionally executed single line should be denoted by indentation
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3981
-  Title: Collection sizes and array length comparisons should make sense
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3984
-  Title: Exceptions should not be created without being thrown
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3990
-  Title: Assemblies should be marked as CLS compliant
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3992
-  Title: Assemblies should explicitly specify COM visibility
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3993
-  Title: Custom attributes should be marked with "System.AttributeUsageAttribute"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3994
-  Title: URI Parameters should not be strings
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3995
-  Title: URI return values should not be strings
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3996
-  Title: URI properties should not be strings
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3997
-  Title: String URI overloads should call "System.Uri" overloads
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3998
-  Title: Threads should not lock on objects with weak identity
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4000
-  Title: Pointers to unmanaged memory should not be visible
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4002
-  Title: Disposable types should declare finalizers
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4004
-  Title: Collection properties should be readonly
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4005
-  Title: '"System.Uri" arguments should be used instead of strings'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4015
-  Title: Inherited member visibility should not be decreased
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4016
-  Title: Enumeration members should not be named "Reserved"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4017
-  Title: Method signatures should not contain nested generic types
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4018
-  Title: All type parameters should be used in the parameter list to enable type inference
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4019
-  Title: Base class methods should not be hidden
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4022
-  Title: Enumerations should have "Int32" storage
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4023
-  Title: Interfaces should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4025
-  Title: Child class fields should not differ from parent class fields only by capitalization
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4026
-  Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4027
-  Title: Exceptions should provide standard constructors
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4035
-  Title: Classes implementing "IEquatable<T>" should be sealed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4036
-  Title: Searching OS commands in PATH is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4039
-  Title: Interface methods should be callable by derived types
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4040
-  Title: Strings should be normalized to uppercase
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4041
-  Title: Type names should not match namespaces
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4047
-  Title: Generics should be used when appropriate
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4049
-  Title: Properties should be preferred
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4050
-  Title: Operators should be overloaded consistently
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4052
-  Title: Types should not extend outdated base types
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4055
-  Title: Literals should not be passed as localized parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4056
-  Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4057
-  Title: Locales should be set for data types
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4058
-  Title: Overloads with a "StringComparison" parameter should be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4059
-  Title: Property names should not match get methods
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4060
-  Title: Non-abstract attributes should be sealed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4061
-  Title: '"params" should be used instead of "varargs"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4069
-  Title: Operator overloads should have named alternatives
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4070
-  Title: Non-flags enums should not be marked with "FlagsAttribute"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4136
-  Title: Method overloads should be grouped together
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4143
-  Title: Collection elements should not be replaced unconditionally
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4144
-  Title: Methods should not have identical implementations
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4158
-  Title: Empty collections should not be accessed or iterated
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4159
-  Title: Classes should implement their "ExportAttribute" interfaces
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4200
-  Title: Native methods should be wrapped
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4201
-  Title: Null checks should not be combined with "is" operator checks
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4210
-  Title: Windows Forms entry points should be marked with STAThread
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4211
-  Title: Members should not have conflicting transparency annotations
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4212
-  Title: Serialization constructors should be secured
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4214
-  Title: '"P/Invoke" methods should not be visible'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4220
-  Title: Events should have proper arguments
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4225
-  Title: Extension methods should not extend "object"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4226
-  Title: Extensions should be in separate namespaces
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4260
-  Title: '"ConstructorArgument" parameters should exist in constructors'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4261
-  Title: Methods should be named according to their synchronicities
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4275
-  Title: Getters and setters should access the expected fields
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4277
-  Title: '"Shared" parts should not be created with "new"'
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4347
-  Title: Secure random number generators should not output predictable values
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4423
-  Title: Weak SSL/TLS protocols should not be used
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4426
-  Title: Cryptographic keys should be robust
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4428
-  Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4433
-  Title: LDAP connections should be authenticated
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4456
-  Title: Parameter validation in yielding methods should be wrapped
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4457
-  Title: Parameter validation in "async"/"await" methods should be wrapped
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4462
-  Title: Calls to "async" methods should not be blocking
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S4487
-  Title: Unread "private" fields should be removed
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4502
-  Title: Disabling CSRF protections is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4507
-  Title: Delivering code in production with debug features activated is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4524
-  Title: '"default" clauses should be first or last'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4545
-  Title: '"DebuggerDisplayAttribute" strings should reference existing members'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4581
-  Title: '"new Guid()" should not be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4583
-  Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4586
-  Title: Non-async "Task/Task<T>" methods should not return null
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4635
-  Title: Start index should be used instead of calling Substring
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4663
-  Title: Comments should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4790
-  Title: Using weak hashing algorithms is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4792
-  Title: Configuring loggers is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4830
-  Title: Server certificates should be verified during SSL/TLS connections
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5034
-  Title: '"ValueTask" should be consumed correctly'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5042
-  Title: Expanding archive files without controlling resource consumption is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5122
-  Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5332
-  Title: Using clear-text protocols is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5344
-  Title: Passwords should not be stored in plaintext or with a fast hashing algorithm
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5443
-  Title: Using publicly writable directories is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5445
-  Title: Insecure temporary file creation methods should not be used
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5542
-  Title: Encryption algorithms should be used with secure mode and padding scheme
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5547
-  Title: Cipher algorithms should be robust
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5659
-  Title: JWT should be signed and verified with strong cipher algorithms
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5693
-  Title: Allowing requests with excessive content length is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5753
-  Title: Disabling ASP.NET "Request Validation" feature is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5766
-  Title: Deserializing objects without performing data validation is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5773
-  Title: Types allowed to be deserialized should be restricted
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5856
-  Title: Regular expressions should be syntactically valid
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6354
-  Title: Use a testable date/time provider
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6377
-  Title: XML signatures should be validated securely
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6419
-  Title: Azure Functions should be stateless
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6420
-  Title: Client instances should not be recreated on each Azure Function invocation
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6421
-  Title: Azure Functions should use Structured Error Handling
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6422
-  Title: Calls to "async" methods should not be blocking in Azure Functions
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6423
-  Title: Azure Functions should log all failures
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6424
-  Title: Interfaces for durable entities should satisfy the restrictions
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6444
-  Title: Not specifying a timeout for regular expressions is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6507
-  Title: Blocks should not be synchronized on local variables
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S6513
-  Title: '"ExcludeFromCodeCoverage" attributes should include a justification'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6561
-  Title: Avoid using "DateTime.Now" for benchmarking or timing operations
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6562
-  Title: Always set the "DateTimeKind" when creating new "DateTime" instances
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6563
-  Title: Use UTC when recording DateTime instants
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6566
-  Title: Use "DateTimeOffset" instead of "DateTime"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6575
-  Title: Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6580
-  Title: Use a format provider when parsing date and time
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6585
-  Title: Don't hardcode the format when turning dates and times to strings
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6588
-  Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6602
-  Title: '"Find" method should be used instead of the "FirstOrDefault" extension'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6603
-  Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6605
-  Title: Collection-specific "Exists" method should be used instead of the "Any" extension
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6607
-  Title: The collection should be filtered before sorting by using "Where" before "OrderBy"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6608
-  Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6609
-  Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6610
-  Title: '"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6612
-  Title: The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6613
-  Title: '"First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6617
-  Title: '"Contains" should be used instead of "Any" for simple equality checks'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6618
-  Title: '"string.Create" should be used instead of "FormattableString"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6640
-  Title: Using unsafe code blocks is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6664
-  Title: The code block contains too many logging calls
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6667
-  Title: Logging in a catch clause should pass the caught exception as a parameter.
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6668
-  Title: Logging arguments should be passed to the correct parameter
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6669
-  Title: Logger field or property name should comply with a naming convention
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6670
-  Title: '"Trace.Write" and "Trace.WriteLine" should not be used'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6672
-  Title: Generic logger injection should match enclosing type
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6673
-  Title: Log message template placeholders should be in the right order
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6674
-  Title: Log message template should be syntactically correct
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6675
-  Title: '"Trace.WriteLineIf" should not be used with "TraceSwitch" levels'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6677
-  Title: Message template placeholders should be unique
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6678
-  Title: Use PascalCase for named placeholders
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6781
-  Title: JWT secret keys should not be disclosed
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6797
-  Title: Blazor query parameter type should be supported
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6798
-  Title: '[JSInvokable] attribute should only be used on public methods'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6800
-  Title: Component parameter type should match the route parameter type constraint
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6802
-  Title: Using lambda expressions in loops should be avoided in Blazor markup section
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6803
-  Title: Parameters with SupplyParameterFromQuery attribute should be used only in routable components
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S6930
-  Title: Backslash should be avoided in route templates
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6931
-  Title: ASP.NET controller actions should not have a route template starting with "/"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6932
-  Title: Use model binding instead of reading raw request data
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6934
-  Title: A Route attribute should be added to the controller when a route template is specified at the action level
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6960
-  Title: Controllers should not have mixed responsibilities
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6961
-  Title: API Controllers should derive from ControllerBase instead of Controller
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6962
-  Title: You should pool HTTP connections with HttpClientFactory
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6964
-  Title: Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6965
-  Title: REST API actions should be annotated with an HTTP verb attribute
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6966
-  Title: Awaitable method should be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6967
-  Title: ModelState.IsValid should be called in controller actions
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6968
-  Title: Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S818
-  Title: Literal suffixes should be upper case
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S881
-  Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S907
-  Title: '"goto" statement should not be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S927
-  Title: Parameter names should match base declaration and other partial definitions
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S9999-cpd
-  Title: Copy-paste token calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-log
-  Title: Log generator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-metadata
-  Title: File metadata generator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-metrics
-  Title: Metrics calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-symbolRef
-  Title: Symbol reference calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-token-type
-  Title: Token type calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-warning
-  Title: Analysis Warning generator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: SA0001
-  Title: XML comment analysis disabled
-  Category: StyleCop.CSharp.SpecialRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA0002
-  Title: Invalid settings file
-  Category: StyleCop.CSharp.SpecialRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1000
-  Title: Keywords should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1001
-  Title: Commas should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1002
-  Title: Semicolons should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1003
-  Title: Symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1004
-  Title: Documentation lines should begin with single space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1005
-  Title: Single line comments should begin with single space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1006
-  Title: Preprocessor keywords should not be preceded by space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1007
-  Title: Operator keyword should be followed by space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1008
-  Title: Opening parenthesis should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1009
-  Title: Closing parenthesis should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1010
-  Title: Opening square brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1011
-  Title: Closing square brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1012
-  Title: Opening braces should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1013
-  Title: Closing braces should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1014
-  Title: Opening generic brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1015
-  Title: Closing generic brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1016
-  Title: Opening attribute brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1017
-  Title: Closing attribute brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1018
-  Title: Nullable type symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1019
-  Title: Member access symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1020
-  Title: Increment decrement symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1021
-  Title: Negative signs should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1022
-  Title: Positive signs should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1023
-  Title: Dereference and access of symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1024
-  Title: Colons Should Be Spaced Correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1025
-  Title: Code should not contain multiple whitespace in a row
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1026
-  Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1027
-  Title: Use tabs correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1028
-  Title: Code should not contain trailing whitespace
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1100
-  Title: Do not prefix calls with base unless local implementation exists
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1101
-  Title: Prefix local calls with this
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1102
-  Title: Query clause should follow previous clause
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1103
-  Title: Query clauses should be on separate lines or all on one line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1104
-  Title: Query clause should begin on new line when previous clause spans multiple lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1105
-  Title: Query clauses spanning multiple lines should begin on own line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1106
-  Title: Code should not contain empty statements
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1107
-  Title: Code should not contain multiple statements on one line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1108
-  Title: Block statements should not contain embedded comments
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1109
-  Title: Block statements should not contain embedded regions
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1110
-  Title: Opening parenthesis or bracket should be on declaration line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1111
-  Title: Closing parenthesis should be on line of last parameter
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1112
-  Title: Closing parenthesis should be on line of opening parenthesis
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1113
-  Title: Comma should be on the same line as previous parameter
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1114
-  Title: Parameter list should follow declaration
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1115
-  Title: Parameter should follow comma
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1116
-  Title: Split parameters should start on line after declaration
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1117
-  Title: Parameters should be on same line or separate lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1118
-  Title: Parameter should not span multiple lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1119
-  Title: Statement should not use unnecessary parenthesis
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1119_p
-  Title: Statement should not use unnecessary parenthesis
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SA1120
-  Title: Comments should contain text
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1121
-  Title: Use built-in type alias
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1122
-  Title: Use string.Empty for empty strings
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1123
-  Title: Do not place regions within elements
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1124
-  Title: Do not use regions
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1125
-  Title: Use shorthand for nullable types
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1126
-  Title: Prefix calls correctly
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1127
-  Title: Generic type constraints should be on their own line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1128
-  Title: Put constructor initializers on their own line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1129
-  Title: Do not use default value type constructor
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1130
-  Title: Use lambda syntax
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1131
-  Title: Use readable conditions
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1132
-  Title: Do not combine fields
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1133
-  Title: Do not combine attributes
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1134
-  Title: Attributes should not share line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1135
-  Title: Using directives should be qualified
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1136
-  Title: Enum values should be on separate lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1137
-  Title: Elements should have the same indentation
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1139
-  Title: Use literal suffix notation instead of casting
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1141
-  Title: Use tuple syntax
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1142
-  Title: Refer to tuple fields by name
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1200
-  Title: Using directives should be placed correctly
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1201
-  Title: Elements should appear in the correct order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1202
-  Title: Elements should be ordered by access
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1203
-  Title: Constants should appear before fields
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1204
-  Title: Static elements should appear before instance elements
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1205
-  Title: Partial elements should declare access
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1206
-  Title: Declaration keywords should follow order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1207
-  Title: Protected should come before internal
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1208
-  Title: System using directives should be placed before other using directives
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1209
-  Title: Using alias directives should be placed after other using directives
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1210
-  Title: Using directives should be ordered alphabetically by namespace
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1211
-  Title: Using alias directives should be ordered alphabetically by alias name
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1212
-  Title: Property accessors should follow order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1213
-  Title: Event accessors should follow order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1214
-  Title: Readonly fields should appear before non-readonly fields
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1216
-  Title: Using static directives should be placed at the correct location
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1217
-  Title: Using static directives should be ordered alphabetically
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1300
-  Title: Element should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1301
-  Title: Element should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1302
-  Title: Interface names should begin with I
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1303
-  Title: Const field names should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1304
-  Title: Non-private readonly fields should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1305
-  Title: Field names should not use Hungarian notation
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1306
-  Title: Field names should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1307
-  Title: Accessible fields should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1308
-  Title: Variable names should not be prefixed
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1309
-  Title: Field names should not begin with underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - None
-  IsEverSuppressed: true
-- Id: SA1310
-  Title: Field names should not contain underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1311
-  Title: Static readonly fields should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1312
-  Title: Variable names should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1313
-  Title: Parameter names should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1314
-  Title: Type parameter names should begin with T
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1316
-  Title: Tuple element names should use correct casing
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1400
-  Title: Access modifier should be declared
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1401
-  Title: Fields should be private
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1402
-  Title: File may only contain a single type
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1403
-  Title: File may only contain a single namespace
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1404
-  Title: Code analysis suppression should have justification
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1405
-  Title: Debug.Assert should provide message text
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1406
-  Title: Debug.Fail should provide message text
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1407
-  Title: Arithmetic expressions should declare precedence
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1408
-  Title: Conditional expressions should declare precedence
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1409
-  Title: Remove unnecessary code
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1410
-  Title: Remove delegate parenthesis when possible
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1411
-  Title: Attribute constructor should not use unnecessary parenthesis
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1412
-  Title: Store files as UTF-8 with byte order mark
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1413
-  Title: Use trailing comma in multi-line initializers
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1414
-  Title: Tuple types in signatures should have element names
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1500
-  Title: Braces for multi-line statements should not share line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1501
-  Title: Statement should not be on a single line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1502
-  Title: Element should not be on a single line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1503
-  Title: Braces should not be omitted
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: true
-- Id: SA1504
-  Title: All accessors should be single-line or multi-line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1505
-  Title: Opening braces should not be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1506
-  Title: Element documentation headers should not be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1507
-  Title: Code should not contain multiple blank lines in a row
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1508
-  Title: Closing braces should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1509
-  Title: Opening braces should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1510
-  Title: Chained statement blocks should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1511
-  Title: While-do footer should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1512
-  Title: Single-line comments should not be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1513
-  Title: Closing brace should be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1514
-  Title: Element documentation header should be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1515
-  Title: Single-line comment should be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1516
-  Title: Elements should be separated by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1517
-  Title: Code should not contain blank lines at start of file
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1518
-  Title: Use line endings correctly at end of file
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1519
-  Title: Braces should not be omitted from multi-line child statement
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1520
-  Title: Use braces consistently
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1600
-  Title: Elements should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1601
-  Title: Partial elements should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1602
-  Title: Enumeration items should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1603
-  Title: Documentation should contain valid XML
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1604
-  Title: Element documentation should have summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1605
-  Title: Partial element documentation should have summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1606
-  Title: Element documentation should have summary text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1607
-  Title: Partial element documentation should have summary text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1608
-  Title: Element documentation should not have default summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1609
-  Title: Property documentation should have value
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1610
-  Title: Property documentation should have value text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1611
-  Title: Element parameters should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1612
-  Title: Element parameter documentation should match element parameters
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1613
-  Title: Element parameter documentation should declare parameter name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1614
-  Title: Element parameter documentation should have text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1615
-  Title: Element return value should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1616
-  Title: Element return value documentation should have text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1617
-  Title: Void return value should not be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1618
-  Title: Generic type parameters should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1619
-  Title: Generic type parameters should be documented partial class
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1620
-  Title: Generic type parameter documentation should match type parameters
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1621
-  Title: Generic type parameter documentation should declare parameter name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1622
-  Title: Generic type parameter documentation should have text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1623
-  Title: Property summary documentation should match accessors
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1624
-  Title: Property summary documentation should omit accessor with restricted access
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1625
-  Title: Element documentation should not be copied and pasted
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1626
-  Title: Single-line comments should not use documentation style slashes
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1627
-  Title: Documentation text should not be empty
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1628
-  Title: Documentation text should begin with a capital letter
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1629
-  Title: Documentation text should end with a period
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1630
-  Title: Documentation text should contain whitespace
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1631
-  Title: Documentation should meet character percentage
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1632
-  Title: Documentation text should meet minimum character length
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1633
-  Title: File should have header
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1634
-  Title: File header should show copyright
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1635
-  Title: File header should have copyright text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1636
-  Title: File header copyright text should match
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1637
-  Title: File header should contain file name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1638
-  Title: File header file name documentation should match file name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1639
-  Title: File header should have summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: SA1640
-  Title: File header should have valid company text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1641
-  Title: File header company name text should match
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1642
-  Title: Constructor summary documentation should begin with standard text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1643
-  Title: Destructor summary documentation should begin with standard text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1644
-  Title: Documentation headers should not contain blank lines
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1645
-  Title: Included documentation file does not exist
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1646
-  Title: Included documentation XPath does not exist
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1647
-  Title: Include node does not contain valid file and path
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1648
-  Title: inheritdoc should be used with inheriting class
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1649
-  Title: File name should match first type name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1650
-  Title: Element documentation should be spelled correctly
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1651
-  Title: Do not use placeholder elements
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SX1101
-  Title: Do not prefix local calls with 'this.'
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SX1309
-  Title: Field names should begin with underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SX1309S
-  Title: Static field names should begin with underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: VSTHRD001
-  Title: Avoid legacy thread switching APIs
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD002
-  Title: Avoid problematic synchronous waits
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD003
-  Title: Avoid awaiting foreign Tasks
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD004
-  Title: Await SwitchToMainThreadAsync
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD010
-  Title: Invoke single-threaded types on Main thread
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD011
-  Title: Use AsyncLazy<T>
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD012
-  Title: Provide JoinableTaskFactory where allowed
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD100
-  Title: Avoid async void methods
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD101
-  Title: Avoid unsupported async delegates
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD102
-  Title: Implement internal logic asynchronously
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD103
-  Title: Call async methods when in an async method
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD104
-  Title: Offer async methods
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD105
-  Title: Avoid method overloads that assume TaskScheduler.Current
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD106
-  Title: Use InvokeAsync to raise async events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD107
-  Title: Await Task within using expression
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD108
-  Title: Assert thread affinity unconditionally
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD109
-  Title: Switch instead of assert in async methods
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD110
-  Title: Observe result of async calls
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD111
-  Title: Use ConfigureAwait(bool)
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: VSTHRD112
-  Title: Implement System.IAsyncDisposable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD113
-  Title: Check for System.IAsyncDisposable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD114
-  Title: Avoid returning a null Task
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD200
-  Title: Use "Async" suffix for async methods
-  Category: Style
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: IDE0028
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
+- {Id: CA1000, Title: Do not declare static members on generic types, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1001, Title: Types that own disposable fields should be disposable, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1002, Title: Do not expose generic lists, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1003, Title: Use generic event handler instances, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1005, Title: Avoid excessive parameters on generic types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1008, Title: Enums should have zero value, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1010, Title: Generic interface should also be implemented, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1012, Title: Abstract types should not have public constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1014, Title: Mark assemblies with CLSCompliant, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1016, Title: Mark assemblies with assembly version, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1017, Title: Mark assemblies with ComVisible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1018, Title: Mark attributes with AttributeUsageAttribute, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1019, Title: Define accessors for attribute arguments, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1021, Title: Avoid out parameters, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1024, Title: Use properties where appropriate, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1027, Title: Mark enums with FlagsAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1028, Title: Enum Storage should be Int32, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1030, Title: Use events where appropriate, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1031, Title: Do not catch general exception types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1032, Title: Implement standard exception constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1033, Title: Interface methods should be callable by child types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1034, Title: Nested types should not be visible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1036, Title: Override methods on comparable types, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1040, Title: Avoid empty interfaces, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1041, Title: Provide ObsoleteAttribute message, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1043, Title: Use Integral Or String Argument For Indexers, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1044, Title: Properties should not be write only, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1045, Title: Do not pass types by reference, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1046, Title: Do not overload equality operator on reference types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1050, Title: Declare types in namespaces, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1051, Title: Do not declare visible instance fields, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1052, Title: Static holder types should be Static or NotInheritable, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1054, Title: URI-like parameters should not be strings, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1055, Title: URI-like return values should not be strings, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1056, Title: URI-like properties should not be strings, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1058, Title: Types should not extend certain base types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1060, Title: Move pinvokes to native methods class, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1061, Title: Do not hide base class methods, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1062, Title: Validate arguments of public methods, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1063, Title: Implement IDisposable Correctly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1064, Title: Exceptions should be public, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1065, Title: Do not raise exceptions in unexpected locations, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1066, Title: Implement IEquatable when overriding Object.Equals, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: CA1067, Title: Override Object.Equals(object) when implementing IEquatable<T>, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1068, Title: CancellationToken parameters must come last, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1069, Title: Enums values should not be duplicated, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1070, Title: Do not declare event fields as virtual, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1200, Title: Avoid using cref tags with a prefix, Category: Documentation, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1303, Title: Do not pass literals as localized parameters, Category: Globalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1304, Title: Specify CultureInfo, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1305, Title: Specify IFormatProvider, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1307, Title: Specify StringComparison for clarity, Category: Globalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1308, Title: Normalize strings to uppercase, Category: Globalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1309, Title: Use ordinal string comparison, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1310, Title: Specify StringComparison for correctness, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1311, Title: Specify a culture or use an invariant version, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1401, Title: P/Invokes should not be visible, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1416, Title: Validate platform compatibility, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1417, Title: Do not use 'OutAttribute' on string parameters for P/Invokes, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1418, Title: Use valid platform string, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1419, Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle', Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1420, Title: 'Property, type, or attribute requires runtime marshalling', Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1421, Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1422, Title: Validate platform compatibility, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1501, Title: Avoid excessive inheritance, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1502, Title: Avoid excessive complexity, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1505, Title: Avoid unmaintainable code, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1506, Title: Avoid excessive class coupling, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1507, Title: Use nameof to express symbol names, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1508, Title: Avoid dead conditional code, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1509, Title: Invalid entry in code metrics rule specification file, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1510, Title: Use ArgumentNullException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1511, Title: Use ArgumentException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1512, Title: Use ArgumentOutOfRangeException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1513, Title: Use ObjectDisposedException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1700, Title: Do not name enum values 'Reserved', Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1707, Title: Identifiers should not contain underscores, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1708, Title: Identifiers should differ by more than case, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1710, Title: Identifiers should have correct suffix, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1711, Title: Identifiers should not have incorrect suffix, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1712, Title: Do not prefix enum values with type name, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1713, Title: Events should not have 'Before' or 'After' prefix, Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1715, Title: Identifiers should have correct prefix, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1716, Title: Identifiers should not match keywords, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1720, Title: Identifier contains type name, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1721, Title: Property names should not match get methods, Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1724, Title: Type names should not match namespaces, Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1725, Title: Parameter names should match base declaration, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1727, Title: Use PascalCase for named placeholders, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1802, Title: Use literals where appropriate, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1805, Title: Do not initialize unnecessarily, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1806, Title: Do not ignore method results, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1810, Title: Initialize reference type static fields inline, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1812, Title: Avoid uninstantiated internal classes, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1813, Title: Avoid unsealed attributes, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1814, Title: Prefer jagged arrays over multidimensional, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1815, Title: Override equals and operator equals on value types, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1816, Title: Dispose methods should call SuppressFinalize, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1819, Title: Properties should not return arrays, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1820, Title: Test for empty strings using string length, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1821, Title: Remove empty Finalizers, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1822, Title: Mark members as static, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1823, Title: Avoid unused private fields, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1824, Title: Mark assemblies with NeutralResourcesLanguageAttribute, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1825, Title: Avoid zero-length array allocations, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1826, Title: Do not use Enumerable methods on indexable collections, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1827, Title: Do not use Count() or LongCount() when Any() can be used, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1828, Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1829, Title: Use Length/Count property instead of Count() when available, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1830, Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1831, Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1832, Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1833, Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1834, Title: Consider using 'StringBuilder.Append(char)' when applicable, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1835, Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1836, Title: Prefer IsEmpty over Count, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1837, Title: Use 'Environment.ProcessId', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1838, Title: Avoid 'StringBuilder' parameters for P/Invokes, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1839, Title: Use 'Environment.ProcessPath', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1840, Title: Use 'Environment.CurrentManagedThreadId', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1841, Title: Prefer Dictionary.Contains methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1842, Title: Do not use 'WhenAll' with a single task, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1843, Title: Do not use 'WaitAll' with a single task, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1844, Title: Provide memory-based overrides of async methods when subclassing 'Stream', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1845, Title: Use span-based 'string.Concat', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1846, Title: Prefer 'AsSpan' over 'Substring', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1847, Title: Use char literal for a single character lookup, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1848, Title: Use the LoggerMessage delegates, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1849, Title: Call async methods when in an async method, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1850, Title: Prefer static 'HashData' method over 'ComputeHash', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1851, Title: Possible multiple enumerations of 'IEnumerable' collection, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1852, Title: Seal internal types, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1853, Title: Unnecessary call to 'Dictionary.ContainsKey(key)', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1854, Title: "Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method", Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1855, Title: Prefer 'Clear' over 'Fill', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1856, Title: Incorrect usage of ConstantExpected attribute, Category: Performance, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1857, Title: A constant is expected for the parameter, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1858, Title: Use 'StartsWith' instead of 'IndexOf', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1859, Title: Use concrete types when possible for improved performance, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1860, Title: Avoid using 'Enumerable.Any()' extension method, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1861, Title: Avoid constant arrays as arguments, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1862, Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1863, Title: Use 'CompositeFormat', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1864, Title: "Prefer the 'IDictionary.TryAdd(TKey, TValue)' method", Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1865, Title: Use char overload, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1866, Title: Use char overload, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1867, Title: Use char overload, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: CA1868, Title: Unnecessary call to 'Contains(item)', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1869, Title: Cache and reuse 'JsonSerializerOptions' instances, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1870, Title: Use a cached 'SearchValues' instance, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2000, Title: Dispose objects before losing scope, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2002, Title: Do not lock on objects with weak identity, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2007, Title: Consider calling ConfigureAwait on the awaited task, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2008, Title: Do not create tasks without passing a TaskScheduler, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2009, Title: Do not call ToImmutableCollection on an ImmutableCollection value, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2011, Title: Avoid infinite recursion, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2012, Title: Use ValueTasks correctly, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2013, Title: Do not use ReferenceEquals with value types, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2014, Title: Do not use stackalloc in loops, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2015, Title: Do not define finalizers for types derived from MemoryManager<T>, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2016, Title: Forward the 'CancellationToken' parameter to methods, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: CA2017, Title: Parameter count mismatch, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2018, Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument", Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2019, Title: Improper 'ThreadStatic' field initialization, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2020, Title: Prevent behavioral change, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2021, Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2100, Title: Review SQL queries for security vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2101, Title: Specify marshaling for P/Invoke string arguments, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2119, Title: Seal methods that satisfy private interfaces, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2153, Title: Do Not Catch Corrupted State Exceptions, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2200, Title: Rethrow to preserve stack details, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2201, Title: Do not raise reserved exception types, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2207, Title: Initialize value type static fields inline, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2208, Title: Instantiate argument exceptions correctly, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2211, Title: Non-constant fields should not be visible, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2213, Title: Disposable fields should be disposed, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2214, Title: Do not call overridable methods in constructors, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2215, Title: Dispose methods should call base class dispose, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2216, Title: Disposable types should declare finalizer, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2217, Title: Do not mark enums with FlagsAttribute, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2219, Title: Do not raise exceptions in finally clauses, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2225, Title: Operator overloads have named alternates, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2226, Title: Operators should have symmetrical overloads, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2227, Title: Collection properties should be read only, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2231, Title: Overload operator equals on overriding value type Equals, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2234, Title: Pass system uri objects instead of strings, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2235, Title: Mark all non-serializable fields, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2237, Title: Mark ISerializable types with serializable, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2241, Title: Provide correct arguments to formatting methods, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2242, Title: Test for NaN correctly, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2243, Title: Attribute string literals should parse correctly, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2244, Title: Do not duplicate indexed element initializations, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2245, Title: Do not assign a property to itself, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2246, Title: Assigning symbol and its member in the same statement, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2247, Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2248, Title: Provide correct 'enum' argument to 'Enum.HasFlag', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2249, Title: Consider using 'string.Contains' instead of 'string.IndexOf', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2250, Title: Use 'ThrowIfCancellationRequested', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2251, Title: Use 'string.Equals', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2252, Title: This API requires opting into preview features, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2253, Title: Named placeholders should not be numeric values, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2254, Title: Template should be a static expression, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2255, Title: The 'ModuleInitializer' attribute should not be used in libraries, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2256, Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2257, Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static', Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2258, Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2259, Title: "'ThreadStatic' only affects static fields", Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2260, Title: Use correct type parameter, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2261, Title: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2300, Title: Do not use insecure deserializer BinaryFormatter, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2301, Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2302, Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2305, Title: Do not use insecure deserializer LosFormatter, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2310, Title: Do not use insecure deserializer NetDataContractSerializer, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2311, Title: Do not deserialize without first setting NetDataContractSerializer.Binder, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2312, Title: Ensure NetDataContractSerializer.Binder is set before deserializing, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2315, Title: Do not use insecure deserializer ObjectStateFormatter, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2321, Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2322, Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2326, Title: Do not use TypeNameHandling values other than None, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2327, Title: Do not use insecure JsonSerializerSettings, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2328, Title: Ensure that JsonSerializerSettings are secure, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2329, Title: Do not deserialize with JsonSerializer using an insecure configuration, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2330, Title: Ensure that JsonSerializer has a secure configuration when deserializing, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2350, Title: Do not use DataTable.ReadXml() with untrusted data, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2351, Title: Do not use DataSet.ReadXml() with untrusted data, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2352, Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2353, Title: Unsafe DataSet or DataTable in serializable type, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2354, Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2355, Title: Unsafe DataSet or DataTable type found in deserializable object graph, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2356, Title: Unsafe DataSet or DataTable type in web deserializable object graph, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2361, Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2362, Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3001, Title: Review code for SQL injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3002, Title: Review code for XSS vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3003, Title: Review code for file path injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3004, Title: Review code for information disclosure vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3005, Title: Review code for LDAP injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3006, Title: Review code for process command injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3007, Title: Review code for open redirect vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3008, Title: Review code for XPath injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3009, Title: Review code for XML injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3010, Title: Review code for XAML injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3011, Title: Review code for DLL injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3012, Title: Review code for regex injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3061, Title: Do Not Add Schema By URL, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3075, Title: Insecure DTD processing in XML, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3076, Title: Insecure XSLT script processing, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3077, Title: 'Insecure Processing in API Design, XmlDocument and XmlTextReader', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3147, Title: Mark Verb Handlers With Validate Antiforgery Token, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5350, Title: Do Not Use Weak Cryptographic Algorithms, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5351, Title: Do Not Use Broken Cryptographic Algorithms, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5358, Title: Review cipher mode usage with cryptography experts, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5359, Title: Do Not Disable Certificate Validation, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5360, Title: Do Not Call Dangerous Methods In Deserialization, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5361, Title: Do Not Disable SChannel Use of Strong Crypto, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5362, Title: Potential reference cycle in deserialized object graph, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5363, Title: Do Not Disable Request Validation, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5364, Title: Do Not Use Deprecated Security Protocols, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5365, Title: Do Not Disable HTTP Header Checking, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5366, Title: Use XmlReader for 'DataSet.ReadXml()', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5367, Title: Do Not Serialize Types With Pointer Fields, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5368, Title: Set ViewStateUserKey For Classes Derived From Page, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5369, Title: Use XmlReader for 'XmlSerializer.Deserialize()', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5370, Title: Use XmlReader for XmlValidatingReader constructor, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5371, Title: Use XmlReader for 'XmlSchema.Read()', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5372, Title: Use XmlReader for XPathDocument constructor, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5373, Title: Do not use obsolete key derivation function, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5374, Title: Do Not Use XslTransform, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5375, Title: Do Not Use Account Shared Access Signature, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5376, Title: Use SharedAccessProtocol HttpsOnly, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5377, Title: Use Container Level Access Policy, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5378, Title: Do not disable ServicePointManagerSecurityProtocols, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5379, Title: Ensure Key Derivation Function algorithm is sufficiently strong, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5380, Title: Do Not Add Certificates To Root Store, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5381, Title: Ensure Certificates Are Not Added To Root Store, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5382, Title: Use Secure Cookies In ASP.NET Core, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5383, Title: Ensure Use Secure Cookies In ASP.NET Core, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5384, Title: Do Not Use Digital Signature Algorithm (DSA), Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5385, Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5386, Title: Avoid hardcoding SecurityProtocolType value, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5387, Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5388, Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5389, Title: Do Not Add Archive Item's Path To The Target File System Path, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5390, Title: Do not hard-code encryption key, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5391, Title: Use antiforgery tokens in ASP.NET Core MVC controllers, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5392, Title: Use DefaultDllImportSearchPaths attribute for P/Invokes, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5393, Title: Do not use unsafe DllImportSearchPath value, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5394, Title: Do not use insecure randomness, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5395, Title: Miss HttpVerb attribute for action methods, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5396, Title: Set HttpOnly to true for HttpCookie, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5397, Title: Do not use deprecated SslProtocols values, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5398, Title: Avoid hardcoded SslProtocols values, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5399, Title: HttpClients should enable certificate revocation list checks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5400, Title: Ensure HttpClient certificate revocation list check is not disabled, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5401, Title: Do not use CreateEncryptor with non-default IV, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5402, Title: 'Use CreateEncryptor with the default IV ', Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5403, Title: Do not hard-code certificate, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5404, Title: Do not disable token validation checks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5405, Title: Do not always skip token validation in delegates, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: EM0001, Title: Switch on Enum Not Exhaustive, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0002, Title: Switch on Nullable Enum Not Exhaustive, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0003, Title: Switch on Closed Type Not Exhaustive, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0011, Title: Concrete Subtype of a Closed Type Must Be a Case, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0012, Title: Closed Type Case Must Be a Direct Subtype, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0013, Title: Closed Type Case Must Be a Subtype, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0014, Title: Concrete Subtype of a Closed Type Must Be a Covered, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0015, Title: Open Interface Subtype of a Closed Type Must Be a Case, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0100, Title: When Guards Not Supported, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0101, Title: Case Pattern Not Supported, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0102, Title: Open Type Not Supported, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0103, Title: Match Must Be On Case Type, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0104, Title: Duplicate Closed Attribute, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0105, Title: Duplicate Case Type, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EnableGenerateDocumentationFile, Title: Set MSBuild property 'GenerateDocumentationFile' to 'true', Category: Style, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: IDE0004, Title: Remove Unnecessary Cast, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0005, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0005_gen, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0007, Title: Use implicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0008, Title: Use explicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0009, Title: Member access should be qualified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0010, Title: Add missing cases, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0011, Title: Add braces, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0016, Title: Use 'throw' expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0017, Title: Simplify object initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0018, Title: Inline variable declaration, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0019, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0020, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0021, Title: Use expression body for constructor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0022, Title: Use expression body for method, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0023, Title: Use expression body for conversion operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0024, Title: Use expression body for operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0025, Title: Use expression body for property, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0026, Title: Use expression body for indexer, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0027, Title: Use expression body for accessor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0028, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0028, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0029, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0030, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0031, Title: Use null propagation, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0032, Title: Use auto property, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0033, Title: Use explicitly provided tuple name, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0034, Title: Simplify 'default' expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0035, Title: Unreachable code detected, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0036, Title: Order modifiers, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0037, Title: Use inferred member name, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0039, Title: Use local function, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0040, Title: Add accessibility modifiers, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0041, Title: Use 'is null' check, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0042, Title: Deconstruct variable declaration, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0043, Title: Invalid format string, Category: Compiler, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0044, Title: Add readonly modifier, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0045, Title: Convert to conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0046, Title: Convert to conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0047, Title: Remove unnecessary parentheses, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0048, Title: Add parentheses for clarity, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0051, Title: Remove unused private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0052, Title: Remove unread private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0053, Title: Use expression body for lambda expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0054, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0055, Title: Fix formatting, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0056, Title: Use index operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0057, Title: Use range operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0058, Title: Expression value is never used, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0059, Title: Unnecessary assignment of a value, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0060, Title: Remove unused parameter, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0061, Title: Use expression body for local function, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0062, Title: Make local function 'static', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0063, Title: Use simple 'using' statement, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0064, Title: Make readonly fields writable, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0065, Title: Misplaced using directive, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0066, Title: Convert switch statement to expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0070, Title: Use 'System.HashCode', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0071, Title: Simplify interpolation, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0072, Title: Add missing cases, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0073, Title: The file header does not match the required text, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0074, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0075, Title: Simplify conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0076, Title: Invalid global 'SuppressMessageAttribute', Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0077, Title: Avoid legacy format target in 'SuppressMessageAttribute', Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0078, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0080, Title: Remove unnecessary suppression operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0082, Title: "'typeof' can be converted to 'nameof'", Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0083, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0090, Title: Use 'new(...)', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0100, Title: Remove redundant equality, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0110, Title: Remove unnecessary discard, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0120, Title: Simplify LINQ expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0130, Title: Namespace does not match folder structure, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0150, Title: Prefer 'null' check over type check, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0160, Title: Convert to block scoped namespace, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0161, Title: Convert to file-scoped namespace, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0170, Title: Property pattern can be simplified, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0180, Title: Use tuple to swap values, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0200, Title: Remove unnecessary lambda expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0210, Title: Convert to top-level statements, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0211, Title: Convert to 'Program.Main' style program, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0220, Title: Add explicit cast, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0230, Title: Use UTF-8 string literal, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0240, Title: Remove redundant nullable directive, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0241, Title: Remove unnecessary nullable directive, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0250, Title: Make struct 'readonly', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0251, Title: Make member 'readonly', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0260, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0270, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0280, Title: Use 'nameof', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0290, Title: Use primary constructor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0300, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0301, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0302, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0303, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0304, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0305, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0320, Title: Make anonymous function static, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE1005, Title: Delegate invocation can be simplified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE1006, Title: Naming Styles, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE2000, Title: Avoid multiple blank lines, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2001, Title: Embedded statements must be on their own line, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2002, Title: Consecutive braces must not have blank line between them, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2003, Title: Blank line required between block and subsequent statement, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2004, Title: Blank line not allowed after constructor initializer colon, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2005, Title: Blank line not allowed after conditional expression token, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2006, Title: Blank line not allowed after arrow expression clause token, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0001, Title: StringComparison is missing, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0002, Title: IEqualityComparer<string> or IComparer<string> is missing, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0003, Title: Add parameter name to improve readability, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0004, Title: Use Task.ConfigureAwait, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0005, Title: Use Array.Empty<T>(), Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0006, Title: Use String.Equals instead of equality operator, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0007, Title: Add a comma after the last value, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0008, Title: Add StructLayoutAttribute, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0009, Title: Add regex evaluation timeout, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0010, Title: Mark attributes with AttributeUsageAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0011, Title: IFormatProvider is missing, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0012, Title: Do not raise reserved exception type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0013, Title: Types should not extend System.ApplicationException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0014, Title: Do not raise System.ApplicationException type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0015, Title: Specify the parameter name in ArgumentException, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0016, Title: Prefer using collection abstraction instead of implementation, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0017, Title: Abstract types should not have public or internal constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0018, Title: Do not declare static members on generic types (deprecated; use CA1000 instead), Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0019, Title: Use EventArgs.Empty, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0020, Title: Use direct methods instead of LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0021, Title: Use StringComparer.GetHashCode instead of string.GetHashCode, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0022, Title: Return Task.FromResult instead of returning null, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0023, Title: Add RegexOptions.ExplicitCapture, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0024, Title: Use an explicit StringComparer when possible, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0025, Title: Implement the functionality instead of throwing NotImplementedException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0026, Title: Fix TODO comment, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
+- {Id: MA0027, Title: Prefer rethrowing an exception implicitly, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0028, Title: Optimize StringBuilder usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0029, Title: Combine LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0030, Title: Remove useless OrderBy call, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0031, Title: Optimize Enumerable.Count() usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0032, Title: Use an overload with a CancellationToken argument, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0033, Title: Do not tag instance fields with ThreadStaticAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0035, Title: Do not use dangerous threading methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0036, Title: Make class static, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0037, Title: Remove empty statement, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0038, Title: 'Make method static (deprecated, use CA1822 instead)', Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0039, Title: Do not write your own certificate validation method, Category: Security, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0040, Title: Forward the CancellationToken parameter to methods that take one, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: MA0041, Title: 'Make property static (deprecated, use CA1822 instead)', Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0042, Title: Do not use blocking calls in an async method, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0043, Title: Use nameof operator in ArgumentException, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0044, Title: Remove useless ToString call, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0045, Title: Do not use blocking calls in a sync method (need to make calling method async), Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0046, Title: Use EventHandler<T> to declare events, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0047, Title: Declare types in namespaces, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0048, Title: File name must match type name, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0049, Title: Type name should not match containing namespace, Category: Design, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0050, Title: Validate arguments correctly in iterator methods, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0051, Title: Method is too long, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: MA0052, Title: Replace constant Enum.ToString with nameof, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0053, Title: Make class sealed, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0054, Title: Embed the caught exception as innerException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0055, Title: Do not use finalizer, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0056, Title: Do not call overridable members in constructor, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0057, Title: Class name should end with 'Attribute', Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0058, Title: Class name should end with 'Exception', Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0059, Title: Class name should end with 'EventArgs', Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0060, Title: The value returned by Stream.Read/Stream.ReadAsync is not used, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0061, Title: Method overrides should not change default values, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0062, Title: Non-flags enums should not be marked with "FlagsAttribute", Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0063, Title: Use Where before OrderBy, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0064, Title: Avoid locking on publicly accessible instance, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0065, Title: Default ValueType.Equals or HashCode is used for struct equality, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0066, Title: Hash table unfriendly type is used in a hash table, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0067, Title: Use Guid.Empty, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0068, Title: Invalid parameter name for nullable attribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0069, Title: Non-constant static fields should not be visible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0070, Title: Obsolete attributes should include explanations, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0071, Title: Avoid using redundant else, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0072, Title: Do not throw from a finally block, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0073, Title: Avoid comparison with bool constant, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0074, Title: Avoid implicit culture-sensitive methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0075, Title: Do not use implicit culture-sensitive ToString, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0076, Title: Do not use implicit culture-sensitive ToString in interpolated strings, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0077, Title: A class that provides Equals(T) should implement IEquatable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0078, Title: Use 'Cast' instead of 'Select' to cast, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0079, Title: Forward the CancellationToken using .WithCancellation(), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0080, Title: Use a cancellation token using .WithCancellation(), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0081, Title: Method overrides should not omit params keyword, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0082, Title: NaN should not be used in comparisons, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0083, Title: ConstructorArgument parameters should exist in constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0084, Title: Local variables should not hide other symbols, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0085, Title: Anonymous delegates should not be used to unsubscribe from Events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0086, Title: Do not throw from a finalizer, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0087, Title: 'Parameters with [DefaultParameterValue] attributes should also be marked [Optional]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0088, Title: 'Use [DefaultParameterValue] instead of [DefaultValue]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0089, Title: Optimize string method usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0090, Title: Remove empty else/finally block, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0091, Title: Sender should be 'this' for instance events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0092, Title: Sender should be 'null' for static events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0093, Title: EventArgs should not be null, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0094, Title: A class that provides CompareTo(T) should implement IComparable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0095, Title: A class that implements IEquatable<T> should override Equals(object), Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0096, Title: A class that implements IComparable<T> should also implement IEquatable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0097, Title: A class that implements IComparable<T> or IComparable should override comparison operators, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0098, Title: Use indexer instead of LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0099, Title: Use Explicit enum value instead of 0, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0100, Title: Await task before disposing of resources, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0101, Title: String contains an implicit end of line character, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: MA0102, Title: Make member readonly, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0103, Title: Use SequenceEqual instead of equality operator, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0104, Title: Do not create a type with a name from the BCL, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0105, Title: Use the lambda parameters instead of using a closure, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0106, Title: Avoid closure by using an overload with the 'factoryArgument' parameter, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0107, Title: Do not use culture-sensitive object.ToString, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0108, Title: Remove redundant argument value, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0109, Title: Consider adding an overload with a Span<T> or Memory<T>, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0110, Title: Use the Regex source generator, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0111, Title: Use string.Create instead of FormattableString, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0112, Title: Use 'Count > 0' instead of 'Any()', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0113, Title: Use DateTime.UnixEpoch, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0114, Title: Use DateTimeOffset.UnixEpoch, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0115, Title: Unknown component parameter, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0116, Title: 'Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0117, Title: 'Parameters with [EditorRequired] attributes should also be marked as [Parameter]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0118, Title: '[JSInvokable] methods must be public', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0119, Title: JSRuntime must not be used in OnInitialized or OnInitializedAsync, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0120, Title: Use InvokeVoidAsync when the returned value is not used, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0121, Title: Do not overwrite parameter value, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0122, Title: 'Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)', Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0123, Title: Sequence number must be a constant, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0124, Title: Log parameter type is not valid, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0125, Title: The list of log parameter types contains an invalid type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0126, Title: The list of log parameter types contains a duplicate, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0127, Title: Use String.Equals instead of is pattern, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0128, Title: Use 'is' operator instead of SequenceEqual, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0129, Title: Await task in using statement, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0130, Title: GetType() should not be used on System.Type instances, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0131, Title: ArgumentNullException.ThrowIfNull should not be used with non-nullable types, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0132, Title: Do not convert implicitly to DateTimeOffset, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0133, Title: Use DateTimeOffset instead of relying on the implicit conversion, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0134, Title: Observe result of async calls, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0135, Title: The log parameter has no configured type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0136, Title: Raw String contains an implicit end of line character, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: MA0137, Title: Use 'Async' suffix when a method returns an awaitable type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0138, Title: Do not use 'Async' suffix when a method does not return an awaitable type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0139, Title: Log parameter type is not valid, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0140, Title: Both if and else branch have identical code, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0141, Title: Use pattern matching instead of inequality operators for null check, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0142, Title: Use pattern matching instead of equality operators for null check, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0143, Title: Primary constructor parameters should be readonly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0144, Title: Use System.OperatingSystem to check the current OS, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0145, Title: 'Signature for [UnsafeAccessorAttribute] method is not valid', Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0146, Title: Name must be set explicitly on local functions, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0147, Title: Avoid async void method for delegate, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0148, Title: Use pattern matching instead of equality operators for discrete value, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0149, Title: Use pattern matching instead of inequality operators for discrete value, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0150, Title: Do not call the default object.ToString explicitly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0151, Title: DebuggerDisplay must contain valid members, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0152, Title: Use Unwrap instead of using await twice, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0153, Title: Do not log symbols decorated with DataClassificationAttribute directly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0154, Title: Use langword in XML comment, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0155, Title: Do not use async void methods, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0156, Title: Use 'Async' suffix when a method returns IAsyncEnumerable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0157, Title: Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0158, Title: Use System.Threading.Lock, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0159, Title: Use 'Order' instead of 'OrderBy', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0160, Title: Use ContainsKey instead of TryGetValue, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: POLYSP0003, Title: Unsupported C# language version, Category: Microsoft.CodeAnalysis.CSharp.CSharpParseOptions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1001, Title: Add braces (when expression spans over multiple lines), Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1002, Title: Remove braces, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1002FadeOut, Title: Remove braces, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1003, Title: Add braces to if-else (when expression spans over multiple lines), Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1004, Title: Remove braces from if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1004FadeOut, Title: Remove braces from if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1005, Title: Simplify nested using statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1005FadeOut, Title: Simplify nested using statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1006, Title: Merge 'else' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1006FadeOut, Title: Merge 'else' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1007, Title: Add braces, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1008, Title: "[deprecated] Use explicit type instead of 'var' (when the type is not obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1009, Title: "[deprecated] Use explicit type instead of 'var' (foreach variable)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1010, Title: "[deprecated] Use 'var' instead of explicit type (when the type is obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1012, Title: "[deprecated] Use explicit type instead of 'var' (when the type is obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1013, Title: Use predefined type, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1014, Title: Use explicitly/implicitly typed array, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1015, Title: Use nameof operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1015FadeOut, Title: Use nameof operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1016, Title: Use block body or expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1018, Title: Add/remove accessibility modifiers, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1019, Title: Order modifiers, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1020, Title: 'Simplify Nullable<T> to T?', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1021, Title: Convert lambda expression body to expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1021FadeOut, Title: Convert lambda expression body to expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1031, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1031FadeOut, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1032, Title: Remove redundant parentheses, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1032FadeOut, Title: Remove redundant parentheses, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1033, Title: Remove redundant boolean literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1034, Title: Remove redundant 'sealed' modifier, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1035, Title: '[deprecated] Remove redundant comma in initializer', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1036, Title: Remove unnecessary blank line, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1037, Title: Remove trailing white-space, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1038, Title: '[deprecated] Remove empty statement', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1039, Title: Remove argument list from attribute, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1040, Title: "[deprecated] Remove empty 'else' clause", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1041, Title: '[deprecated] Remove empty initializer', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1042, Title: Remove enum default underlying type, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1043, Title: Remove 'partial' modifier from type with a single part, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1044, Title: Remove original exception from throw statement, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1046, Title: Asynchronous method name should end with 'Async', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1047, Title: Non-asynchronous method name should not end with 'Async', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1047FadeOut, Title: Non-asynchronous method name should not end with 'Async', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1048, Title: Use lambda expression instead of anonymous method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1048FadeOut, Title: Use lambda expression instead of anonymous method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1049, Title: Simplify boolean comparison, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1049FadeOut, Title: Simplify boolean comparison, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1050, Title: Include/omit parentheses when creating new object, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1051, Title: Add/remove parentheses from condition in conditional operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1052, Title: Declare each attribute separately, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1055, Title: Unnecessary semicolon at the end of declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1056, Title: Avoid usage of using alias directive, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1058, Title: Use compound assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1058FadeOut, Title: Use compound assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1059, Title: Avoid locking on publicly accessible instance, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1060, Title: Declare each type in separate file, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1061, Title: Merge 'if' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1061FadeOut, Title: Merge 'if' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1063, Title: '[deprecated] Avoid usage of do statement to create an infinite loop', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1064, Title: '[deprecated] Avoid usage of for statement to create an infinite loop', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1065, Title: '[deprecated] Avoid usage of while statement to create an infinite loop', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1066, Title: "[deprecated] Remove empty 'finally' clause", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1066FadeOut, Title: "[deprecated] Remove empty 'finally' clause", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1068, Title: Simplify logical negation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1069, Title: Remove unnecessary case label, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1070, Title: Remove redundant default switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1071, Title: Remove redundant base constructor call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1072, Title: '[deprecated] Remove empty namespace declaration', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1073, Title: Convert 'if' to 'return' statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1073FadeOut, Title: Convert 'if' to 'return' statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1074, Title: Remove redundant constructor, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1075, Title: Avoid empty catch clause that catches System.Exception, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1077, Title: Optimize LINQ method call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1078, Title: Use "" or 'string.Empty', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1079, Title: Throwing of new NotImplementedException, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1080, Title: Use 'Count/Length' property instead of 'Any' method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1081, Title: Split variable declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1084, Title: Use coalesce expression instead of conditional expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1085, Title: Use auto-implemented property, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1085FadeOut, Title: Use auto-implemented property, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1089, Title: Use --/++ operator instead of assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1089FadeOut, Title: Use --/++ operator instead of assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1090, Title: Add/remove 'ConfigureAwait(false)' call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1091, Title: '[deprecated] Remove empty region', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1091FadeOut, Title: '[deprecated] Remove empty region', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1093, Title: File contains no code, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1094, Title: Declare using directive on top level, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1096, Title: Use 'HasFlag' method or bitwise operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1097, Title: Remove redundant 'ToString' call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1098, Title: Constant values should be placed on right side of comparisons, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1099, Title: Default label should be the last label in a switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1100, Title: '[deprecated] Format documentation summary on a single line', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1101, Title: '[deprecated] Format documentation summary on multiple lines', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1102, Title: Make class static, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1103, Title: Convert 'if' to assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1104, Title: Simplify conditional expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1105, Title: Unnecessary interpolation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1106, Title: '[deprecated] Remove empty destructor', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1107, Title: Remove redundant 'ToCharArray' call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1108, Title: Add 'static' modifier to all partial class declarations, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1110, Title: Declare type inside namespace, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1111, Title: Add braces to switch section with multiple statements, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1112, Title: Combine 'Enumerable.Where' method chain, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1112FadeOut, Title: Combine 'Enumerable.Where' method chain, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1113, Title: Use 'string.IsNullOrEmpty' method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1114, Title: Remove redundant delegate creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1114FadeOut, Title: Remove redundant delegate creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1118, Title: Mark local variable as const, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1123, Title: Add parentheses when necessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1124, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1124FadeOut, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1126, Title: Add braces to if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1128, Title: Use coalesce expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1129, Title: Remove redundant field initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1130, Title: Bitwise operation on enum without Flags attribute, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1132, Title: Remove redundant overriding member, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1133, Title: Remove redundant Dispose/Close call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1134, Title: Remove redundant statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1135, Title: Declare enum member with zero value (when enum has FlagsAttribute), Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1136, Title: Merge switch sections with equivalent content, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1138, Title: Add summary to documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1139, Title: Add summary element to documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1140, Title: Add exception to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1141, Title: Add 'param' element to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1142, Title: Add 'typeparam' element to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1143, Title: Simplify coalesce expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1145, Title: Remove redundant 'as' operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1146, Title: Use conditional access, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1151, Title: Remove redundant cast, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1154, Title: Sort enum members, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1155, Title: Use StringComparison when comparing strings, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1156, Title: Use string.Length instead of comparison with empty string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1157, Title: Composite enum value contains undefined flag, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1158, Title: Static member in generic type should use a type parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1159, Title: Use EventHandler<T>, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1160, Title: Abstract type should not have public constructors, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1161, Title: Enum should declare explicit values, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1162, Title: Avoid chain of assignments, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1163, Title: Unused parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1164, Title: Unused type parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1165, Title: Unconstrained type parameter checked for null, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1166, Title: Value type object is never equal to null, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1168, Title: Parameter name differs from base name, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1169, Title: Make field read-only, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1170, Title: Use read-only auto-implemented property, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1171, Title: Simplify lazy initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1172, Title: Use 'is' operator instead of 'as' operator, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1173, Title: Use coalesce expression instead of 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1174, Title: Remove redundant async/await, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1174FadeOut, Title: Remove redundant async/await, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1175, Title: Unused 'this' parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1176, Title: "[deprecated] Use 'var' instead of explicit type (when the type is not obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1177, Title: "[deprecated] Use 'var' instead of explicit type (in foreach)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1179, Title: Unnecessary assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1180, Title: Inline lazy initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1181, Title: Convert comment to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1182, Title: Remove redundant base interface, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1186, Title: Use Regex instance instead of static method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1187, Title: Use constant instead of field, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1188, Title: Remove redundant auto-property initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1189, Title: Add or remove region name, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1190, Title: Join string expressions, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1191, Title: Declare enum value as combination of names, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1192, Title: Unnecessary usage of verbatim string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1193, Title: Overriding member should not change 'params' modifier, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1194, Title: Implement exception constructors, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1195, Title: Use ^ operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1196, Title: Call extension method as instance method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1197, Title: Optimize StringBuilder.Append/AppendLine call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1198, Title: Avoid unnecessary boxing of value type, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1199, Title: Unnecessary null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1200, Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1201, Title: Use method chaining, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1202, Title: Avoid NullReferenceException, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1203, Title: Use AttributeUsageAttribute, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1204, Title: Use EventArgs.Empty, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1205, Title: Order named arguments according to the order of parameters, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1206, Title: Use conditional access instead of conditional expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1207, Title: Use anonymous function or method group, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1208, Title: Reduce 'if' nesting, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1209, Title: Order type parameter constraints, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1210, Title: Return completed task instead of returning null, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1211, Title: Remove unnecessary 'else', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1212, Title: Remove redundant assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1212FadeOut, Title: Remove redundant assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1213, Title: Remove unused member declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1214, Title: Unnecessary interpolated string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1214FadeOut, Title: Unnecessary interpolated string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1215, Title: Expression is always equal to true/false, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1216, Title: Unnecessary unsafe context, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1217, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1217FadeOut, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1218, Title: Simplify code branching, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1220, Title: Use pattern matching instead of combination of 'is' operator and cast operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1221, Title: Use pattern matching instead of combination of 'as' operator and null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1222, Title: Merge preprocessor directives, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1223, Title: Mark publicly visible type with DebuggerDisplay attribute, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1224, Title: Make method an extension method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1225, Title: Make class sealed, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1226, Title: Add paragraph to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1227, Title: Validate arguments correctly, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1228, Title: Unused element in a documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1229, Title: Use async/await when necessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1230, Title: Unnecessary explicit use of enumerator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1231, Title: Make parameter ref read-only, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1232, Title: Order elements in documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1233, Title: Use short-circuiting operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1234, Title: Duplicate enum value, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1235, Title: Optimize method call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1236, Title: Use exception filter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1237, Title: '[deprecated] Use bit shift operator', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1238, Title: 'Avoid nested ?: operators', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1239, Title: Use 'for' statement instead of 'while' statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1240, Title: Operator is unnecessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1241, Title: Implement non-generic counterpart, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1242, Title: Do not pass non-read-only struct by read-only reference, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1243, Title: Duplicate word in a comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1244, Title: Simplify 'default' expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1246, Title: Use element access, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1247, Title: Fix documentation comment tag, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1248, Title: Normalize null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1249, Title: Unnecessary null-forgiving operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1250, Title: Use implicit/explicit object creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1251, Title: Remove unnecessary braces from record declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1252, Title: Normalize usage of infinite loop, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1253, Title: Format documentation comment summary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1254, Title: Normalize format of enum flag value, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1255, Title: Simplify argument null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1256, Title: Invalid argument null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1257, Title: Use enum field explicitly, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1258, Title: Unnecessary enum flag, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1259, Title: Remove empty syntax, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1260, Title: Add/remove trailing comma, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1261, Title: Resource can be disposed asynchronously, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1262, Title: Unnecessary raw string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1263, Title: Invalid reference in a documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1264, Title: Use 'var' or explicit type, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1265, Title: Remove redundant catch block, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1266, Title: Use raw string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1267, Title: Use string interpolation instead of 'string.Concat', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1268, Title: Simplify numeric comparison, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RemoveUnnecessaryImportsFixable, Title: '', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: ROS0002, Title: Analyzer option is obsolete, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: ROS0003, Title: Analyzer requires config option to be specified, Category: '', DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RS1001, Title: Missing diagnostic analyzer attribute, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1002, Title: Missing kind argument when registering an analyzer action, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1003, Title: Unsupported SymbolKind argument when registering a symbol analyzer action, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1004, Title: Recommend adding language support to diagnostic analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1005, Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1006, Title: Invalid type argument for DiagnosticAnalyzer's Register method, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1007, Title: Provide localizable arguments to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisLocalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RS1008, Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1009, Title: Only internal implementations of this interface are allowed, Category: MicrosoftCodeAnalysisCompatibility, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1010, Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1011, Title: Use code actions that have a unique EquivalenceKey for FixAll occurrences support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1012, Title: Start action has no registered actions, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1013, Title: Start action has no registered non-end actions, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1014, Title: Do not ignore values returned by methods on immutable objects, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1015, Title: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisDocumentation, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1016, Title: Code fix providers should provide FixAll support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1017, Title: DiagnosticId for analyzers must be a non-null constant, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1018, Title: DiagnosticId for analyzers must be in specified format, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1019, Title: DiagnosticId must be unique across analyzers, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1020, Title: Category for analyzers must be from the specified values, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1021, Title: Invalid entry in analyzer category and diagnostic ID range specification file, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1022, Title: Do not use types from Workspaces assembly in an analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1023, Title: Upgrade MSBuildWorkspace, Category: Library, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1024, Title: Symbols should be compared for equality, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1025, Title: Configure generated code analysis, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1026, Title: Enable concurrent execution, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1027, Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1028, Title: Provide non-null 'customTags' value to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisDocumentation, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RS1029, Title: Do not use reserved diagnostic IDs, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1030, Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1031, Title: Define diagnostic title correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1032, Title: Define diagnostic message correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1033, Title: Define diagnostic description correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1034, Title: Prefer 'IsKind' for checking syntax kinds, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1035, Title: Do not use APIs banned for analyzers, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1036, Title: Specify analyzer banned API enforcement setting, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1037, Title: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2000, Title: Add analyzer diagnostic IDs to analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2001, Title: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2002, Title: Do not add removed analyzer diagnostic IDs to unshipped analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2003, Title: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2004, Title: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2005, Title: Remove duplicate entries for diagnostic ID in the same analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2006, Title: Remove duplicate entries for diagnostic ID between analyzer releases, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2007, Title: Invalid entry in analyzer release file, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2008, Title: Enable analyzer release tracking, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S100, Title: Methods and properties should be named in PascalCase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S1006, Title: Method overrides should not change parameter defaults, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S101, Title: Types should be named in PascalCase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S103, Title: Lines should not be too long, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S104, Title: Files should not have too many lines of code, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1048, Title: Finalizers should not throw exceptions, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S105, Title: Tabulation characters should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S106, Title: Standard outputs should not be used directly to log anything, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1066, Title: Mergeable "if" statements should be combined, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1067, Title: Expressions should not be too complex, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S107, Title: Methods should not have too many parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1075, Title: URIs should not be hardcoded, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S108, Title: Nested blocks of code should not be left empty, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S109, Title: Magic numbers should not be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S110, Title: Inheritance tree of classes should not be too deep, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1104, Title: Fields should not have public accessibility, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1109, Title: A close curly brace should be located at the beginning of a line, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1110, Title: Redundant pairs of parentheses should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1116, Title: Empty statements should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1117, Title: Local variables should not shadow class fields or properties, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1118, Title: Utility classes should not have public constructors, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S112, Title: General or reserved exceptions should never be thrown, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1121, Title: Assignments should not be made from within sub-expressions, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1123, Title: '"Obsolete" attributes should include explanations', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1125, Title: Boolean literals should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1128, Title: Unnecessary "using" should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S113, Title: Files should end with a newline, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1133, Title: Deprecated code should be removed, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1134, Title: Track uses of "FIXME" tags, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1135, Title: Track uses of "TODO" tags, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: S1144, Title: Unused private types or members should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1147, Title: Exit methods should not be called, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1151, Title: '"switch case" clauses should not have too many lines of code', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1155, Title: '"Any()" should be used to test for emptiness', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1163, Title: Exceptions should not be thrown in finally blocks, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1168, Title: Empty arrays and collections should be returned instead of null, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1172, Title: Unused method parameters should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1185, Title: Overriding members should do more than simply call the same member in the base class, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1186, Title: Methods should not be empty, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1192, Title: String literals should not be duplicated, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1199, Title: Nested code blocks should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1200, Title: Classes should not be coupled to too many other classes, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1206, Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S121, Title: Control structures should use curly braces, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1210, Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1215, Title: '"GC.Collect" should not be called', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S122, Title: Statements should be on separate lines, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1226, Title: "Method parameters, caught exceptions and foreach variables' initial values should not be ignored", Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1227, Title: break statements should not be used except for switch cases, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1244, Title: Floating point numbers should not be tested for equality, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S125, Title: Sections of code should not be commented out, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S126, Title: '"if ... else if" constructs should end with "else" clauses', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1264, Title: A "while" loop should be used instead of a "for" loop, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S127, Title: '"for" loop stop conditions should be invariant', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1301, Title: '"switch" statements should have at least 3 "case" clauses', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1309, Title: Track uses of in-source issue suppressions, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S131, Title: '"switch/Select" statements should contain a "default/Case Else" clauses', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1312, Title: Logger fields should be "private static readonly", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1313, Title: Using hardcoded IP addresses is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S134, Title: 'Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S138, Title: Functions should not have too many lines of code, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1449, Title: Culture should be specified for "string" operations, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1450, Title: Private fields only used as local variables in methods should become local variables, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1451, Title: Track lack of copyright and license headers, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1479, Title: '"switch" statements with many "case" clauses should have only one statement', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1481, Title: Unused local variables should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1541, Title: Methods and properties should not be too complex, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1607, Title: Tests should not be ignored, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1643, Title: Strings should not be concatenated using '+' in a loop, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1656, Title: Variables should not be self-assigned, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1659, Title: Multiple variables should not be declared on the same line, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1694, Title: An abstract class should have both abstract and concrete methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1696, Title: NullReferenceException should not be caught, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1698, Title: '"==" should not be used when "Equals" is overridden', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1699, Title: Constructors should only call non-overridable methods, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1751, Title: Loops with at most one iteration should be refactored, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1764, Title: Identical expressions should not be used on both sides of operators, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1821, Title: '"switch" statements should not be nested', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1848, Title: Objects should not be created to be dropped immediately without being used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1854, Title: Unused assignments should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1858, Title: '"ToString()" calls should not be redundant', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1862, Title: Related "if/else if" statements should not have the same condition, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1871, Title: Two branches in a conditional structure should not have exactly the same implementation, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1905, Title: Redundant casts should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1939, Title: Inheritance list should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1940, Title: Boolean checks should not be inverted, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1944, Title: Invalid casts should be avoided, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1994, Title: "\"for\" loop increment clauses should modify the loops' counters", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2053, Title: Password hashing functions should use an unpredictable salt, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2068, Title: Hard-coded credentials are security-sensitive, Category: Blocker Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2077, Title: Formatting SQL queries is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2092, Title: Creating cookies without the "secure" flag is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2094, Title: Classes should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2114, Title: Collections should not be passed as arguments to their own methods, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2115, Title: A secure password should be used when connecting to a database, Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2123, Title: Values should not be uselessly incremented, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2139, Title: Exceptions should be either logged or rethrown but not both, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2148, Title: Underscores should be used to make large numbers readable, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2156, Title: '"sealed" classes should not have "protected" members', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2166, Title: Classes named like "Exception" should extend "Exception" or a subclass, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2178, Title: Short-circuit logic should be used in boolean contexts, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2183, Title: Integral numbers should not be shifted by zero or more than their number of bits-1, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2184, Title: Results of integer division should not be assigned to floating point variables, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2187, Title: Test classes should contain at least one test case, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2190, Title: Loops and recursions should not be infinite, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2197, Title: Modulus results should not be checked for direct equality, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2198, Title: Unnecessary mathematical comparisons should not be made, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2201, Title: Methods without side effects should not have their return values ignored, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2219, Title: Runtime type checking should be simplified, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2221, Title: '"Exception" should not be caught', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2222, Title: Locks should be released on all paths, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2223, Title: Non-constant static fields should not be visible, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2225, Title: '"ToString()" method should not return null', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2234, Title: Arguments should be passed in the same order as the method parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2245, Title: Using pseudorandom number generators (PRNGs) is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2251, Title: A "for" loop update clause should move the counter in the right direction, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2252, Title: For-loop conditions should be true at least once, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2257, Title: Using non-standard cryptographic algorithms is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2259, Title: Null pointers should not be dereferenced, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2275, Title: Composite format strings should not lead to unexpected behavior at runtime, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2290, Title: Field-like events should not be virtual, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2291, Title: Overflow checking should not be disabled for "Enumerable.Sum", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2292, Title: Trivial properties should be auto-implemented, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2302, Title: '"nameof" should be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2306, Title: '"async" and "await" should not be used as identifiers', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2325, Title: Methods and properties that don't access instance data should be static, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2326, Title: Unused type parameters should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2327, Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2328, Title: '"GetHashCode" should not reference mutable fields', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2330, Title: Array covariance should not be used, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2333, Title: Redundant modifiers should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2339, Title: Public constant members should not be used, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2342, Title: Enumeration types should comply with a naming convention, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2344, Title: Enumeration type names should not have "Flags" or "Enum" suffixes, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2345, Title: Flags enumerations should explicitly initialize all their members, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2346, Title: Flags enumerations zero-value members should be named "None", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2357, Title: Fields should be private, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2360, Title: Optional parameters should not be used, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2365, Title: Properties should not make collection or array copies, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2368, Title: Public methods should not have multidimensional array parameters, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2372, Title: Exceptions should not be thrown from property getters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2376, Title: Write-only properties should not be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2386, Title: Mutable fields should not be "public static", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2387, Title: Child class fields should not shadow parent class fields, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2436, Title: Types and methods should not have too many generic parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2437, Title: Unnecessary bit operations should not be performed, Category: Blocker Code Smell, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: S2445, Title: Blocks should be synchronized on read-only fields, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2479, Title: Whitespace and control characters in string literals should be explicit, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2486, Title: Generic exceptions should not be ignored, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2551, Title: Shared resources should not be used for locking, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2583, Title: Conditionally executed code should be reachable, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2589, Title: Boolean expressions should not be gratuitous, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: S2612, Title: Setting loose file permissions is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2629, Title: Logging templates should be constant, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2674, Title: The length returned from a stream read should be checked, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2681, Title: Multiline blocks should be enclosed in curly braces, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2688, Title: '"NaN" should not be used in comparisons', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2692, Title: '"IndexOf" checks should not be for positive numbers', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2696, Title: Instance members should not write to "static" fields, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2699, Title: Tests should include assertions, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2701, Title: Literal boolean values should not be used in assertions, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2737, Title: '"catch" clauses should do more than rethrow', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2743, Title: Static fields should not be used in generic types, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2755, Title: XML parsers should not be vulnerable to XXE attacks, Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2757, Title: Non-existent operators like "=+" should not be used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2760, Title: Sequential tests should not check the same condition, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2761, Title: Doubled prefix operators "!!" and "~~" should not be used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2857, Title: SQL keywords should be delimited by whitespace, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2925, Title: '"Thread.Sleep" should not be used in tests', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2930, Title: '"IDisposables" should be disposed', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2931, Title: Classes with "IDisposable" members should implement "IDisposable", Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2933, Title: Fields that are only assigned in the constructor should be "readonly", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2934, Title: Property assignments should not be made for "readonly" fields not constrained to reference types, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2952, Title: Classes should "Dispose" of members from the classes' own "Dispose" methods, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2953, Title: Methods named "Dispose" should implement "IDisposable.Dispose", Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2955, Title: Generic parameters not constrained to reference types should not be compared to "null", Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2970, Title: Assertions should be complete, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2971, Title: LINQ expressions should be simplified, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2995, Title: '"Object.ReferenceEquals" should not be used for value types', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2996, Title: '"ThreadStatic" fields should not be initialized', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2997, Title: '"IDisposables" created in a "using" statement should not be returned', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3005, Title: '"ThreadStatic" should not be used on non-static fields', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3010, Title: Static fields should not be updated in constructors, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3011, Title: 'Reflection should not be used to increase accessibility of classes, methods, or fields', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3052, Title: Members should not be initialized to default values, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3059, Title: Types should not have members with visibility set higher than the type's visibility, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3060, Title: '"is" should not be used with "this"', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3063, Title: '"StringBuilder" data should be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3168, Title: '"async" methods should not return "void"', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3169, Title: Multiple "OrderBy" calls should not be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3172, Title: Delegates should not be subtracted, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3215, Title: '"interface" instances should not be cast to concrete types', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3216, Title: '"ConfigureAwait(false)" should be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3217, Title: '"Explicit" conversions of "foreach" loops should not be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3218, Title: Inner class members should not shadow outer class "static" or type members, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3220, Title: Method calls should not resolve ambiguously to overloads with "params", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3234, Title: '"GC.SuppressFinalize" should not be invoked for types without destructors', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3235, Title: Redundant parentheses should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3236, Title: Caller information arguments should not be provided explicitly, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3237, Title: '"value" contextual keyword should be used', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3240, Title: The simplest possible condition syntax should be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3241, Title: Methods should not return values that are never used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3242, Title: Method parameters should be declared with base types, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3244, Title: Anonymous delegates should not be used to unsubscribe from Events, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3246, Title: Generic type parameters should be co/contravariant when possible, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3247, Title: Duplicate casts should not be made, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3249, Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals", Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3251, Title: Implementations should be provided for "partial" methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3253, Title: Constructor and destructor declarations should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3254, Title: Default parameter values should not be passed as arguments, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3256, Title: '"string.IsNullOrEmpty" should be used', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3257, Title: Declarations and initializations should be as concise as possible, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3260, Title: Non-derived "private" classes and records should be "sealed", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3261, Title: Namespaces should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3262, Title: '"params" should be used on overrides', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3263, Title: 'Static fields should appear in the order they must be initialized ', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3264, Title: Events should be invoked, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3265, Title: Non-flags enums should not be used in bitwise operations, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3267, Title: Loops should be simplified with "LINQ" expressions, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3329, Title: Cipher Block Chaining IVs should be unpredictable, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3330, Title: Creating cookies without the "HttpOnly" flag is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3343, Title: Caller information parameters should come at the end of the parameter list, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3346, Title: Expressions used in "Debug.Assert" should not produce side effects, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3353, Title: Unchanged variables should be marked as "const", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3358, Title: Ternary operators should not be nested, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3363, Title: Date and time should not be used as a type for primary keys, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3366, Title: '"this" should not be exposed from constructors', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3376, Title: 'Attribute, EventArgs, and Exception type names should end with the type being extended', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3397, Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3398, Title: '"private" methods called only by inner classes should be moved to those classes', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3400, Title: Methods should not return constants, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3415, Title: Assertion arguments should be passed in the correct order, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3416, Title: Loggers should be named for their enclosing types, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3427, Title: Method overloads with default parameter values should not overlap, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3431, Title: '"[ExpectedException]" should not be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3433, Title: Test method signatures should be correct, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3440, Title: Variables should not be checked against the values they're about to be assigned, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3441, Title: Redundant property names should be omitted in anonymous classes, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3442, Title: '"abstract" classes should not have "public" constructors', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3443, Title: Type should not be examined on "System.Type" instances, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3444, Title: Interfaces should not simply inherit from base interfaces with colliding members, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3445, Title: Exceptions should not be explicitly rethrown, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3447, Title: '"[Optional]" should not be used on "ref" or "out" parameters', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3449, Title: Right operands of shift operators should be integers, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3450, Title: 'Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3451, Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3453, Title: Classes should not have only "private" constructors, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3456, Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3457, Title: Composite format strings should be used correctly, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3458, Title: Empty "case" clauses that fall through to the "default" should be omitted, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3459, Title: Unassigned members should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3464, Title: Type inheritance should not be recursive, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3466, Title: Optional parameters should be passed to "base" calls, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3532, Title: Empty "default" clauses should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3597, Title: '"ServiceContract" and "OperationContract" attributes should be used together', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3598, Title: One-way "OperationContract" methods should have "void" return type, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3600, Title: '"params" should not be introduced on overrides', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3603, Title: 'Methods with "Pure" attribute should return a value ', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3604, Title: Member initializer values should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3610, Title: Nullable type comparison should not be redundant, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3626, Title: Jump statements should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3655, Title: Empty nullable value should not be accessed, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3717, Title: Track use of "NotImplementedException", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3776, Title: Cognitive Complexity of methods should not be too high, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3869, Title: '"SafeHandle.DangerousGetHandle" should not be called', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3871, Title: Exception types should be "public", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3872, Title: Parameter names should not duplicate the names of their methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3874, Title: '"out" and "ref" parameters should not be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3875, Title: '"operator==" should not be overloaded on reference types', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3876, Title: Strings or integral types should be used for indexers, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3877, Title: Exceptions should not be thrown from unexpected methods, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3878, Title: Arrays should not be created for params parameters, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3880, Title: Finalizers should not be empty, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3881, Title: '"IDisposable" should be implemented correctly', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3884, Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used', Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3885, Title: '"Assembly.Load" should be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3887, Title: 'Mutable, non-private fields should not be "readonly"', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3889, Title: '"Thread.Resume" and "Thread.Suspend" should not be used', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3897, Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3898, Title: Value types should implement "IEquatable<T>", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3900, Title: Arguments of public methods should be validated against null, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S3902, Title: '"Assembly.GetExecutingAssembly" should not be called', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3903, Title: Types should be defined in named namespaces, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3904, Title: Assemblies should have version information, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3906, Title: Event Handlers should have the correct signature, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3908, Title: Generic event handlers should be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3909, Title: Collections should implement the generic interface, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3923, Title: All branches in a conditional structure should not have exactly the same implementation, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3925, Title: '"ISerializable" should be implemented correctly', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3926, Title: Deserialization methods should be provided for "OptionalField" members, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3927, Title: Serialization event handlers should be implemented correctly, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3928, Title: 'Parameter names used into ArgumentException constructors should match an existing one ', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3937, Title: Number patterns should be regular, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3949, Title: Calculations should not overflow, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3956, Title: '"Generic.List" instances should not be part of public APIs', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3962, Title: '"static readonly" constants should be "const" instead', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3963, Title: '"static" fields should be initialized inline', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3966, Title: Objects should not be disposed more than once, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3967, Title: Multidimensional arrays should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3971, Title: '"GC.SuppressFinalize" should not be called', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3972, Title: Conditionals should start on new lines, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3973, Title: A conditionally executed single line should be denoted by indentation, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3981, Title: Collection sizes and array length comparisons should make sense, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3984, Title: Exceptions should not be created without being thrown, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3990, Title: Assemblies should be marked as CLS compliant, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3992, Title: Assemblies should explicitly specify COM visibility, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3993, Title: Custom attributes should be marked with "System.AttributeUsageAttribute", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3994, Title: URI Parameters should not be strings, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3995, Title: URI return values should not be strings, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3996, Title: URI properties should not be strings, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3997, Title: String URI overloads should call "System.Uri" overloads, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3998, Title: Threads should not lock on objects with weak identity, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4000, Title: Pointers to unmanaged memory should not be visible, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4002, Title: Disposable types should declare finalizers, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4004, Title: Collection properties should be readonly, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4005, Title: '"System.Uri" arguments should be used instead of strings', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4015, Title: Inherited member visibility should not be decreased, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4016, Title: Enumeration members should not be named "Reserved", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4017, Title: Method signatures should not contain nested generic types, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4018, Title: All type parameters should be used in the parameter list to enable type inference, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4019, Title: Base class methods should not be hidden, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4022, Title: Enumerations should have "Int32" storage, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4023, Title: Interfaces should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4025, Title: Child class fields should not differ from parent class fields only by capitalization, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4026, Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4027, Title: Exceptions should provide standard constructors, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4035, Title: Classes implementing "IEquatable<T>" should be sealed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4036, Title: Searching OS commands in PATH is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4039, Title: Interface methods should be callable by derived types, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4040, Title: Strings should be normalized to uppercase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4041, Title: Type names should not match namespaces, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4047, Title: Generics should be used when appropriate, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4049, Title: Properties should be preferred, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4050, Title: Operators should be overloaded consistently, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4052, Title: Types should not extend outdated base types, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4055, Title: Literals should not be passed as localized parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4056, Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4057, Title: Locales should be set for data types, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4058, Title: Overloads with a "StringComparison" parameter should be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4059, Title: Property names should not match get methods, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4060, Title: Non-abstract attributes should be sealed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4061, Title: '"params" should be used instead of "varargs"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4069, Title: Operator overloads should have named alternatives, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4070, Title: Non-flags enums should not be marked with "FlagsAttribute", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4136, Title: Method overloads should be grouped together, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4143, Title: Collection elements should not be replaced unconditionally, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4144, Title: Methods should not have identical implementations, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4158, Title: Empty collections should not be accessed or iterated, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4159, Title: Classes should implement their "ExportAttribute" interfaces, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4200, Title: Native methods should be wrapped, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4201, Title: Null checks should not be combined with "is" operator checks, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4210, Title: Windows Forms entry points should be marked with STAThread, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4211, Title: Members should not have conflicting transparency annotations, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4212, Title: Serialization constructors should be secured, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4214, Title: '"P/Invoke" methods should not be visible', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4220, Title: Events should have proper arguments, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4225, Title: Extension methods should not extend "object", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4226, Title: Extensions should be in separate namespaces, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4260, Title: '"ConstructorArgument" parameters should exist in constructors', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4261, Title: Methods should be named according to their synchronicities, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4275, Title: Getters and setters should access the expected fields, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4277, Title: '"Shared" parts should not be created with "new"', Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4347, Title: Secure random number generators should not output predictable values, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4423, Title: Weak SSL/TLS protocols should not be used, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4426, Title: Cryptographic keys should be robust, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4428, Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4433, Title: LDAP connections should be authenticated, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4456, Title: Parameter validation in yielding methods should be wrapped, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4457, Title: Parameter validation in "async"/"await" methods should be wrapped, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4462, Title: Calls to "async" methods should not be blocking, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S4487, Title: Unread "private" fields should be removed, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4502, Title: Disabling CSRF protections is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4507, Title: Delivering code in production with debug features activated is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4524, Title: '"default" clauses should be first or last', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4545, Title: '"DebuggerDisplayAttribute" strings should reference existing members', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4581, Title: '"new Guid()" should not be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4583, Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke", Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4586, Title: Non-async "Task/Task<T>" methods should not return null, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4635, Title: Start index should be used instead of calling Substring, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4663, Title: Comments should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4790, Title: Using weak hashing algorithms is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4792, Title: Configuring loggers is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4830, Title: Server certificates should be verified during SSL/TLS connections, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5034, Title: '"ValueTask" should be consumed correctly', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5042, Title: Expanding archive files without controlling resource consumption is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5122, Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5332, Title: Using clear-text protocols is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5344, Title: Passwords should not be stored in plaintext or with a fast hashing algorithm, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5443, Title: Using publicly writable directories is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5445, Title: Insecure temporary file creation methods should not be used, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5542, Title: Encryption algorithms should be used with secure mode and padding scheme, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5547, Title: Cipher algorithms should be robust, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5659, Title: JWT should be signed and verified with strong cipher algorithms, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5693, Title: Allowing requests with excessive content length is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5753, Title: Disabling ASP.NET "Request Validation" feature is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5766, Title: Deserializing objects without performing data validation is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5773, Title: Types allowed to be deserialized should be restricted, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5856, Title: Regular expressions should be syntactically valid, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6354, Title: Use a testable date/time provider, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6377, Title: XML signatures should be validated securely, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6419, Title: Azure Functions should be stateless, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6420, Title: Client instances should not be recreated on each Azure Function invocation, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6421, Title: Azure Functions should use Structured Error Handling, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6422, Title: Calls to "async" methods should not be blocking in Azure Functions, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6423, Title: Azure Functions should log all failures, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6424, Title: Interfaces for durable entities should satisfy the restrictions, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6444, Title: Not specifying a timeout for regular expressions is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6507, Title: Blocks should not be synchronized on local variables, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S6513, Title: '"ExcludeFromCodeCoverage" attributes should include a justification', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6561, Title: Avoid using "DateTime.Now" for benchmarking or timing operations, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6562, Title: Always set the "DateTimeKind" when creating new "DateTime" instances, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6563, Title: Use UTC when recording DateTime instants, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6566, Title: Use "DateTimeOffset" instead of "DateTime", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6575, Title: Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6580, Title: Use a format provider when parsing date and time, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6585, Title: Don't hardcode the format when turning dates and times to strings, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6588, Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6602, Title: '"Find" method should be used instead of the "FirstOrDefault" extension', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6603, Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6605, Title: Collection-specific "Exists" method should be used instead of the "Any" extension, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6607, Title: The collection should be filtered before sorting by using "Where" before "OrderBy", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6608, Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6609, Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6610, Title: '"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6612, Title: The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6613, Title: '"First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6617, Title: '"Contains" should be used instead of "Any" for simple equality checks', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6618, Title: '"string.Create" should be used instead of "FormattableString"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6640, Title: Using unsafe code blocks is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6664, Title: The code block contains too many logging calls, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6667, Title: Logging in a catch clause should pass the caught exception as a parameter., Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6668, Title: Logging arguments should be passed to the correct parameter, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6669, Title: Logger field or property name should comply with a naming convention, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6670, Title: '"Trace.Write" and "Trace.WriteLine" should not be used', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6672, Title: Generic logger injection should match enclosing type, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6673, Title: Log message template placeholders should be in the right order, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6674, Title: Log message template should be syntactically correct, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6675, Title: '"Trace.WriteLineIf" should not be used with "TraceSwitch" levels', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6677, Title: Message template placeholders should be unique, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6678, Title: Use PascalCase for named placeholders, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6781, Title: JWT secret keys should not be disclosed, Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6797, Title: Blazor query parameter type should be supported, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6798, Title: '[JSInvokable] attribute should only be used on public methods', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6800, Title: Component parameter type should match the route parameter type constraint, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6802, Title: Using lambda expressions in loops should be avoided in Blazor markup section, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6803, Title: Parameters with SupplyParameterFromQuery attribute should be used only in routable components, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S6930, Title: Backslash should be avoided in route templates, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6931, Title: ASP.NET controller actions should not have a route template starting with "/", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6932, Title: Use model binding instead of reading raw request data, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6934, Title: A Route attribute should be added to the controller when a route template is specified at the action level, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6960, Title: Controllers should not have mixed responsibilities, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6961, Title: API Controllers should derive from ControllerBase instead of Controller, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6962, Title: You should pool HTTP connections with HttpClientFactory, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6964, Title: 'Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6965, Title: REST API actions should be annotated with an HTTP verb attribute, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6966, Title: Awaitable method should be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6967, Title: ModelState.IsValid should be called in controller actions, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6968, Title: Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S818, Title: Literal suffixes should be upper case, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S881, Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S907, Title: '"goto" statement should not be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S927, Title: Parameter names should match base declaration and other partial definitions, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S9999-cpd, Title: Copy-paste token calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-log, Title: Log generator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-metadata, Title: File metadata generator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-metrics, Title: Metrics calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-symbolRef, Title: Symbol reference calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-token-type, Title: Token type calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-warning, Title: Analysis Warning generator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: SA0001, Title: XML comment analysis disabled, Category: StyleCop.CSharp.SpecialRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA0002, Title: Invalid settings file, Category: StyleCop.CSharp.SpecialRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1000, Title: Keywords should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1001, Title: Commas should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1002, Title: Semicolons should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1003, Title: Symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1004, Title: Documentation lines should begin with single space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1005, Title: Single line comments should begin with single space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1006, Title: Preprocessor keywords should not be preceded by space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1007, Title: Operator keyword should be followed by space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1008, Title: Opening parenthesis should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1009, Title: Closing parenthesis should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1010, Title: Opening square brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1011, Title: Closing square brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1012, Title: Opening braces should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1013, Title: Closing braces should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1014, Title: Opening generic brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1015, Title: Closing generic brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1016, Title: Opening attribute brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1017, Title: Closing attribute brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1018, Title: Nullable type symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1019, Title: Member access symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1020, Title: Increment decrement symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1021, Title: Negative signs should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1022, Title: Positive signs should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1023, Title: Dereference and access of symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1024, Title: Colons Should Be Spaced Correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1025, Title: Code should not contain multiple whitespace in a row, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1026, Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1027, Title: Use tabs correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1028, Title: Code should not contain trailing whitespace, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1100, Title: Do not prefix calls with base unless local implementation exists, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1101, Title: Prefix local calls with this, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1102, Title: Query clause should follow previous clause, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1103, Title: Query clauses should be on separate lines or all on one line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1104, Title: Query clause should begin on new line when previous clause spans multiple lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1105, Title: Query clauses spanning multiple lines should begin on own line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1106, Title: Code should not contain empty statements, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1107, Title: Code should not contain multiple statements on one line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1108, Title: Block statements should not contain embedded comments, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1109, Title: Block statements should not contain embedded regions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1110, Title: Opening parenthesis or bracket should be on declaration line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1111, Title: Closing parenthesis should be on line of last parameter, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1112, Title: Closing parenthesis should be on line of opening parenthesis, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1113, Title: Comma should be on the same line as previous parameter, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1114, Title: Parameter list should follow declaration, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1115, Title: Parameter should follow comma, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1116, Title: Split parameters should start on line after declaration, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1117, Title: Parameters should be on same line or separate lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1118, Title: Parameter should not span multiple lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1119, Title: Statement should not use unnecessary parenthesis, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1119_p, Title: Statement should not use unnecessary parenthesis, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SA1120, Title: Comments should contain text, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1121, Title: Use built-in type alias, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1122, Title: Use string.Empty for empty strings, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1123, Title: Do not place regions within elements, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1124, Title: Do not use regions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1125, Title: Use shorthand for nullable types, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1126, Title: Prefix calls correctly, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1127, Title: Generic type constraints should be on their own line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1128, Title: Put constructor initializers on their own line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1129, Title: Do not use default value type constructor, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1130, Title: Use lambda syntax, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1131, Title: Use readable conditions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1132, Title: Do not combine fields, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1133, Title: Do not combine attributes, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1134, Title: Attributes should not share line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1135, Title: Using directives should be qualified, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1136, Title: Enum values should be on separate lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1137, Title: Elements should have the same indentation, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1139, Title: Use literal suffix notation instead of casting, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1141, Title: Use tuple syntax, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1142, Title: Refer to tuple fields by name, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1200, Title: Using directives should be placed correctly, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1201, Title: Elements should appear in the correct order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1202, Title: Elements should be ordered by access, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1203, Title: Constants should appear before fields, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1204, Title: Static elements should appear before instance elements, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1205, Title: Partial elements should declare access, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1206, Title: Declaration keywords should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1207, Title: Protected should come before internal, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1208, Title: System using directives should be placed before other using directives, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1209, Title: Using alias directives should be placed after other using directives, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1210, Title: Using directives should be ordered alphabetically by namespace, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1211, Title: Using alias directives should be ordered alphabetically by alias name, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1212, Title: Property accessors should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1213, Title: Event accessors should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1214, Title: Readonly fields should appear before non-readonly fields, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1216, Title: Using static directives should be placed at the correct location, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1217, Title: Using static directives should be ordered alphabetically, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1300, Title: Element should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1301, Title: Element should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1302, Title: Interface names should begin with I, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1303, Title: Const field names should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1304, Title: Non-private readonly fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1305, Title: Field names should not use Hungarian notation, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1306, Title: Field names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1307, Title: Accessible fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1308, Title: Variable names should not be prefixed, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1309, Title: Field names should not begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
+- {Id: SA1310, Title: Field names should not contain underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1311, Title: Static readonly fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1312, Title: Variable names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1313, Title: Parameter names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1314, Title: Type parameter names should begin with T, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1316, Title: Tuple element names should use correct casing, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1400, Title: Access modifier should be declared, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1401, Title: Fields should be private, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1402, Title: File may only contain a single type, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1403, Title: File may only contain a single namespace, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1404, Title: Code analysis suppression should have justification, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1405, Title: Debug.Assert should provide message text, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1406, Title: Debug.Fail should provide message text, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1407, Title: Arithmetic expressions should declare precedence, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1408, Title: Conditional expressions should declare precedence, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1409, Title: Remove unnecessary code, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1410, Title: Remove delegate parenthesis when possible, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1411, Title: Attribute constructor should not use unnecessary parenthesis, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1412, Title: Store files as UTF-8 with byte order mark, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1413, Title: Use trailing comma in multi-line initializers, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1414, Title: Tuple types in signatures should have element names, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1500, Title: Braces for multi-line statements should not share line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1501, Title: Statement should not be on a single line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1502, Title: Element should not be on a single line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1503, Title: Braces should not be omitted, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: SA1504, Title: All accessors should be single-line or multi-line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1505, Title: Opening braces should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1506, Title: Element documentation headers should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1507, Title: Code should not contain multiple blank lines in a row, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1508, Title: Closing braces should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1509, Title: Opening braces should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1510, Title: Chained statement blocks should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1511, Title: While-do footer should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1512, Title: Single-line comments should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1513, Title: Closing brace should be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1514, Title: Element documentation header should be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1515, Title: Single-line comment should be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1516, Title: Elements should be separated by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1517, Title: Code should not contain blank lines at start of file, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1518, Title: Use line endings correctly at end of file, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1519, Title: Braces should not be omitted from multi-line child statement, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1520, Title: Use braces consistently, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1600, Title: Elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1601, Title: Partial elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1602, Title: Enumeration items should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1603, Title: Documentation should contain valid XML, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1604, Title: Element documentation should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1605, Title: Partial element documentation should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1606, Title: Element documentation should have summary text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1607, Title: Partial element documentation should have summary text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1608, Title: Element documentation should not have default summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1609, Title: Property documentation should have value, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1610, Title: Property documentation should have value text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1611, Title: Element parameters should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1612, Title: Element parameter documentation should match element parameters, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1613, Title: Element parameter documentation should declare parameter name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1614, Title: Element parameter documentation should have text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1615, Title: Element return value should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1616, Title: Element return value documentation should have text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1617, Title: Void return value should not be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1618, Title: Generic type parameters should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1619, Title: Generic type parameters should be documented partial class, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1620, Title: Generic type parameter documentation should match type parameters, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1621, Title: Generic type parameter documentation should declare parameter name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1622, Title: Generic type parameter documentation should have text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1623, Title: Property summary documentation should match accessors, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1624, Title: Property summary documentation should omit accessor with restricted access, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1625, Title: Element documentation should not be copied and pasted, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1626, Title: Single-line comments should not use documentation style slashes, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1627, Title: Documentation text should not be empty, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1628, Title: Documentation text should begin with a capital letter, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1629, Title: Documentation text should end with a period, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1630, Title: Documentation text should contain whitespace, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1631, Title: Documentation should meet character percentage, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1632, Title: Documentation text should meet minimum character length, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1633, Title: File should have header, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1634, Title: File header should show copyright, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1635, Title: File header should have copyright text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1636, Title: File header copyright text should match, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1637, Title: File header should contain file name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1638, Title: File header file name documentation should match file name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1639, Title: File header should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: SA1640, Title: File header should have valid company text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1641, Title: File header company name text should match, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1642, Title: Constructor summary documentation should begin with standard text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1643, Title: Destructor summary documentation should begin with standard text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1644, Title: Documentation headers should not contain blank lines, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1645, Title: Included documentation file does not exist, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1646, Title: Included documentation XPath does not exist, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1647, Title: Include node does not contain valid file and path, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1648, Title: inheritdoc should be used with inheriting class, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1649, Title: File name should match first type name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1650, Title: Element documentation should be spelled correctly, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1651, Title: Do not use placeholder elements, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SX1101, Title: Do not prefix local calls with 'this.', Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SX1309, Title: Field names should begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SX1309S, Title: Static field names should begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: VSTHRD001, Title: Avoid legacy thread switching APIs, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD002, Title: Avoid problematic synchronous waits, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD003, Title: Avoid awaiting foreign Tasks, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD004, Title: Await SwitchToMainThreadAsync, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD010, Title: Invoke single-threaded types on Main thread, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD011, Title: Use AsyncLazy<T>, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD012, Title: Provide JoinableTaskFactory where allowed, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD100, Title: Avoid async void methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD101, Title: Avoid unsupported async delegates, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD102, Title: Implement internal logic asynchronously, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD103, Title: Call async methods when in an async method, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD104, Title: Offer async methods, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD105, Title: Avoid method overloads that assume TaskScheduler.Current, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD106, Title: Use InvokeAsync to raise async events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD107, Title: Await Task within using expression, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD108, Title: Assert thread affinity unconditionally, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD109, Title: Switch instead of assert in async methods, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD110, Title: Observe result of async calls, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD111, Title: Use ConfigureAwait(bool), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: VSTHRD112, Title: Implement System.IAsyncDisposable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD113, Title: Check for System.IAsyncDisposable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD114, Title: Avoid returning a null Task, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD200, Title: Use "Async" suffix for async methods, Category: Style, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}

--- a/src/Moq.Analyzers/SquiggleCop.Baseline.yaml
+++ b/src/Moq.Analyzers/SquiggleCop.Baseline.yaml
@@ -1,0 +1,12512 @@
+- Id: CA1000
+  Title: Do not declare static members on generic types
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1001
+  Title: Types that own disposable fields should be disposable
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1002
+  Title: Do not expose generic lists
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1003
+  Title: Use generic event handler instances
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1005
+  Title: Avoid excessive parameters on generic types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1008
+  Title: Enums should have zero value
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1010
+  Title: Generic interface should also be implemented
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1012
+  Title: Abstract types should not have public constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1014
+  Title: Mark assemblies with CLSCompliant
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1016
+  Title: Mark assemblies with assembly version
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1017
+  Title: Mark assemblies with ComVisible
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1018
+  Title: Mark attributes with AttributeUsageAttribute
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1019
+  Title: Define accessors for attribute arguments
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1021
+  Title: Avoid out parameters
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1024
+  Title: Use properties where appropriate
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1027
+  Title: Mark enums with FlagsAttribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1028
+  Title: Enum Storage should be Int32
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1030
+  Title: Use events where appropriate
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1031
+  Title: Do not catch general exception types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1032
+  Title: Implement standard exception constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1033
+  Title: Interface methods should be callable by child types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1034
+  Title: Nested types should not be visible
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1036
+  Title: Override methods on comparable types
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1040
+  Title: Avoid empty interfaces
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1041
+  Title: Provide ObsoleteAttribute message
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1043
+  Title: Use Integral Or String Argument For Indexers
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1044
+  Title: Properties should not be write only
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1045
+  Title: Do not pass types by reference
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1046
+  Title: Do not overload equality operator on reference types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1050
+  Title: Declare types in namespaces
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1051
+  Title: Do not declare visible instance fields
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1052
+  Title: Static holder types should be Static or NotInheritable
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1054
+  Title: URI-like parameters should not be strings
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1055
+  Title: URI-like return values should not be strings
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1056
+  Title: URI-like properties should not be strings
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1058
+  Title: Types should not extend certain base types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1060
+  Title: Move pinvokes to native methods class
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1061
+  Title: Do not hide base class methods
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1062
+  Title: Validate arguments of public methods
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1063
+  Title: Implement IDisposable Correctly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1064
+  Title: Exceptions should be public
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1065
+  Title: Do not raise exceptions in unexpected locations
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1066
+  Title: Implement IEquatable when overriding Object.Equals
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: CA1067
+  Title: Override Object.Equals(object) when implementing IEquatable<T>
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1068
+  Title: CancellationToken parameters must come last
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1069
+  Title: Enums values should not be duplicated
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1070
+  Title: Do not declare event fields as virtual
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1200
+  Title: Avoid using cref tags with a prefix
+  Category: Documentation
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1303
+  Title: Do not pass literals as localized parameters
+  Category: Globalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1304
+  Title: Specify CultureInfo
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1305
+  Title: Specify IFormatProvider
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1307
+  Title: Specify StringComparison for clarity
+  Category: Globalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1308
+  Title: Normalize strings to uppercase
+  Category: Globalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1309
+  Title: Use ordinal string comparison
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1310
+  Title: Specify StringComparison for correctness
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1311
+  Title: Specify a culture or use an invariant version
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1401
+  Title: P/Invokes should not be visible
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1416
+  Title: Validate platform compatibility
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1417
+  Title: Do not use 'OutAttribute' on string parameters for P/Invokes
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1418
+  Title: Use valid platform string
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1419
+  Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1420
+  Title: Property, type, or attribute requires runtime marshalling
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1421
+  Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1422
+  Title: Validate platform compatibility
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1501
+  Title: Avoid excessive inheritance
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1502
+  Title: Avoid excessive complexity
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1505
+  Title: Avoid unmaintainable code
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1506
+  Title: Avoid excessive class coupling
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1507
+  Title: Use nameof to express symbol names
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1508
+  Title: Avoid dead conditional code
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1509
+  Title: Invalid entry in code metrics rule specification file
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1510
+  Title: Use ArgumentNullException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1511
+  Title: Use ArgumentException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1512
+  Title: Use ArgumentOutOfRangeException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1513
+  Title: Use ObjectDisposedException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1700
+  Title: Do not name enum values 'Reserved'
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1707
+  Title: Identifiers should not contain underscores
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1708
+  Title: Identifiers should differ by more than case
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1710
+  Title: Identifiers should have correct suffix
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1711
+  Title: Identifiers should not have incorrect suffix
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1712
+  Title: Do not prefix enum values with type name
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1713
+  Title: Events should not have 'Before' or 'After' prefix
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1715
+  Title: Identifiers should have correct prefix
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1716
+  Title: Identifiers should not match keywords
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1720
+  Title: Identifier contains type name
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1721
+  Title: Property names should not match get methods
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1724
+  Title: Type names should not match namespaces
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1725
+  Title: Parameter names should match base declaration
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1727
+  Title: Use PascalCase for named placeholders
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1802
+  Title: Use literals where appropriate
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1805
+  Title: Do not initialize unnecessarily
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1806
+  Title: Do not ignore method results
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1810
+  Title: Initialize reference type static fields inline
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1812
+  Title: Avoid uninstantiated internal classes
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1813
+  Title: Avoid unsealed attributes
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1814
+  Title: Prefer jagged arrays over multidimensional
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1815
+  Title: Override equals and operator equals on value types
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1816
+  Title: Dispose methods should call SuppressFinalize
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1819
+  Title: Properties should not return arrays
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1820
+  Title: Test for empty strings using string length
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1821
+  Title: Remove empty Finalizers
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1822
+  Title: Mark members as static
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1823
+  Title: Avoid unused private fields
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1824
+  Title: Mark assemblies with NeutralResourcesLanguageAttribute
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1825
+  Title: Avoid zero-length array allocations
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1826
+  Title: Do not use Enumerable methods on indexable collections
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1827
+  Title: Do not use Count() or LongCount() when Any() can be used
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1828
+  Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1829
+  Title: Use Length/Count property instead of Count() when available
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1830
+  Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1831
+  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1832
+  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1833
+  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1834
+  Title: Consider using 'StringBuilder.Append(char)' when applicable
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1835
+  Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1836
+  Title: Prefer IsEmpty over Count
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1837
+  Title: Use 'Environment.ProcessId'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1838
+  Title: Avoid 'StringBuilder' parameters for P/Invokes
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1839
+  Title: Use 'Environment.ProcessPath'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1840
+  Title: Use 'Environment.CurrentManagedThreadId'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1841
+  Title: Prefer Dictionary.Contains methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1842
+  Title: Do not use 'WhenAll' with a single task
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1843
+  Title: Do not use 'WaitAll' with a single task
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1844
+  Title: Provide memory-based overrides of async methods when subclassing 'Stream'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1845
+  Title: Use span-based 'string.Concat'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1846
+  Title: Prefer 'AsSpan' over 'Substring'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1847
+  Title: Use char literal for a single character lookup
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1848
+  Title: Use the LoggerMessage delegates
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1849
+  Title: Call async methods when in an async method
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1850
+  Title: Prefer static 'HashData' method over 'ComputeHash'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1851
+  Title: Possible multiple enumerations of 'IEnumerable' collection
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1852
+  Title: Seal internal types
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1853
+  Title: Unnecessary call to 'Dictionary.ContainsKey(key)'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1854
+  Title: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1855
+  Title: Prefer 'Clear' over 'Fill'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1856
+  Title: Incorrect usage of ConstantExpected attribute
+  Category: Performance
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1857
+  Title: A constant is expected for the parameter
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1858
+  Title: Use 'StartsWith' instead of 'IndexOf'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1859
+  Title: Use concrete types when possible for improved performance
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1860
+  Title: Avoid using 'Enumerable.Any()' extension method
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1861
+  Title: Avoid constant arrays as arguments
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1862
+  Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1863
+  Title: Use 'CompositeFormat'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1864
+  Title: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1865
+  Title: Use char overload
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1866
+  Title: Use char overload
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1867
+  Title: Use char overload
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: CA1868
+  Title: Unnecessary call to 'Contains(item)'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1869
+  Title: Cache and reuse 'JsonSerializerOptions' instances
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1870
+  Title: Use a cached 'SearchValues' instance
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2000
+  Title: Dispose objects before losing scope
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2002
+  Title: Do not lock on objects with weak identity
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2007
+  Title: Consider calling ConfigureAwait on the awaited task
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2008
+  Title: Do not create tasks without passing a TaskScheduler
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2009
+  Title: Do not call ToImmutableCollection on an ImmutableCollection value
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2011
+  Title: Avoid infinite recursion
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2012
+  Title: Use ValueTasks correctly
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2013
+  Title: Do not use ReferenceEquals with value types
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2014
+  Title: Do not use stackalloc in loops
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2015
+  Title: Do not define finalizers for types derived from MemoryManager<T>
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2016
+  Title: Forward the 'CancellationToken' parameter to methods
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: CA2017
+  Title: Parameter count mismatch
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2018
+  Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument"
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2019
+  Title: Improper 'ThreadStatic' field initialization
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2020
+  Title: Prevent behavioral change
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2021
+  Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2100
+  Title: Review SQL queries for security vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2101
+  Title: Specify marshaling for P/Invoke string arguments
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2119
+  Title: Seal methods that satisfy private interfaces
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2153
+  Title: Do Not Catch Corrupted State Exceptions
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2200
+  Title: Rethrow to preserve stack details
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2201
+  Title: Do not raise reserved exception types
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA2207
+  Title: Initialize value type static fields inline
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2208
+  Title: Instantiate argument exceptions correctly
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2211
+  Title: Non-constant fields should not be visible
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2213
+  Title: Disposable fields should be disposed
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2214
+  Title: Do not call overridable methods in constructors
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2215
+  Title: Dispose methods should call base class dispose
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA2216
+  Title: Disposable types should declare finalizer
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2217
+  Title: Do not mark enums with FlagsAttribute
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2219
+  Title: Do not raise exceptions in finally clauses
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2225
+  Title: Operator overloads have named alternates
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2226
+  Title: Operators should have symmetrical overloads
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2227
+  Title: Collection properties should be read only
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2231
+  Title: Overload operator equals on overriding value type Equals
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2234
+  Title: Pass system uri objects instead of strings
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2235
+  Title: Mark all non-serializable fields
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2237
+  Title: Mark ISerializable types with serializable
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2241
+  Title: Provide correct arguments to formatting methods
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2242
+  Title: Test for NaN correctly
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2243
+  Title: Attribute string literals should parse correctly
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2244
+  Title: Do not duplicate indexed element initializations
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2245
+  Title: Do not assign a property to itself
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2246
+  Title: Assigning symbol and its member in the same statement
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2247
+  Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2248
+  Title: Provide correct 'enum' argument to 'Enum.HasFlag'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2249
+  Title: Consider using 'string.Contains' instead of 'string.IndexOf'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2250
+  Title: Use 'ThrowIfCancellationRequested'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2251
+  Title: Use 'string.Equals'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA2252
+  Title: This API requires opting into preview features
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2253
+  Title: Named placeholders should not be numeric values
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2254
+  Title: Template should be a static expression
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2255
+  Title: The 'ModuleInitializer' attribute should not be used in libraries
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2256
+  Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2257
+  Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2258
+  Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2259
+  Title: "'ThreadStatic' only affects static fields"
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2260
+  Title: Use correct type parameter
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2261
+  Title: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2300
+  Title: Do not use insecure deserializer BinaryFormatter
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2301
+  Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2302
+  Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2305
+  Title: Do not use insecure deserializer LosFormatter
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2310
+  Title: Do not use insecure deserializer NetDataContractSerializer
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2311
+  Title: Do not deserialize without first setting NetDataContractSerializer.Binder
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2312
+  Title: Ensure NetDataContractSerializer.Binder is set before deserializing
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2315
+  Title: Do not use insecure deserializer ObjectStateFormatter
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2321
+  Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2322
+  Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2326
+  Title: Do not use TypeNameHandling values other than None
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2327
+  Title: Do not use insecure JsonSerializerSettings
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2328
+  Title: Ensure that JsonSerializerSettings are secure
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2329
+  Title: Do not deserialize with JsonSerializer using an insecure configuration
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2330
+  Title: Ensure that JsonSerializer has a secure configuration when deserializing
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2350
+  Title: Do not use DataTable.ReadXml() with untrusted data
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2351
+  Title: Do not use DataSet.ReadXml() with untrusted data
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2352
+  Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2353
+  Title: Unsafe DataSet or DataTable in serializable type
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2354
+  Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2355
+  Title: Unsafe DataSet or DataTable type found in deserializable object graph
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2356
+  Title: Unsafe DataSet or DataTable type in web deserializable object graph
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2361
+  Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2362
+  Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3001
+  Title: Review code for SQL injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3002
+  Title: Review code for XSS vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3003
+  Title: Review code for file path injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3004
+  Title: Review code for information disclosure vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3005
+  Title: Review code for LDAP injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3006
+  Title: Review code for process command injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3007
+  Title: Review code for open redirect vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3008
+  Title: Review code for XPath injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3009
+  Title: Review code for XML injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3010
+  Title: Review code for XAML injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3011
+  Title: Review code for DLL injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3012
+  Title: Review code for regex injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3061
+  Title: Do Not Add Schema By URL
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3075
+  Title: Insecure DTD processing in XML
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3076
+  Title: Insecure XSLT script processing
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3077
+  Title: Insecure Processing in API Design, XmlDocument and XmlTextReader
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3147
+  Title: Mark Verb Handlers With Validate Antiforgery Token
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5350
+  Title: Do Not Use Weak Cryptographic Algorithms
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5351
+  Title: Do Not Use Broken Cryptographic Algorithms
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5358
+  Title: Review cipher mode usage with cryptography experts
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5359
+  Title: Do Not Disable Certificate Validation
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5360
+  Title: Do Not Call Dangerous Methods In Deserialization
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5361
+  Title: Do Not Disable SChannel Use of Strong Crypto
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5362
+  Title: Potential reference cycle in deserialized object graph
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5363
+  Title: Do Not Disable Request Validation
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5364
+  Title: Do Not Use Deprecated Security Protocols
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5365
+  Title: Do Not Disable HTTP Header Checking
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5366
+  Title: Use XmlReader for 'DataSet.ReadXml()'
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5367
+  Title: Do Not Serialize Types With Pointer Fields
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5368
+  Title: Set ViewStateUserKey For Classes Derived From Page
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5369
+  Title: Use XmlReader for 'XmlSerializer.Deserialize()'
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5370
+  Title: Use XmlReader for XmlValidatingReader constructor
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5371
+  Title: Use XmlReader for 'XmlSchema.Read()'
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5372
+  Title: Use XmlReader for XPathDocument constructor
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5373
+  Title: Do not use obsolete key derivation function
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5374
+  Title: Do Not Use XslTransform
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5375
+  Title: Do Not Use Account Shared Access Signature
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5376
+  Title: Use SharedAccessProtocol HttpsOnly
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5377
+  Title: Use Container Level Access Policy
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5378
+  Title: Do not disable ServicePointManagerSecurityProtocols
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5379
+  Title: Ensure Key Derivation Function algorithm is sufficiently strong
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5380
+  Title: Do Not Add Certificates To Root Store
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5381
+  Title: Ensure Certificates Are Not Added To Root Store
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5382
+  Title: Use Secure Cookies In ASP.NET Core
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5383
+  Title: Ensure Use Secure Cookies In ASP.NET Core
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5384
+  Title: Do Not Use Digital Signature Algorithm (DSA)
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5385
+  Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5386
+  Title: Avoid hardcoding SecurityProtocolType value
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5387
+  Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5388
+  Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5389
+  Title: Do Not Add Archive Item's Path To The Target File System Path
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5390
+  Title: Do not hard-code encryption key
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5391
+  Title: Use antiforgery tokens in ASP.NET Core MVC controllers
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5392
+  Title: Use DefaultDllImportSearchPaths attribute for P/Invokes
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5393
+  Title: Do not use unsafe DllImportSearchPath value
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5394
+  Title: Do not use insecure randomness
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5395
+  Title: Miss HttpVerb attribute for action methods
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5396
+  Title: Set HttpOnly to true for HttpCookie
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5397
+  Title: Do not use deprecated SslProtocols values
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5398
+  Title: Avoid hardcoded SslProtocols values
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5399
+  Title: HttpClients should enable certificate revocation list checks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5400
+  Title: Ensure HttpClient certificate revocation list check is not disabled
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5401
+  Title: Do not use CreateEncryptor with non-default IV
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5402
+  Title: 'Use CreateEncryptor with the default IV '
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5403
+  Title: Do not hard-code certificate
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5404
+  Title: Do not disable token validation checks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5405
+  Title: Do not always skip token validation in delegates
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: EM0001
+  Title: Switch on Enum Not Exhaustive
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0002
+  Title: Switch on Nullable Enum Not Exhaustive
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0003
+  Title: Switch on Closed Type Not Exhaustive
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0011
+  Title: Concrete Subtype of a Closed Type Must Be a Case
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0012
+  Title: Closed Type Case Must Be a Direct Subtype
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0013
+  Title: Closed Type Case Must Be a Subtype
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0014
+  Title: Concrete Subtype of a Closed Type Must Be a Covered
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0015
+  Title: Open Interface Subtype of a Closed Type Must Be a Case
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0100
+  Title: When Guards Not Supported
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0101
+  Title: Case Pattern Not Supported
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0102
+  Title: Open Type Not Supported
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0103
+  Title: Match Must Be On Case Type
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0104
+  Title: Duplicate Closed Attribute
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0105
+  Title: Duplicate Case Type
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EnableGenerateDocumentationFile
+  Title: Set MSBuild property 'GenerateDocumentationFile' to 'true'
+  Category: Style
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: IDE0004
+  Title: Remove Unnecessary Cast
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0005
+  Title: Using directive is unnecessary.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0005_gen
+  Title: Using directive is unnecessary.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0007
+  Title: Use implicit type
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0008
+  Title: Use explicit type
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0009
+  Title: Member access should be qualified.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0010
+  Title: Add missing cases
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0011
+  Title: Add braces
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0016
+  Title: Use 'throw' expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0017
+  Title: Simplify object initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0018
+  Title: Inline variable declaration
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0019
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0020
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0021
+  Title: Use expression body for constructor
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0022
+  Title: Use expression body for method
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0023
+  Title: Use expression body for conversion operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0024
+  Title: Use expression body for operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0025
+  Title: Use expression body for property
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0026
+  Title: Use expression body for indexer
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0027
+  Title: Use expression body for accessor
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0028
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0029
+  Title: Use coalesce expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0030
+  Title: Use coalesce expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0031
+  Title: Use null propagation
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0032
+  Title: Use auto property
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0033
+  Title: Use explicitly provided tuple name
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0034
+  Title: Simplify 'default' expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0035
+  Title: Unreachable code detected
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0036
+  Title: Order modifiers
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0037
+  Title: Use inferred member name
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0039
+  Title: Use local function
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0040
+  Title: Add accessibility modifiers
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0041
+  Title: Use 'is null' check
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0042
+  Title: Deconstruct variable declaration
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0043
+  Title: Invalid format string
+  Category: Compiler
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0044
+  Title: Add readonly modifier
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0045
+  Title: Convert to conditional expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0046
+  Title: Convert to conditional expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0047
+  Title: Remove unnecessary parentheses
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0048
+  Title: Add parentheses for clarity
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0051
+  Title: Remove unused private members
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0052
+  Title: Remove unread private members
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0053
+  Title: Use expression body for lambda expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0054
+  Title: Use compound assignment
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0055
+  Title: Fix formatting
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0056
+  Title: Use index operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0057
+  Title: Use range operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0058
+  Title: Expression value is never used
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0059
+  Title: Unnecessary assignment of a value
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0060
+  Title: Remove unused parameter
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0061
+  Title: Use expression body for local function
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0062
+  Title: Make local function 'static'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0063
+  Title: Use simple 'using' statement
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0064
+  Title: Make readonly fields writable
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0065
+  Title: Misplaced using directive
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0066
+  Title: Convert switch statement to expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0070
+  Title: Use 'System.HashCode'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0071
+  Title: Simplify interpolation
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0072
+  Title: Add missing cases
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0073
+  Title: The file header does not match the required text
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0074
+  Title: Use compound assignment
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0075
+  Title: Simplify conditional expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0076
+  Title: Invalid global 'SuppressMessageAttribute'
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0077
+  Title: Avoid legacy format target in 'SuppressMessageAttribute'
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0078
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0080
+  Title: Remove unnecessary suppression operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0082
+  Title: "'typeof' can be converted to 'nameof'"
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0083
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0090
+  Title: Use 'new(...)'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0100
+  Title: Remove redundant equality
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0110
+  Title: Remove unnecessary discard
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0120
+  Title: Simplify LINQ expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0130
+  Title: Namespace does not match folder structure
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0150
+  Title: Prefer 'null' check over type check
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0160
+  Title: Convert to block scoped namespace
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0161
+  Title: Convert to file-scoped namespace
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0170
+  Title: Property pattern can be simplified
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0180
+  Title: Use tuple to swap values
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0200
+  Title: Remove unnecessary lambda expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0210
+  Title: Convert to top-level statements
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0211
+  Title: Convert to 'Program.Main' style program
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0220
+  Title: Add explicit cast
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0230
+  Title: Use UTF-8 string literal
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0240
+  Title: Remove redundant nullable directive
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0241
+  Title: Remove unnecessary nullable directive
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0250
+  Title: Make struct 'readonly'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0251
+  Title: Make member 'readonly'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0260
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0270
+  Title: Use coalesce expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0280
+  Title: Use 'nameof'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0290
+  Title: Use primary constructor
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0300
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0301
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0302
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0303
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0304
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0305
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0320
+  Title: Make anonymous function static
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE1005
+  Title: Delegate invocation can be simplified.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE1006
+  Title: Naming Styles
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE2000
+  Title: Avoid multiple blank lines
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2001
+  Title: Embedded statements must be on their own line
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2002
+  Title: Consecutive braces must not have blank line between them
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2003
+  Title: Blank line required between block and subsequent statement
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2004
+  Title: Blank line not allowed after constructor initializer colon
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2005
+  Title: Blank line not allowed after conditional expression token
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2006
+  Title: Blank line not allowed after arrow expression clause token
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0001
+  Title: StringComparison is missing
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0002
+  Title: IEqualityComparer<string> or IComparer<string> is missing
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0003
+  Title: Add parameter name to improve readability
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0004
+  Title: Use Task.ConfigureAwait
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0005
+  Title: Use Array.Empty<T>()
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0006
+  Title: Use String.Equals instead of equality operator
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0007
+  Title: Add a comma after the last value
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0008
+  Title: Add StructLayoutAttribute
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0009
+  Title: Add regex evaluation timeout
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0010
+  Title: Mark attributes with AttributeUsageAttribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0011
+  Title: IFormatProvider is missing
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0012
+  Title: Do not raise reserved exception type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0013
+  Title: Types should not extend System.ApplicationException
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0014
+  Title: Do not raise System.ApplicationException type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0015
+  Title: Specify the parameter name in ArgumentException
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0016
+  Title: Prefer using collection abstraction instead of implementation
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0017
+  Title: Abstract types should not have public or internal constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0018
+  Title: Do not declare static members on generic types (deprecated; use CA1000 instead)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0019
+  Title: Use EventArgs.Empty
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0020
+  Title: Use direct methods instead of LINQ methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0021
+  Title: Use StringComparer.GetHashCode instead of string.GetHashCode
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0022
+  Title: Return Task.FromResult instead of returning null
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0023
+  Title: Add RegexOptions.ExplicitCapture
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0024
+  Title: Use an explicit StringComparer when possible
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0025
+  Title: Implement the functionality instead of throwing NotImplementedException
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0026
+  Title: Fix TODO comment
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - None
+  IsEverSuppressed: true
+- Id: MA0027
+  Title: Prefer rethrowing an exception implicitly
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0028
+  Title: Optimize StringBuilder usage
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0029
+  Title: Combine LINQ methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0030
+  Title: Remove useless OrderBy call
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0031
+  Title: Optimize Enumerable.Count() usage
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0032
+  Title: Use an overload with a CancellationToken argument
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0033
+  Title: Do not tag instance fields with ThreadStaticAttribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0035
+  Title: Do not use dangerous threading methods
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0036
+  Title: Make class static
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0037
+  Title: Remove empty statement
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0038
+  Title: Make method static (deprecated, use CA1822 instead)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0039
+  Title: Do not write your own certificate validation method
+  Category: Security
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0040
+  Title: Forward the CancellationToken parameter to methods that take one
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: MA0041
+  Title: Make property static (deprecated, use CA1822 instead)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0042
+  Title: Do not use blocking calls in an async method
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0043
+  Title: Use nameof operator in ArgumentException
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0044
+  Title: Remove useless ToString call
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0045
+  Title: Do not use blocking calls in a sync method (need to make calling method async)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0046
+  Title: Use EventHandler<T> to declare events
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0047
+  Title: Declare types in namespaces
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0048
+  Title: File name must match type name
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0049
+  Title: Type name should not match containing namespace
+  Category: Design
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0050
+  Title: Validate arguments correctly in iterator methods
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0051
+  Title: Method is too long
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: true
+- Id: MA0052
+  Title: Replace constant Enum.ToString with nameof
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0053
+  Title: Make class sealed
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0054
+  Title: Embed the caught exception as innerException
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0055
+  Title: Do not use finalizer
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0056
+  Title: Do not call overridable members in constructor
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0057
+  Title: Class name should end with 'Attribute'
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0058
+  Title: Class name should end with 'Exception'
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0059
+  Title: Class name should end with 'EventArgs'
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0060
+  Title: The value returned by Stream.Read/Stream.ReadAsync is not used
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0061
+  Title: Method overrides should not change default values
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0062
+  Title: Non-flags enums should not be marked with "FlagsAttribute"
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0063
+  Title: Use Where before OrderBy
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0064
+  Title: Avoid locking on publicly accessible instance
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0065
+  Title: Default ValueType.Equals or HashCode is used for struct equality
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0066
+  Title: Hash table unfriendly type is used in a hash table
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0067
+  Title: Use Guid.Empty
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0068
+  Title: Invalid parameter name for nullable attribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0069
+  Title: Non-constant static fields should not be visible
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0070
+  Title: Obsolete attributes should include explanations
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0071
+  Title: Avoid using redundant else
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0072
+  Title: Do not throw from a finally block
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0073
+  Title: Avoid comparison with bool constant
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0074
+  Title: Avoid implicit culture-sensitive methods
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0075
+  Title: Do not use implicit culture-sensitive ToString
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0076
+  Title: Do not use implicit culture-sensitive ToString in interpolated strings
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0077
+  Title: A class that provides Equals(T) should implement IEquatable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0078
+  Title: Use 'Cast' instead of 'Select' to cast
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0079
+  Title: Forward the CancellationToken using .WithCancellation()
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0080
+  Title: Use a cancellation token using .WithCancellation()
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0081
+  Title: Method overrides should not omit params keyword
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0082
+  Title: NaN should not be used in comparisons
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0083
+  Title: ConstructorArgument parameters should exist in constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0084
+  Title: Local variables should not hide other symbols
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0085
+  Title: Anonymous delegates should not be used to unsubscribe from Events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0086
+  Title: Do not throw from a finalizer
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0087
+  Title: Parameters with [DefaultParameterValue] attributes should also be marked [Optional]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0088
+  Title: Use [DefaultParameterValue] instead of [DefaultValue]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0089
+  Title: Optimize string method usage
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0090
+  Title: Remove empty else/finally block
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0091
+  Title: Sender should be 'this' for instance events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0092
+  Title: Sender should be 'null' for static events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0093
+  Title: EventArgs should not be null
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0094
+  Title: A class that provides CompareTo(T) should implement IComparable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0095
+  Title: A class that implements IEquatable<T> should override Equals(object)
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0096
+  Title: A class that implements IComparable<T> should also implement IEquatable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0097
+  Title: A class that implements IComparable<T> or IComparable should override comparison operators
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0098
+  Title: Use indexer instead of LINQ methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0099
+  Title: Use Explicit enum value instead of 0
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0100
+  Title: Await task before disposing of resources
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0101
+  Title: String contains an implicit end of line character
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: MA0102
+  Title: Make member readonly
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0103
+  Title: Use SequenceEqual instead of equality operator
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0104
+  Title: Do not create a type with a name from the BCL
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0105
+  Title: Use the lambda parameters instead of using a closure
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0106
+  Title: Avoid closure by using an overload with the 'factoryArgument' parameter
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0107
+  Title: Do not use culture-sensitive object.ToString
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0108
+  Title: Remove redundant argument value
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0109
+  Title: Consider adding an overload with a Span<T> or Memory<T>
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0110
+  Title: Use the Regex source generator
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0111
+  Title: Use string.Create instead of FormattableString
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0112
+  Title: Use 'Count > 0' instead of 'Any()'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0113
+  Title: Use DateTime.UnixEpoch
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0114
+  Title: Use DateTimeOffset.UnixEpoch
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0115
+  Title: Unknown component parameter
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0116
+  Title: Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0117
+  Title: Parameters with [EditorRequired] attributes should also be marked as [Parameter]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0118
+  Title: '[JSInvokable] methods must be public'
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0119
+  Title: JSRuntime must not be used in OnInitialized or OnInitializedAsync
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0120
+  Title: Use InvokeVoidAsync when the returned value is not used
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0121
+  Title: Do not overwrite parameter value
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0122
+  Title: Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0123
+  Title: Sequence number must be a constant
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0124
+  Title: Log parameter type is not valid
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0125
+  Title: The list of log parameter types contains an invalid type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0126
+  Title: The list of log parameter types contains a duplicate
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0127
+  Title: Use String.Equals instead of is pattern
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0128
+  Title: Use 'is' operator instead of SequenceEqual
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0129
+  Title: Await task in using statement
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0130
+  Title: GetType() should not be used on System.Type instances
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0131
+  Title: ArgumentNullException.ThrowIfNull should not be used with non-nullable types
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0132
+  Title: Do not convert implicitly to DateTimeOffset
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0133
+  Title: Use DateTimeOffset instead of relying on the implicit conversion
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0134
+  Title: Observe result of async calls
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0135
+  Title: The log parameter has no configured type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0136
+  Title: Raw String contains an implicit end of line character
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: MA0137
+  Title: Use 'Async' suffix when a method returns an awaitable type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0138
+  Title: Do not use 'Async' suffix when a method does not return an awaitable type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0139
+  Title: Log parameter type is not valid
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0140
+  Title: Both if and else branch have identical code
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0141
+  Title: Use pattern matching instead of inequality operators for null check
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0142
+  Title: Use pattern matching instead of equality operators for null check
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0143
+  Title: Primary constructor parameters should be readonly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0144
+  Title: Use System.OperatingSystem to check the current OS
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0145
+  Title: Signature for [UnsafeAccessorAttribute] method is not valid
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0146
+  Title: Name must be set explicitly on local functions
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0147
+  Title: Avoid async void method for delegate
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0148
+  Title: Use pattern matching instead of equality operators for discrete value
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0149
+  Title: Use pattern matching instead of inequality operators for discrete value
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0150
+  Title: Do not call the default object.ToString explicitly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0151
+  Title: DebuggerDisplay must contain valid members
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0152
+  Title: Use Unwrap instead of using await twice
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0153
+  Title: Do not log symbols decorated with DataClassificationAttribute directly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0154
+  Title: Use langword in XML comment
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0155
+  Title: Do not use async void methods
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0156
+  Title: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0157
+  Title: Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0158
+  Title: Use System.Threading.Lock
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0159
+  Title: Use 'Order' instead of 'OrderBy'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0160
+  Title: Use ContainsKey instead of TryGetValue
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: POLYSP0003
+  Title: Unsupported C# language version
+  Category: Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1001
+  Title: Add braces (when expression spans over multiple lines)
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1002
+  Title: Remove braces
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1002FadeOut
+  Title: Remove braces
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1003
+  Title: Add braces to if-else (when expression spans over multiple lines)
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1004
+  Title: Remove braces from if-else
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1004FadeOut
+  Title: Remove braces from if-else
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1005
+  Title: Simplify nested using statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1005FadeOut
+  Title: Simplify nested using statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1006
+  Title: Merge 'else' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1006FadeOut
+  Title: Merge 'else' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1007
+  Title: Add braces
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1008
+  Title: "[deprecated] Use explicit type instead of 'var' (when the type is not obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1009
+  Title: "[deprecated] Use explicit type instead of 'var' (foreach variable)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1010
+  Title: "[deprecated] Use 'var' instead of explicit type (when the type is obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1012
+  Title: "[deprecated] Use explicit type instead of 'var' (when the type is obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1013
+  Title: Use predefined type
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1014
+  Title: Use explicitly/implicitly typed array
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1015
+  Title: Use nameof operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1015FadeOut
+  Title: Use nameof operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1016
+  Title: Use block body or expression body
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1018
+  Title: Add/remove accessibility modifiers
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1019
+  Title: Order modifiers
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1020
+  Title: Simplify Nullable<T> to T?
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1021
+  Title: Convert lambda expression body to expression body
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1021FadeOut
+  Title: Convert lambda expression body to expression body
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1031
+  Title: Remove unnecessary braces in switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1031FadeOut
+  Title: Remove unnecessary braces in switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1032
+  Title: Remove redundant parentheses
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1032FadeOut
+  Title: Remove redundant parentheses
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1033
+  Title: Remove redundant boolean literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1034
+  Title: Remove redundant 'sealed' modifier
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1035
+  Title: '[deprecated] Remove redundant comma in initializer'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1036
+  Title: Remove unnecessary blank line
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1037
+  Title: Remove trailing white-space
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1038
+  Title: '[deprecated] Remove empty statement'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1039
+  Title: Remove argument list from attribute
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1040
+  Title: "[deprecated] Remove empty 'else' clause"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1041
+  Title: '[deprecated] Remove empty initializer'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1042
+  Title: Remove enum default underlying type
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1043
+  Title: Remove 'partial' modifier from type with a single part
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1044
+  Title: Remove original exception from throw statement
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1046
+  Title: Asynchronous method name should end with 'Async'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1047
+  Title: Non-asynchronous method name should not end with 'Async'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1047FadeOut
+  Title: Non-asynchronous method name should not end with 'Async'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1048
+  Title: Use lambda expression instead of anonymous method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1048FadeOut
+  Title: Use lambda expression instead of anonymous method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1049
+  Title: Simplify boolean comparison
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1049FadeOut
+  Title: Simplify boolean comparison
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1050
+  Title: Include/omit parentheses when creating new object
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1051
+  Title: Add/remove parentheses from condition in conditional operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1052
+  Title: Declare each attribute separately
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1055
+  Title: Unnecessary semicolon at the end of declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1056
+  Title: Avoid usage of using alias directive
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1058
+  Title: Use compound assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1058FadeOut
+  Title: Use compound assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1059
+  Title: Avoid locking on publicly accessible instance
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1060
+  Title: Declare each type in separate file
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1061
+  Title: Merge 'if' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1061FadeOut
+  Title: Merge 'if' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1063
+  Title: '[deprecated] Avoid usage of do statement to create an infinite loop'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1064
+  Title: '[deprecated] Avoid usage of for statement to create an infinite loop'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1065
+  Title: '[deprecated] Avoid usage of while statement to create an infinite loop'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1066
+  Title: "[deprecated] Remove empty 'finally' clause"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1066FadeOut
+  Title: "[deprecated] Remove empty 'finally' clause"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1068
+  Title: Simplify logical negation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1069
+  Title: Remove unnecessary case label
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1070
+  Title: Remove redundant default switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1071
+  Title: Remove redundant base constructor call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1072
+  Title: '[deprecated] Remove empty namespace declaration'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1073
+  Title: Convert 'if' to 'return' statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1073FadeOut
+  Title: Convert 'if' to 'return' statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1074
+  Title: Remove redundant constructor
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1075
+  Title: Avoid empty catch clause that catches System.Exception
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1077
+  Title: Optimize LINQ method call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1078
+  Title: Use "" or 'string.Empty'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1079
+  Title: Throwing of new NotImplementedException
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1080
+  Title: Use 'Count/Length' property instead of 'Any' method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1081
+  Title: Split variable declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1084
+  Title: Use coalesce expression instead of conditional expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1085
+  Title: Use auto-implemented property
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1085FadeOut
+  Title: Use auto-implemented property
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1089
+  Title: Use --/++ operator instead of assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1089FadeOut
+  Title: Use --/++ operator instead of assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1090
+  Title: Add/remove 'ConfigureAwait(false)' call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1091
+  Title: '[deprecated] Remove empty region'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1091FadeOut
+  Title: '[deprecated] Remove empty region'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1093
+  Title: File contains no code
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1094
+  Title: Declare using directive on top level
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1096
+  Title: Use 'HasFlag' method or bitwise operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1097
+  Title: Remove redundant 'ToString' call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1098
+  Title: Constant values should be placed on right side of comparisons
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1099
+  Title: Default label should be the last label in a switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1100
+  Title: '[deprecated] Format documentation summary on a single line'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1101
+  Title: '[deprecated] Format documentation summary on multiple lines'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1102
+  Title: Make class static
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1103
+  Title: Convert 'if' to assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1104
+  Title: Simplify conditional expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1105
+  Title: Unnecessary interpolation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1106
+  Title: '[deprecated] Remove empty destructor'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1107
+  Title: Remove redundant 'ToCharArray' call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1108
+  Title: Add 'static' modifier to all partial class declarations
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1110
+  Title: Declare type inside namespace
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1111
+  Title: Add braces to switch section with multiple statements
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1112
+  Title: Combine 'Enumerable.Where' method chain
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1112FadeOut
+  Title: Combine 'Enumerable.Where' method chain
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1113
+  Title: Use 'string.IsNullOrEmpty' method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1114
+  Title: Remove redundant delegate creation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1114FadeOut
+  Title: Remove redundant delegate creation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1118
+  Title: Mark local variable as const
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1123
+  Title: Add parentheses when necessary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1124
+  Title: Inline local variable
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1124FadeOut
+  Title: Inline local variable
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1126
+  Title: Add braces to if-else
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1128
+  Title: Use coalesce expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1129
+  Title: Remove redundant field initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1130
+  Title: Bitwise operation on enum without Flags attribute
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1132
+  Title: Remove redundant overriding member
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1133
+  Title: Remove redundant Dispose/Close call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1134
+  Title: Remove redundant statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1135
+  Title: Declare enum member with zero value (when enum has FlagsAttribute)
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1136
+  Title: Merge switch sections with equivalent content
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1138
+  Title: Add summary to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1139
+  Title: Add summary element to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1140
+  Title: Add exception to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1141
+  Title: Add 'param' element to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1142
+  Title: Add 'typeparam' element to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1143
+  Title: Simplify coalesce expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1145
+  Title: Remove redundant 'as' operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1146
+  Title: Use conditional access
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1151
+  Title: Remove redundant cast
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1154
+  Title: Sort enum members
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1155
+  Title: Use StringComparison when comparing strings
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1156
+  Title: Use string.Length instead of comparison with empty string
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1157
+  Title: Composite enum value contains undefined flag
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1158
+  Title: Static member in generic type should use a type parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1159
+  Title: Use EventHandler<T>
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1160
+  Title: Abstract type should not have public constructors
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1161
+  Title: Enum should declare explicit values
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1162
+  Title: Avoid chain of assignments
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1163
+  Title: Unused parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1164
+  Title: Unused type parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1165
+  Title: Unconstrained type parameter checked for null
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1166
+  Title: Value type object is never equal to null
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1168
+  Title: Parameter name differs from base name
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1169
+  Title: Make field read-only
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1170
+  Title: Use read-only auto-implemented property
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1171
+  Title: Simplify lazy initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1172
+  Title: Use 'is' operator instead of 'as' operator
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1173
+  Title: Use coalesce expression instead of 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1174
+  Title: Remove redundant async/await
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1174FadeOut
+  Title: Remove redundant async/await
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1175
+  Title: Unused 'this' parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1176
+  Title: "[deprecated] Use 'var' instead of explicit type (when the type is not obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1177
+  Title: "[deprecated] Use 'var' instead of explicit type (in foreach)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1179
+  Title: Unnecessary assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1180
+  Title: Inline lazy initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1181
+  Title: Convert comment to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1182
+  Title: Remove redundant base interface
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1186
+  Title: Use Regex instance instead of static method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1187
+  Title: Use constant instead of field
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1188
+  Title: Remove redundant auto-property initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1189
+  Title: Add or remove region name
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1190
+  Title: Join string expressions
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1191
+  Title: Declare enum value as combination of names
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1192
+  Title: Unnecessary usage of verbatim string literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1193
+  Title: Overriding member should not change 'params' modifier
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1194
+  Title: Implement exception constructors
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1195
+  Title: Use ^ operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1196
+  Title: Call extension method as instance method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1197
+  Title: Optimize StringBuilder.Append/AppendLine call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1198
+  Title: Avoid unnecessary boxing of value type
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1199
+  Title: Unnecessary null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1200
+  Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1201
+  Title: Use method chaining
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1202
+  Title: Avoid NullReferenceException
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1203
+  Title: Use AttributeUsageAttribute
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1204
+  Title: Use EventArgs.Empty
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1205
+  Title: Order named arguments according to the order of parameters
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1206
+  Title: Use conditional access instead of conditional expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1207
+  Title: Use anonymous function or method group
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1208
+  Title: Reduce 'if' nesting
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1209
+  Title: Order type parameter constraints
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1210
+  Title: Return completed task instead of returning null
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1211
+  Title: Remove unnecessary 'else'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1212
+  Title: Remove redundant assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1212FadeOut
+  Title: Remove redundant assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1213
+  Title: Remove unused member declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1214
+  Title: Unnecessary interpolated string
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1214FadeOut
+  Title: Unnecessary interpolated string
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1215
+  Title: Expression is always equal to true/false
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1216
+  Title: Unnecessary unsafe context
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1217
+  Title: Convert interpolated string to concatenation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1217FadeOut
+  Title: Convert interpolated string to concatenation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1218
+  Title: Simplify code branching
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1220
+  Title: Use pattern matching instead of combination of 'is' operator and cast operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1221
+  Title: Use pattern matching instead of combination of 'as' operator and null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1222
+  Title: Merge preprocessor directives
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1223
+  Title: Mark publicly visible type with DebuggerDisplay attribute
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1224
+  Title: Make method an extension method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1225
+  Title: Make class sealed
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1226
+  Title: Add paragraph to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1227
+  Title: Validate arguments correctly
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1228
+  Title: Unused element in a documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1229
+  Title: Use async/await when necessary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1230
+  Title: Unnecessary explicit use of enumerator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1231
+  Title: Make parameter ref read-only
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1232
+  Title: Order elements in documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1233
+  Title: Use short-circuiting operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1234
+  Title: Duplicate enum value
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1235
+  Title: Optimize method call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1236
+  Title: Use exception filter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1237
+  Title: '[deprecated] Use bit shift operator'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1238
+  Title: 'Avoid nested ?: operators'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1239
+  Title: Use 'for' statement instead of 'while' statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1240
+  Title: Operator is unnecessary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1241
+  Title: Implement non-generic counterpart
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1242
+  Title: Do not pass non-read-only struct by read-only reference
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1243
+  Title: Duplicate word in a comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1244
+  Title: Simplify 'default' expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1246
+  Title: Use element access
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1247
+  Title: Fix documentation comment tag
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1248
+  Title: Normalize null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1249
+  Title: Unnecessary null-forgiving operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1250
+  Title: Use implicit/explicit object creation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1251
+  Title: Remove unnecessary braces from record declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1252
+  Title: Normalize usage of infinite loop
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1253
+  Title: Format documentation comment summary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1254
+  Title: Normalize format of enum flag value
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1255
+  Title: Simplify argument null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1256
+  Title: Invalid argument null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1257
+  Title: Use enum field explicitly
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1258
+  Title: Unnecessary enum flag
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1259
+  Title: Remove empty syntax
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1260
+  Title: Add/remove trailing comma
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1261
+  Title: Resource can be disposed asynchronously
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1262
+  Title: Unnecessary raw string literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1263
+  Title: Invalid reference in a documentation comment
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1264
+  Title: Use 'var' or explicit type
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1265
+  Title: Remove redundant catch block
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1266
+  Title: Use raw string literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1267
+  Title: Use string interpolation instead of 'string.Concat'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1268
+  Title: Simplify numeric comparison
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RemoveUnnecessaryImportsFixable
+  Title: ''
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: ROS0002
+  Title: Analyzer option is obsolete
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: ROS0003
+  Title: Analyzer requires config option to be specified
+  Category: ''
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RS1001
+  Title: Missing diagnostic analyzer attribute
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1002
+  Title: Missing kind argument when registering an analyzer action
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1003
+  Title: Unsupported SymbolKind argument when registering a symbol analyzer action
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1004
+  Title: Recommend adding language support to diagnostic analyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1005
+  Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1006
+  Title: Invalid type argument for DiagnosticAnalyzer's Register method
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1007
+  Title: Provide localizable arguments to diagnostic descriptor constructor
+  Category: MicrosoftCodeAnalysisLocalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RS1008
+  Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1009
+  Title: Only internal implementations of this interface are allowed
+  Category: MicrosoftCodeAnalysisCompatibility
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1010
+  Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support
+  Category: Correctness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1011
+  Title: Use code actions that have a unique EquivalenceKey for FixAll occurrences support
+  Category: Correctness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1012
+  Title: Start action has no registered actions
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1013
+  Title: Start action has no registered non-end actions
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1014
+  Title: Do not ignore values returned by methods on immutable objects
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1015
+  Title: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor
+  Category: MicrosoftCodeAnalysisDocumentation
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1016
+  Title: Code fix providers should provide FixAll support
+  Category: Correctness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1017
+  Title: DiagnosticId for analyzers must be a non-null constant
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1018
+  Title: DiagnosticId for analyzers must be in specified format
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1019
+  Title: DiagnosticId must be unique across analyzers
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1020
+  Title: Category for analyzers must be from the specified values
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1021
+  Title: Invalid entry in analyzer category and diagnostic ID range specification file
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1022
+  Title: Do not use types from Workspaces assembly in an analyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1023
+  Title: Upgrade MSBuildWorkspace
+  Category: Library
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1024
+  Title: Symbols should be compared for equality
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1025
+  Title: Configure generated code analysis
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1026
+  Title: Enable concurrent execution
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1027
+  Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1028
+  Title: Provide non-null 'customTags' value to diagnostic descriptor constructor
+  Category: MicrosoftCodeAnalysisDocumentation
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RS1029
+  Title: Do not use reserved diagnostic IDs
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1030
+  Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1031
+  Title: Define diagnostic title correctly
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1032
+  Title: Define diagnostic message correctly
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1033
+  Title: Define diagnostic description correctly
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1034
+  Title: Prefer 'IsKind' for checking syntax kinds
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1035
+  Title: Do not use APIs banned for analyzers
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1036
+  Title: Specify analyzer banned API enforcement setting
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1037
+  Title: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2000
+  Title: Add analyzer diagnostic IDs to analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2001
+  Title: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2002
+  Title: Do not add removed analyzer diagnostic IDs to unshipped analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2003
+  Title: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2004
+  Title: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2005
+  Title: Remove duplicate entries for diagnostic ID in the same analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2006
+  Title: Remove duplicate entries for diagnostic ID between analyzer releases
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2007
+  Title: Invalid entry in analyzer release file
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2008
+  Title: Enable analyzer release tracking
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S100
+  Title: Methods and properties should be named in PascalCase
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S1006
+  Title: Method overrides should not change parameter defaults
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S101
+  Title: Types should be named in PascalCase
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S103
+  Title: Lines should not be too long
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S104
+  Title: Files should not have too many lines of code
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1048
+  Title: Finalizers should not throw exceptions
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S105
+  Title: Tabulation characters should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S106
+  Title: Standard outputs should not be used directly to log anything
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1066
+  Title: Mergeable "if" statements should be combined
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1067
+  Title: Expressions should not be too complex
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S107
+  Title: Methods should not have too many parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1075
+  Title: URIs should not be hardcoded
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S108
+  Title: Nested blocks of code should not be left empty
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S109
+  Title: Magic numbers should not be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S110
+  Title: Inheritance tree of classes should not be too deep
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1104
+  Title: Fields should not have public accessibility
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1109
+  Title: A close curly brace should be located at the beginning of a line
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1110
+  Title: Redundant pairs of parentheses should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1116
+  Title: Empty statements should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1117
+  Title: Local variables should not shadow class fields or properties
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1118
+  Title: Utility classes should not have public constructors
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S112
+  Title: General or reserved exceptions should never be thrown
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1121
+  Title: Assignments should not be made from within sub-expressions
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1123
+  Title: '"Obsolete" attributes should include explanations'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1125
+  Title: Boolean literals should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1128
+  Title: Unnecessary "using" should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S113
+  Title: Files should end with a newline
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1133
+  Title: Deprecated code should be removed
+  Category: Info Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1134
+  Title: Track uses of "FIXME" tags
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1135
+  Title: Track uses of "TODO" tags
+  Category: Info Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: S1144
+  Title: Unused private types or members should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1147
+  Title: Exit methods should not be called
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1151
+  Title: '"switch case" clauses should not have too many lines of code'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1155
+  Title: '"Any()" should be used to test for emptiness'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1163
+  Title: Exceptions should not be thrown in finally blocks
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1168
+  Title: Empty arrays and collections should be returned instead of null
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1172
+  Title: Unused method parameters should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1185
+  Title: Overriding members should do more than simply call the same member in the base class
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1186
+  Title: Methods should not be empty
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1192
+  Title: String literals should not be duplicated
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1199
+  Title: Nested code blocks should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1200
+  Title: Classes should not be coupled to too many other classes
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1206
+  Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S121
+  Title: Control structures should use curly braces
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1210
+  Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1215
+  Title: '"GC.Collect" should not be called'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S122
+  Title: Statements should be on separate lines
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1226
+  Title: Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1227
+  Title: break statements should not be used except for switch cases
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1244
+  Title: Floating point numbers should not be tested for equality
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S125
+  Title: Sections of code should not be commented out
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S126
+  Title: '"if ... else if" constructs should end with "else" clauses'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1264
+  Title: A "while" loop should be used instead of a "for" loop
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S127
+  Title: '"for" loop stop conditions should be invariant'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1301
+  Title: '"switch" statements should have at least 3 "case" clauses'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1309
+  Title: Track uses of in-source issue suppressions
+  Category: Info Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S131
+  Title: '"switch/Select" statements should contain a "default/Case Else" clauses'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1312
+  Title: Logger fields should be "private static readonly"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1313
+  Title: Using hardcoded IP addresses is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S134
+  Title: Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S138
+  Title: Functions should not have too many lines of code
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1449
+  Title: Culture should be specified for "string" operations
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1450
+  Title: Private fields only used as local variables in methods should become local variables
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1451
+  Title: Track lack of copyright and license headers
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1479
+  Title: '"switch" statements with many "case" clauses should have only one statement'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1481
+  Title: Unused local variables should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1541
+  Title: Methods and properties should not be too complex
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1607
+  Title: Tests should not be ignored
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1643
+  Title: Strings should not be concatenated using '+' in a loop
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1656
+  Title: Variables should not be self-assigned
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1659
+  Title: Multiple variables should not be declared on the same line
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1694
+  Title: An abstract class should have both abstract and concrete methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1696
+  Title: NullReferenceException should not be caught
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1698
+  Title: '"==" should not be used when "Equals" is overridden'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1699
+  Title: Constructors should only call non-overridable methods
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1751
+  Title: Loops with at most one iteration should be refactored
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1764
+  Title: Identical expressions should not be used on both sides of operators
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1821
+  Title: '"switch" statements should not be nested'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1848
+  Title: Objects should not be created to be dropped immediately without being used
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1854
+  Title: Unused assignments should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1858
+  Title: '"ToString()" calls should not be redundant'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1862
+  Title: Related "if/else if" statements should not have the same condition
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1871
+  Title: Two branches in a conditional structure should not have exactly the same implementation
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1905
+  Title: Redundant casts should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1939
+  Title: Inheritance list should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1940
+  Title: Boolean checks should not be inverted
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1944
+  Title: Invalid casts should be avoided
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1994
+  Title: "\"for\" loop increment clauses should modify the loops' counters"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2053
+  Title: Password hashing functions should use an unpredictable salt
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2068
+  Title: Hard-coded credentials are security-sensitive
+  Category: Blocker Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2077
+  Title: Formatting SQL queries is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2092
+  Title: Creating cookies without the "secure" flag is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2094
+  Title: Classes should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2114
+  Title: Collections should not be passed as arguments to their own methods
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2115
+  Title: A secure password should be used when connecting to a database
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2123
+  Title: Values should not be uselessly incremented
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2139
+  Title: Exceptions should be either logged or rethrown but not both
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2148
+  Title: Underscores should be used to make large numbers readable
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2156
+  Title: '"sealed" classes should not have "protected" members'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2166
+  Title: Classes named like "Exception" should extend "Exception" or a subclass
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2178
+  Title: Short-circuit logic should be used in boolean contexts
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2183
+  Title: Integral numbers should not be shifted by zero or more than their number of bits-1
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2184
+  Title: Results of integer division should not be assigned to floating point variables
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2187
+  Title: Test classes should contain at least one test case
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2190
+  Title: Loops and recursions should not be infinite
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2197
+  Title: Modulus results should not be checked for direct equality
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2198
+  Title: Unnecessary mathematical comparisons should not be made
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2201
+  Title: Methods without side effects should not have their return values ignored
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2219
+  Title: Runtime type checking should be simplified
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2221
+  Title: '"Exception" should not be caught'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2222
+  Title: Locks should be released on all paths
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2223
+  Title: Non-constant static fields should not be visible
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2225
+  Title: '"ToString()" method should not return null'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2234
+  Title: Arguments should be passed in the same order as the method parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2245
+  Title: Using pseudorandom number generators (PRNGs) is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2251
+  Title: A "for" loop update clause should move the counter in the right direction
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2252
+  Title: For-loop conditions should be true at least once
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2257
+  Title: Using non-standard cryptographic algorithms is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2259
+  Title: Null pointers should not be dereferenced
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2275
+  Title: Composite format strings should not lead to unexpected behavior at runtime
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2290
+  Title: Field-like events should not be virtual
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2291
+  Title: Overflow checking should not be disabled for "Enumerable.Sum"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2292
+  Title: Trivial properties should be auto-implemented
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2302
+  Title: '"nameof" should be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2306
+  Title: '"async" and "await" should not be used as identifiers'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2325
+  Title: Methods and properties that don't access instance data should be static
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2326
+  Title: Unused type parameters should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2327
+  Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2328
+  Title: '"GetHashCode" should not reference mutable fields'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2330
+  Title: Array covariance should not be used
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2333
+  Title: Redundant modifiers should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2339
+  Title: Public constant members should not be used
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2342
+  Title: Enumeration types should comply with a naming convention
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2344
+  Title: Enumeration type names should not have "Flags" or "Enum" suffixes
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2345
+  Title: Flags enumerations should explicitly initialize all their members
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2346
+  Title: Flags enumerations zero-value members should be named "None"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2357
+  Title: Fields should be private
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2360
+  Title: Optional parameters should not be used
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2365
+  Title: Properties should not make collection or array copies
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2368
+  Title: Public methods should not have multidimensional array parameters
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2372
+  Title: Exceptions should not be thrown from property getters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2376
+  Title: Write-only properties should not be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2386
+  Title: Mutable fields should not be "public static"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2387
+  Title: Child class fields should not shadow parent class fields
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2436
+  Title: Types and methods should not have too many generic parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2437
+  Title: Unnecessary bit operations should not be performed
+  Category: Blocker Code Smell
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: S2445
+  Title: Blocks should be synchronized on read-only fields
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2479
+  Title: Whitespace and control characters in string literals should be explicit
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2486
+  Title: Generic exceptions should not be ignored
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2551
+  Title: Shared resources should not be used for locking
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2583
+  Title: Conditionally executed code should be reachable
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2589
+  Title: Boolean expressions should not be gratuitous
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: true
+- Id: S2612
+  Title: Setting loose file permissions is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2629
+  Title: Logging templates should be constant
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2674
+  Title: The length returned from a stream read should be checked
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2681
+  Title: Multiline blocks should be enclosed in curly braces
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2688
+  Title: '"NaN" should not be used in comparisons'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2692
+  Title: '"IndexOf" checks should not be for positive numbers'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2696
+  Title: Instance members should not write to "static" fields
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2699
+  Title: Tests should include assertions
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2701
+  Title: Literal boolean values should not be used in assertions
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2737
+  Title: '"catch" clauses should do more than rethrow'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2743
+  Title: Static fields should not be used in generic types
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2755
+  Title: XML parsers should not be vulnerable to XXE attacks
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2757
+  Title: Non-existent operators like "=+" should not be used
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2760
+  Title: Sequential tests should not check the same condition
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2761
+  Title: Doubled prefix operators "!!" and "~~" should not be used
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2857
+  Title: SQL keywords should be delimited by whitespace
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2925
+  Title: '"Thread.Sleep" should not be used in tests'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2930
+  Title: '"IDisposables" should be disposed'
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2931
+  Title: Classes with "IDisposable" members should implement "IDisposable"
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2933
+  Title: Fields that are only assigned in the constructor should be "readonly"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2934
+  Title: Property assignments should not be made for "readonly" fields not constrained to reference types
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2952
+  Title: Classes should "Dispose" of members from the classes' own "Dispose" methods
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2953
+  Title: Methods named "Dispose" should implement "IDisposable.Dispose"
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2955
+  Title: Generic parameters not constrained to reference types should not be compared to "null"
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2970
+  Title: Assertions should be complete
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2971
+  Title: LINQ expressions should be simplified
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2995
+  Title: '"Object.ReferenceEquals" should not be used for value types'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2996
+  Title: '"ThreadStatic" fields should not be initialized'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2997
+  Title: '"IDisposables" created in a "using" statement should not be returned'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3005
+  Title: '"ThreadStatic" should not be used on non-static fields'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3010
+  Title: Static fields should not be updated in constructors
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3011
+  Title: Reflection should not be used to increase accessibility of classes, methods, or fields
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3052
+  Title: Members should not be initialized to default values
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3059
+  Title: Types should not have members with visibility set higher than the type's visibility
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3060
+  Title: '"is" should not be used with "this"'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3063
+  Title: '"StringBuilder" data should be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3168
+  Title: '"async" methods should not return "void"'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3169
+  Title: Multiple "OrderBy" calls should not be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3172
+  Title: Delegates should not be subtracted
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3215
+  Title: '"interface" instances should not be cast to concrete types'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3216
+  Title: '"ConfigureAwait(false)" should be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3217
+  Title: '"Explicit" conversions of "foreach" loops should not be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3218
+  Title: Inner class members should not shadow outer class "static" or type members
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3220
+  Title: Method calls should not resolve ambiguously to overloads with "params"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3234
+  Title: '"GC.SuppressFinalize" should not be invoked for types without destructors'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3235
+  Title: Redundant parentheses should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3236
+  Title: Caller information arguments should not be provided explicitly
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3237
+  Title: '"value" contextual keyword should be used'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3240
+  Title: The simplest possible condition syntax should be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3241
+  Title: Methods should not return values that are never used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3242
+  Title: Method parameters should be declared with base types
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3244
+  Title: Anonymous delegates should not be used to unsubscribe from Events
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3246
+  Title: Generic type parameters should be co/contravariant when possible
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3247
+  Title: Duplicate casts should not be made
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3249
+  Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3251
+  Title: Implementations should be provided for "partial" methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3253
+  Title: Constructor and destructor declarations should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3254
+  Title: Default parameter values should not be passed as arguments
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3256
+  Title: '"string.IsNullOrEmpty" should be used'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3257
+  Title: Declarations and initializations should be as concise as possible
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3260
+  Title: Non-derived "private" classes and records should be "sealed"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3261
+  Title: Namespaces should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3262
+  Title: '"params" should be used on overrides'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3263
+  Title: 'Static fields should appear in the order they must be initialized '
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3264
+  Title: Events should be invoked
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3265
+  Title: Non-flags enums should not be used in bitwise operations
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3267
+  Title: Loops should be simplified with "LINQ" expressions
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3329
+  Title: Cipher Block Chaining IVs should be unpredictable
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3330
+  Title: Creating cookies without the "HttpOnly" flag is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3343
+  Title: Caller information parameters should come at the end of the parameter list
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3346
+  Title: Expressions used in "Debug.Assert" should not produce side effects
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3353
+  Title: Unchanged variables should be marked as "const"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3358
+  Title: Ternary operators should not be nested
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3363
+  Title: Date and time should not be used as a type for primary keys
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3366
+  Title: '"this" should not be exposed from constructors'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3376
+  Title: Attribute, EventArgs, and Exception type names should end with the type being extended
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3397
+  Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3398
+  Title: '"private" methods called only by inner classes should be moved to those classes'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3400
+  Title: Methods should not return constants
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3415
+  Title: Assertion arguments should be passed in the correct order
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3416
+  Title: Loggers should be named for their enclosing types
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3427
+  Title: Method overloads with default parameter values should not overlap
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3431
+  Title: '"[ExpectedException]" should not be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3433
+  Title: Test method signatures should be correct
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3440
+  Title: Variables should not be checked against the values they're about to be assigned
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3441
+  Title: Redundant property names should be omitted in anonymous classes
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3442
+  Title: '"abstract" classes should not have "public" constructors'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3443
+  Title: Type should not be examined on "System.Type" instances
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3444
+  Title: Interfaces should not simply inherit from base interfaces with colliding members
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3445
+  Title: Exceptions should not be explicitly rethrown
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3447
+  Title: '"[Optional]" should not be used on "ref" or "out" parameters'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3449
+  Title: Right operands of shift operators should be integers
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3450
+  Title: Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3451
+  Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3453
+  Title: Classes should not have only "private" constructors
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3456
+  Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3457
+  Title: Composite format strings should be used correctly
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3458
+  Title: Empty "case" clauses that fall through to the "default" should be omitted
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3459
+  Title: Unassigned members should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3464
+  Title: Type inheritance should not be recursive
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3466
+  Title: Optional parameters should be passed to "base" calls
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3532
+  Title: Empty "default" clauses should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3597
+  Title: '"ServiceContract" and "OperationContract" attributes should be used together'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3598
+  Title: One-way "OperationContract" methods should have "void" return type
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3600
+  Title: '"params" should not be introduced on overrides'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3603
+  Title: 'Methods with "Pure" attribute should return a value '
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3604
+  Title: Member initializer values should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3610
+  Title: Nullable type comparison should not be redundant
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3626
+  Title: Jump statements should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3655
+  Title: Empty nullable value should not be accessed
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3717
+  Title: Track use of "NotImplementedException"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3776
+  Title: Cognitive Complexity of methods should not be too high
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3869
+  Title: '"SafeHandle.DangerousGetHandle" should not be called'
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3871
+  Title: Exception types should be "public"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3872
+  Title: Parameter names should not duplicate the names of their methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3874
+  Title: '"out" and "ref" parameters should not be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3875
+  Title: '"operator==" should not be overloaded on reference types'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3876
+  Title: Strings or integral types should be used for indexers
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3877
+  Title: Exceptions should not be thrown from unexpected methods
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3878
+  Title: Arrays should not be created for params parameters
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3880
+  Title: Finalizers should not be empty
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3881
+  Title: '"IDisposable" should be implemented correctly'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3884
+  Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used'
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3885
+  Title: '"Assembly.Load" should be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3887
+  Title: Mutable, non-private fields should not be "readonly"
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3889
+  Title: '"Thread.Resume" and "Thread.Suspend" should not be used'
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3897
+  Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3898
+  Title: Value types should implement "IEquatable<T>"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3900
+  Title: Arguments of public methods should be validated against null
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S3902
+  Title: '"Assembly.GetExecutingAssembly" should not be called'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3903
+  Title: Types should be defined in named namespaces
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3904
+  Title: Assemblies should have version information
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3906
+  Title: Event Handlers should have the correct signature
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3908
+  Title: Generic event handlers should be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3909
+  Title: Collections should implement the generic interface
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3923
+  Title: All branches in a conditional structure should not have exactly the same implementation
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3925
+  Title: '"ISerializable" should be implemented correctly'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3926
+  Title: Deserialization methods should be provided for "OptionalField" members
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3927
+  Title: Serialization event handlers should be implemented correctly
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3928
+  Title: 'Parameter names used into ArgumentException constructors should match an existing one '
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3937
+  Title: Number patterns should be regular
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3949
+  Title: Calculations should not overflow
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3956
+  Title: '"Generic.List" instances should not be part of public APIs'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3962
+  Title: '"static readonly" constants should be "const" instead'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3963
+  Title: '"static" fields should be initialized inline'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3966
+  Title: Objects should not be disposed more than once
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3967
+  Title: Multidimensional arrays should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3971
+  Title: '"GC.SuppressFinalize" should not be called'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3972
+  Title: Conditionals should start on new lines
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3973
+  Title: A conditionally executed single line should be denoted by indentation
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3981
+  Title: Collection sizes and array length comparisons should make sense
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3984
+  Title: Exceptions should not be created without being thrown
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3990
+  Title: Assemblies should be marked as CLS compliant
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3992
+  Title: Assemblies should explicitly specify COM visibility
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3993
+  Title: Custom attributes should be marked with "System.AttributeUsageAttribute"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3994
+  Title: URI Parameters should not be strings
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3995
+  Title: URI return values should not be strings
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3996
+  Title: URI properties should not be strings
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3997
+  Title: String URI overloads should call "System.Uri" overloads
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3998
+  Title: Threads should not lock on objects with weak identity
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4000
+  Title: Pointers to unmanaged memory should not be visible
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4002
+  Title: Disposable types should declare finalizers
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4004
+  Title: Collection properties should be readonly
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4005
+  Title: '"System.Uri" arguments should be used instead of strings'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4015
+  Title: Inherited member visibility should not be decreased
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4016
+  Title: Enumeration members should not be named "Reserved"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4017
+  Title: Method signatures should not contain nested generic types
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4018
+  Title: All type parameters should be used in the parameter list to enable type inference
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4019
+  Title: Base class methods should not be hidden
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4022
+  Title: Enumerations should have "Int32" storage
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4023
+  Title: Interfaces should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4025
+  Title: Child class fields should not differ from parent class fields only by capitalization
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4026
+  Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4027
+  Title: Exceptions should provide standard constructors
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4035
+  Title: Classes implementing "IEquatable<T>" should be sealed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4036
+  Title: Searching OS commands in PATH is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4039
+  Title: Interface methods should be callable by derived types
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4040
+  Title: Strings should be normalized to uppercase
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4041
+  Title: Type names should not match namespaces
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4047
+  Title: Generics should be used when appropriate
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4049
+  Title: Properties should be preferred
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4050
+  Title: Operators should be overloaded consistently
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4052
+  Title: Types should not extend outdated base types
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4055
+  Title: Literals should not be passed as localized parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4056
+  Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4057
+  Title: Locales should be set for data types
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4058
+  Title: Overloads with a "StringComparison" parameter should be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4059
+  Title: Property names should not match get methods
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4060
+  Title: Non-abstract attributes should be sealed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4061
+  Title: '"params" should be used instead of "varargs"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4069
+  Title: Operator overloads should have named alternatives
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4070
+  Title: Non-flags enums should not be marked with "FlagsAttribute"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4136
+  Title: Method overloads should be grouped together
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4143
+  Title: Collection elements should not be replaced unconditionally
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4144
+  Title: Methods should not have identical implementations
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4158
+  Title: Empty collections should not be accessed or iterated
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4159
+  Title: Classes should implement their "ExportAttribute" interfaces
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4200
+  Title: Native methods should be wrapped
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4201
+  Title: Null checks should not be combined with "is" operator checks
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4210
+  Title: Windows Forms entry points should be marked with STAThread
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4211
+  Title: Members should not have conflicting transparency annotations
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4212
+  Title: Serialization constructors should be secured
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4214
+  Title: '"P/Invoke" methods should not be visible'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4220
+  Title: Events should have proper arguments
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4225
+  Title: Extension methods should not extend "object"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4226
+  Title: Extensions should be in separate namespaces
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4260
+  Title: '"ConstructorArgument" parameters should exist in constructors'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4261
+  Title: Methods should be named according to their synchronicities
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4275
+  Title: Getters and setters should access the expected fields
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4277
+  Title: '"Shared" parts should not be created with "new"'
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4347
+  Title: Secure random number generators should not output predictable values
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4423
+  Title: Weak SSL/TLS protocols should not be used
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4426
+  Title: Cryptographic keys should be robust
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4428
+  Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4433
+  Title: LDAP connections should be authenticated
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4456
+  Title: Parameter validation in yielding methods should be wrapped
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4457
+  Title: Parameter validation in "async"/"await" methods should be wrapped
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4462
+  Title: Calls to "async" methods should not be blocking
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S4487
+  Title: Unread "private" fields should be removed
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4502
+  Title: Disabling CSRF protections is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4507
+  Title: Delivering code in production with debug features activated is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4524
+  Title: '"default" clauses should be first or last'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4545
+  Title: '"DebuggerDisplayAttribute" strings should reference existing members'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4581
+  Title: '"new Guid()" should not be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4583
+  Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4586
+  Title: Non-async "Task/Task<T>" methods should not return null
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4635
+  Title: Start index should be used instead of calling Substring
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4663
+  Title: Comments should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4790
+  Title: Using weak hashing algorithms is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4792
+  Title: Configuring loggers is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4830
+  Title: Server certificates should be verified during SSL/TLS connections
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5034
+  Title: '"ValueTask" should be consumed correctly'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5042
+  Title: Expanding archive files without controlling resource consumption is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5122
+  Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5332
+  Title: Using clear-text protocols is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5344
+  Title: Passwords should not be stored in plaintext or with a fast hashing algorithm
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5443
+  Title: Using publicly writable directories is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5445
+  Title: Insecure temporary file creation methods should not be used
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5542
+  Title: Encryption algorithms should be used with secure mode and padding scheme
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5547
+  Title: Cipher algorithms should be robust
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5659
+  Title: JWT should be signed and verified with strong cipher algorithms
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5693
+  Title: Allowing requests with excessive content length is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5753
+  Title: Disabling ASP.NET "Request Validation" feature is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5766
+  Title: Deserializing objects without performing data validation is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5773
+  Title: Types allowed to be deserialized should be restricted
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5856
+  Title: Regular expressions should be syntactically valid
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6354
+  Title: Use a testable date/time provider
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6377
+  Title: XML signatures should be validated securely
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6419
+  Title: Azure Functions should be stateless
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6420
+  Title: Client instances should not be recreated on each Azure Function invocation
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6421
+  Title: Azure Functions should use Structured Error Handling
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6422
+  Title: Calls to "async" methods should not be blocking in Azure Functions
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6423
+  Title: Azure Functions should log all failures
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6424
+  Title: Interfaces for durable entities should satisfy the restrictions
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6444
+  Title: Not specifying a timeout for regular expressions is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6507
+  Title: Blocks should not be synchronized on local variables
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S6513
+  Title: '"ExcludeFromCodeCoverage" attributes should include a justification'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6561
+  Title: Avoid using "DateTime.Now" for benchmarking or timing operations
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6562
+  Title: Always set the "DateTimeKind" when creating new "DateTime" instances
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6563
+  Title: Use UTC when recording DateTime instants
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6566
+  Title: Use "DateTimeOffset" instead of "DateTime"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6575
+  Title: Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6580
+  Title: Use a format provider when parsing date and time
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6585
+  Title: Don't hardcode the format when turning dates and times to strings
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6588
+  Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6602
+  Title: '"Find" method should be used instead of the "FirstOrDefault" extension'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6603
+  Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6605
+  Title: Collection-specific "Exists" method should be used instead of the "Any" extension
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6607
+  Title: The collection should be filtered before sorting by using "Where" before "OrderBy"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6608
+  Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6609
+  Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6610
+  Title: '"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6612
+  Title: The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6613
+  Title: '"First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6617
+  Title: '"Contains" should be used instead of "Any" for simple equality checks'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6618
+  Title: '"string.Create" should be used instead of "FormattableString"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6640
+  Title: Using unsafe code blocks is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6664
+  Title: The code block contains too many logging calls
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6667
+  Title: Logging in a catch clause should pass the caught exception as a parameter.
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6668
+  Title: Logging arguments should be passed to the correct parameter
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6669
+  Title: Logger field or property name should comply with a naming convention
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6670
+  Title: '"Trace.Write" and "Trace.WriteLine" should not be used'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6672
+  Title: Generic logger injection should match enclosing type
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6673
+  Title: Log message template placeholders should be in the right order
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6674
+  Title: Log message template should be syntactically correct
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6675
+  Title: '"Trace.WriteLineIf" should not be used with "TraceSwitch" levels'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6677
+  Title: Message template placeholders should be unique
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6678
+  Title: Use PascalCase for named placeholders
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6781
+  Title: JWT secret keys should not be disclosed
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6797
+  Title: Blazor query parameter type should be supported
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6798
+  Title: '[JSInvokable] attribute should only be used on public methods'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6800
+  Title: Component parameter type should match the route parameter type constraint
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6802
+  Title: Using lambda expressions in loops should be avoided in Blazor markup section
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6803
+  Title: Parameters with SupplyParameterFromQuery attribute should be used only in routable components
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S6930
+  Title: Backslash should be avoided in route templates
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6931
+  Title: ASP.NET controller actions should not have a route template starting with "/"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6932
+  Title: Use model binding instead of reading raw request data
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6934
+  Title: A Route attribute should be added to the controller when a route template is specified at the action level
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6960
+  Title: Controllers should not have mixed responsibilities
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6961
+  Title: API Controllers should derive from ControllerBase instead of Controller
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6962
+  Title: You should pool HTTP connections with HttpClientFactory
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6964
+  Title: Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6965
+  Title: REST API actions should be annotated with an HTTP verb attribute
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6966
+  Title: Awaitable method should be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6967
+  Title: ModelState.IsValid should be called in controller actions
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6968
+  Title: Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S818
+  Title: Literal suffixes should be upper case
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S881
+  Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S907
+  Title: '"goto" statement should not be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S927
+  Title: Parameter names should match base declaration and other partial definitions
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S9999-cpd
+  Title: Copy-paste token calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-log
+  Title: Log generator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-metadata
+  Title: File metadata generator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-metrics
+  Title: Metrics calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-symbolRef
+  Title: Symbol reference calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-token-type
+  Title: Token type calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-warning
+  Title: Analysis Warning generator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: SA0001
+  Title: XML comment analysis disabled
+  Category: StyleCop.CSharp.SpecialRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA0002
+  Title: Invalid settings file
+  Category: StyleCop.CSharp.SpecialRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1000
+  Title: Keywords should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1001
+  Title: Commas should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1002
+  Title: Semicolons should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1003
+  Title: Symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1004
+  Title: Documentation lines should begin with single space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1005
+  Title: Single line comments should begin with single space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1006
+  Title: Preprocessor keywords should not be preceded by space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1007
+  Title: Operator keyword should be followed by space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1008
+  Title: Opening parenthesis should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1009
+  Title: Closing parenthesis should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1010
+  Title: Opening square brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1011
+  Title: Closing square brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1012
+  Title: Opening braces should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1013
+  Title: Closing braces should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1014
+  Title: Opening generic brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1015
+  Title: Closing generic brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1016
+  Title: Opening attribute brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1017
+  Title: Closing attribute brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1018
+  Title: Nullable type symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1019
+  Title: Member access symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1020
+  Title: Increment decrement symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1021
+  Title: Negative signs should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1022
+  Title: Positive signs should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1023
+  Title: Dereference and access of symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1024
+  Title: Colons Should Be Spaced Correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1025
+  Title: Code should not contain multiple whitespace in a row
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1026
+  Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1027
+  Title: Use tabs correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1028
+  Title: Code should not contain trailing whitespace
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1100
+  Title: Do not prefix calls with base unless local implementation exists
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1101
+  Title: Prefix local calls with this
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1102
+  Title: Query clause should follow previous clause
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1103
+  Title: Query clauses should be on separate lines or all on one line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1104
+  Title: Query clause should begin on new line when previous clause spans multiple lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1105
+  Title: Query clauses spanning multiple lines should begin on own line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1106
+  Title: Code should not contain empty statements
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1107
+  Title: Code should not contain multiple statements on one line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1108
+  Title: Block statements should not contain embedded comments
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1109
+  Title: Block statements should not contain embedded regions
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1110
+  Title: Opening parenthesis or bracket should be on declaration line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1111
+  Title: Closing parenthesis should be on line of last parameter
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1112
+  Title: Closing parenthesis should be on line of opening parenthesis
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1113
+  Title: Comma should be on the same line as previous parameter
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1114
+  Title: Parameter list should follow declaration
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1115
+  Title: Parameter should follow comma
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1116
+  Title: Split parameters should start on line after declaration
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1117
+  Title: Parameters should be on same line or separate lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1118
+  Title: Parameter should not span multiple lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1119
+  Title: Statement should not use unnecessary parenthesis
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1119_p
+  Title: Statement should not use unnecessary parenthesis
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SA1120
+  Title: Comments should contain text
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1121
+  Title: Use built-in type alias
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1122
+  Title: Use string.Empty for empty strings
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1123
+  Title: Do not place regions within elements
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1124
+  Title: Do not use regions
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1125
+  Title: Use shorthand for nullable types
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1126
+  Title: Prefix calls correctly
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1127
+  Title: Generic type constraints should be on their own line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1128
+  Title: Put constructor initializers on their own line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1129
+  Title: Do not use default value type constructor
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1130
+  Title: Use lambda syntax
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1131
+  Title: Use readable conditions
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1132
+  Title: Do not combine fields
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1133
+  Title: Do not combine attributes
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1134
+  Title: Attributes should not share line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1135
+  Title: Using directives should be qualified
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1136
+  Title: Enum values should be on separate lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1137
+  Title: Elements should have the same indentation
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1139
+  Title: Use literal suffix notation instead of casting
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1141
+  Title: Use tuple syntax
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1142
+  Title: Refer to tuple fields by name
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1200
+  Title: Using directives should be placed correctly
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1201
+  Title: Elements should appear in the correct order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1202
+  Title: Elements should be ordered by access
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1203
+  Title: Constants should appear before fields
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1204
+  Title: Static elements should appear before instance elements
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1205
+  Title: Partial elements should declare access
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1206
+  Title: Declaration keywords should follow order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1207
+  Title: Protected should come before internal
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1208
+  Title: System using directives should be placed before other using directives
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1209
+  Title: Using alias directives should be placed after other using directives
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1210
+  Title: Using directives should be ordered alphabetically by namespace
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1211
+  Title: Using alias directives should be ordered alphabetically by alias name
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1212
+  Title: Property accessors should follow order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1213
+  Title: Event accessors should follow order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1214
+  Title: Readonly fields should appear before non-readonly fields
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1216
+  Title: Using static directives should be placed at the correct location
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1217
+  Title: Using static directives should be ordered alphabetically
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1300
+  Title: Element should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1301
+  Title: Element should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1302
+  Title: Interface names should begin with I
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1303
+  Title: Const field names should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1304
+  Title: Non-private readonly fields should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1305
+  Title: Field names should not use Hungarian notation
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1306
+  Title: Field names should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1307
+  Title: Accessible fields should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1308
+  Title: Variable names should not be prefixed
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1309
+  Title: Field names should not begin with underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - None
+  IsEverSuppressed: true
+- Id: SA1310
+  Title: Field names should not contain underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1311
+  Title: Static readonly fields should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1312
+  Title: Variable names should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1313
+  Title: Parameter names should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1314
+  Title: Type parameter names should begin with T
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1316
+  Title: Tuple element names should use correct casing
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1400
+  Title: Access modifier should be declared
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1401
+  Title: Fields should be private
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1402
+  Title: File may only contain a single type
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1403
+  Title: File may only contain a single namespace
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1404
+  Title: Code analysis suppression should have justification
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1405
+  Title: Debug.Assert should provide message text
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1406
+  Title: Debug.Fail should provide message text
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1407
+  Title: Arithmetic expressions should declare precedence
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1408
+  Title: Conditional expressions should declare precedence
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1409
+  Title: Remove unnecessary code
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1410
+  Title: Remove delegate parenthesis when possible
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1411
+  Title: Attribute constructor should not use unnecessary parenthesis
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1412
+  Title: Store files as UTF-8 with byte order mark
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1413
+  Title: Use trailing comma in multi-line initializers
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1414
+  Title: Tuple types in signatures should have element names
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1500
+  Title: Braces for multi-line statements should not share line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1501
+  Title: Statement should not be on a single line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1502
+  Title: Element should not be on a single line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1503
+  Title: Braces should not be omitted
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: true
+- Id: SA1504
+  Title: All accessors should be single-line or multi-line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1505
+  Title: Opening braces should not be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1506
+  Title: Element documentation headers should not be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1507
+  Title: Code should not contain multiple blank lines in a row
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1508
+  Title: Closing braces should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1509
+  Title: Opening braces should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1510
+  Title: Chained statement blocks should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1511
+  Title: While-do footer should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1512
+  Title: Single-line comments should not be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1513
+  Title: Closing brace should be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1514
+  Title: Element documentation header should be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1515
+  Title: Single-line comment should be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1516
+  Title: Elements should be separated by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1517
+  Title: Code should not contain blank lines at start of file
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1518
+  Title: Use line endings correctly at end of file
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1519
+  Title: Braces should not be omitted from multi-line child statement
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1520
+  Title: Use braces consistently
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1600
+  Title: Elements should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1601
+  Title: Partial elements should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1602
+  Title: Enumeration items should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1603
+  Title: Documentation should contain valid XML
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1604
+  Title: Element documentation should have summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1605
+  Title: Partial element documentation should have summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1606
+  Title: Element documentation should have summary text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1607
+  Title: Partial element documentation should have summary text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1608
+  Title: Element documentation should not have default summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1609
+  Title: Property documentation should have value
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1610
+  Title: Property documentation should have value text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1611
+  Title: Element parameters should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1612
+  Title: Element parameter documentation should match element parameters
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1613
+  Title: Element parameter documentation should declare parameter name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1614
+  Title: Element parameter documentation should have text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1615
+  Title: Element return value should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1616
+  Title: Element return value documentation should have text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1617
+  Title: Void return value should not be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1618
+  Title: Generic type parameters should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1619
+  Title: Generic type parameters should be documented partial class
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1620
+  Title: Generic type parameter documentation should match type parameters
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1621
+  Title: Generic type parameter documentation should declare parameter name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1622
+  Title: Generic type parameter documentation should have text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1623
+  Title: Property summary documentation should match accessors
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1624
+  Title: Property summary documentation should omit accessor with restricted access
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1625
+  Title: Element documentation should not be copied and pasted
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1626
+  Title: Single-line comments should not use documentation style slashes
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1627
+  Title: Documentation text should not be empty
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1628
+  Title: Documentation text should begin with a capital letter
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1629
+  Title: Documentation text should end with a period
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1630
+  Title: Documentation text should contain whitespace
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1631
+  Title: Documentation should meet character percentage
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1632
+  Title: Documentation text should meet minimum character length
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1633
+  Title: File should have header
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1634
+  Title: File header should show copyright
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1635
+  Title: File header should have copyright text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1636
+  Title: File header copyright text should match
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1637
+  Title: File header should contain file name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1638
+  Title: File header file name documentation should match file name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1639
+  Title: File header should have summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: SA1640
+  Title: File header should have valid company text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1641
+  Title: File header company name text should match
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1642
+  Title: Constructor summary documentation should begin with standard text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1643
+  Title: Destructor summary documentation should begin with standard text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1644
+  Title: Documentation headers should not contain blank lines
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1645
+  Title: Included documentation file does not exist
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1646
+  Title: Included documentation XPath does not exist
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1647
+  Title: Include node does not contain valid file and path
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1648
+  Title: inheritdoc should be used with inheriting class
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1649
+  Title: File name should match first type name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1650
+  Title: Element documentation should be spelled correctly
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1651
+  Title: Do not use placeholder elements
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SX1101
+  Title: Do not prefix local calls with 'this.'
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SX1309
+  Title: Field names should begin with underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SX1309S
+  Title: Static field names should begin with underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: VSTHRD001
+  Title: Avoid legacy thread switching APIs
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD002
+  Title: Avoid problematic synchronous waits
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD003
+  Title: Avoid awaiting foreign Tasks
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD004
+  Title: Await SwitchToMainThreadAsync
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD010
+  Title: Invoke single-threaded types on Main thread
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD011
+  Title: Use AsyncLazy<T>
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD012
+  Title: Provide JoinableTaskFactory where allowed
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD100
+  Title: Avoid async void methods
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD101
+  Title: Avoid unsupported async delegates
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD102
+  Title: Implement internal logic asynchronously
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD103
+  Title: Call async methods when in an async method
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD104
+  Title: Offer async methods
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD105
+  Title: Avoid method overloads that assume TaskScheduler.Current
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD106
+  Title: Use InvokeAsync to raise async events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD107
+  Title: Await Task within using expression
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD108
+  Title: Assert thread affinity unconditionally
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD109
+  Title: Switch instead of assert in async methods
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD110
+  Title: Observe result of async calls
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD111
+  Title: Use ConfigureAwait(bool)
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: VSTHRD112
+  Title: Implement System.IAsyncDisposable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD113
+  Title: Check for System.IAsyncDisposable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD114
+  Title: Avoid returning a null Task
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD200
+  Title: Use "Async" suffix for async methods
+  Category: Style
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: IDE0028
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false

--- a/src/tools/PerfDiff/SquiggleCop.Baseline.yaml
+++ b/src/tools/PerfDiff/SquiggleCop.Baseline.yaml
@@ -125,7 +125,7 @@
 - {Id: CA1845, Title: Use span-based 'string.Concat', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: CA1846, Title: Prefer 'AsSpan' over 'Substring', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: CA1847, Title: Use char literal for a single character lookup, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: CA1848, Title: Use the LoggerMessage delegates, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1848, Title: Use the LoggerMessage delegates, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: CA1849, Title: Call async methods when in an async method, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: CA1850, Title: Prefer static 'HashData' method over 'ComputeHash', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: CA1851, Title: Possible multiple enumerations of 'IEnumerable' collection, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
@@ -137,7 +137,7 @@
 - {Id: CA1857, Title: A constant is expected for the parameter, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: CA1858, Title: Use 'StartsWith' instead of 'IndexOf', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: CA1859, Title: Use concrete types when possible for improved performance, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: CA1860, Title: Avoid using 'Enumerable.Any()' extension method, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1860, Title: Avoid using 'Enumerable.Any()' extension method, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: true}
 - {Id: CA1861, Title: Avoid constant arrays as arguments, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: CA1862, Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: CA1863, Title: Use 'CompositeFormat', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
@@ -169,7 +169,7 @@
 - {Id: CA2119, Title: Seal methods that satisfy private interfaces, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: CA2153, Title: Do Not Catch Corrupted State Exceptions, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: CA2200, Title: Rethrow to preserve stack details, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: CA2201, Title: Do not raise reserved exception types, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2201, Title: Do not raise reserved exception types, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: true}
 - {Id: CA2207, Title: Initialize value type static fields inline, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: CA2208, Title: Instantiate argument exceptions correctly, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: CA2211, Title: Non-constant fields should not be visible, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -199,7 +199,7 @@
 - {Id: CA2251, Title: Use 'string.Equals', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: CA2252, Title: This API requires opting into preview features, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: CA2253, Title: Named placeholders should not be numeric values, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: CA2254, Title: Template should be a static expression, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2254, Title: Template should be a static expression, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: CA2255, Title: The 'ModuleInitializer' attribute should not be used in libraries, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: CA2256, Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: CA2257, Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static', Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -314,27 +314,26 @@
 - {Id: EM0105, Title: Duplicate Case Type, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: EnableGenerateDocumentationFile, Title: Set MSBuild property 'GenerateDocumentationFile' to 'true', Category: Style, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: IDE0004, Title: Remove Unnecessary Cast, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
-- {Id: IDE0005, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0005, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0005_gen, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0007, Title: Use implicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0008, Title: Use explicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0008, Title: Use explicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: false}
 - {Id: IDE0009, Title: Member access should be qualified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0010, Title: Add missing cases, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0011, Title: Add braces, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0016, Title: Use 'throw' expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0017, Title: Simplify object initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0017, Title: Simplify object initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: false}
 - {Id: IDE0018, Title: Inline variable declaration, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0019, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0020, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0021, Title: Use expression body for constructor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0022, Title: Use expression body for method, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0022, Title: Use expression body for method, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: false}
 - {Id: IDE0023, Title: Use expression body for conversion operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0024, Title: Use expression body for operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0025, Title: Use expression body for property, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0026, Title: Use expression body for indexer, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0027, Title: Use expression body for accessor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0028, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0028, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0028, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: true}
 - {Id: IDE0029, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0030, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0031, Title: Use null propagation, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -351,7 +350,7 @@
 - {Id: IDE0043, Title: Invalid format string, Category: Compiler, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0044, Title: Add readonly modifier, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0045, Title: Convert to conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0046, Title: Convert to conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0046, Title: Convert to conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: false}
 - {Id: IDE0047, Title: Remove unnecessary parentheses, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0048, Title: Add parentheses for clarity, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0051, Title: Remove unused private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -389,7 +388,7 @@
 - {Id: IDE0130, Title: Namespace does not match folder structure, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0150, Title: Prefer 'null' check over type check, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0160, Title: Convert to block scoped namespace, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0161, Title: Convert to file-scoped namespace, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0161, Title: Convert to file-scoped namespace, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: false}
 - {Id: IDE0170, Title: Property pattern can be simplified, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0180, Title: Use tuple to swap values, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0200, Title: Remove unnecessary lambda expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -404,13 +403,13 @@
 - {Id: IDE0260, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0270, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0280, Title: Use 'nameof', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
-- {Id: IDE0290, Title: Use primary constructor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0300, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0301, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0290, Title: Use primary constructor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: false}
+- {Id: IDE0300, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: false}
+- {Id: IDE0301, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: false}
 - {Id: IDE0302, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0303, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0304, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0305, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0305, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: false}
 - {Id: IDE1005, Title: Delegate invocation can be simplified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE1006, Title: Naming Styles, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE2000, Title: Avoid multiple blank lines, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -421,7 +420,7 @@
 - {Id: IDE2005, Title: Blank line not allowed after conditional expression token, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE2006, Title: Blank line not allowed after arrow expression clause token, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0001, Title: StringComparison is missing, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: MA0002, Title: IEqualityComparer<string> or IComparer<string> is missing, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0002, Title: IEqualityComparer<string> or IComparer<string> is missing, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: MA0003, Title: Add parameter name to improve readability, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0004, Title: Use Task.ConfigureAwait, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0005, Title: Use Array.Empty<T>(), Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -463,13 +462,13 @@
 - {Id: MA0042, Title: Do not use blocking calls in an async method, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0043, Title: Use nameof operator in ArgumentException, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0044, Title: Remove useless ToString call, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: MA0045, Title: Do not use blocking calls in a sync method (need to make calling method async), Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0045, Title: Do not use blocking calls in a sync method (need to make calling method async), Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: MA0046, Title: Use EventHandler<T> to declare events, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0047, Title: Declare types in namespaces, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0048, Title: File name must match type name, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: MA0049, Title: Type name should not match containing namespace, Category: Design, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0049, Title: Type name should not match containing namespace, Category: Design, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: MA0050, Title: Validate arguments correctly in iterator methods, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: MA0051, Title: Method is too long, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: MA0051, Title: Method is too long, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: MA0052, Title: Replace constant Enum.ToString with nameof, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0053, Title: Make class sealed, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0054, Title: Embed the caught exception as innerException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -489,12 +488,12 @@
 - {Id: MA0068, Title: Invalid parameter name for nullable attribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0069, Title: Non-constant static fields should not be visible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0070, Title: Obsolete attributes should include explanations, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: MA0071, Title: Avoid using redundant else, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0071, Title: Avoid using redundant else, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: true}
 - {Id: MA0072, Title: Do not throw from a finally block, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0073, Title: Avoid comparison with bool constant, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0074, Title: Avoid implicit culture-sensitive methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0075, Title: Do not use implicit culture-sensitive ToString, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: MA0076, Title: Do not use implicit culture-sensitive ToString in interpolated strings, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0076, Title: Do not use implicit culture-sensitive ToString in interpolated strings, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: true}
 - {Id: MA0077, Title: A class that provides Equals(T) should implement IEquatable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: MA0078, Title: Use 'Cast' instead of 'Select' to cast, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0079, Title: Forward the CancellationToken using .WithCancellation(), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -530,7 +529,7 @@
 - {Id: MA0109, Title: Consider adding an overload with a Span<T> or Memory<T>, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: MA0110, Title: Use the Regex source generator, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0111, Title: Use string.Create instead of FormattableString, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: MA0112, Title: Use 'Count > 0' instead of 'Any()', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0112, Title: Use 'Count > 0' instead of 'Any()', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: MA0113, Title: Use DateTime.UnixEpoch, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0114, Title: Use DateTimeOffset.UnixEpoch, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: MA0115, Title: Unknown component parameter, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -605,8 +604,8 @@
 - {Id: RCS1020, Title: 'Simplify Nullable<T> to T?', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1021, Title: Convert lambda expression body to expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1021FadeOut, Title: Convert lambda expression body to expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: RCS1031, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
-- {Id: RCS1031FadeOut, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1031, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1031FadeOut, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1032, Title: Remove redundant parentheses, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1032FadeOut, Title: Remove redundant parentheses, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1033, Title: Remove redundant boolean literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -690,8 +689,8 @@
 - {Id: RCS1114FadeOut, Title: Remove redundant delegate creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1118, Title: Mark local variable as const, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1123, Title: Add parentheses when necessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: RCS1124, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: RCS1124FadeOut, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1124, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1124FadeOut, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: RCS1126, Title: Add braces to if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: RCS1128, Title: Use coalesce expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1129, Title: Remove redundant field initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
@@ -719,7 +718,7 @@
 - {Id: RCS1160, Title: Abstract type should not have public constructors, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1161, Title: Enum should declare explicit values, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: RCS1162, Title: Avoid chain of assignments, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
-- {Id: RCS1163, Title: Unused parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1163, Title: Unused parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: true}
 - {Id: RCS1164, Title: Unused type parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1165, Title: Unconstrained type parameter checked for null, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: RCS1166, Title: Value type object is never equal to null, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -744,7 +743,7 @@
 - {Id: RCS1189, Title: Add or remove region name, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: RCS1190, Title: Join string expressions, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1191, Title: Declare enum value as combination of names, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: RCS1192, Title: Unnecessary usage of verbatim string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1192, Title: Unnecessary usage of verbatim string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note, None], IsEverSuppressed: true}
 - {Id: RCS1193, Title: Overriding member should not change 'params' modifier, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RCS1194, Title: Implement exception constructors, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RCS1195, Title: Use ^ operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -753,7 +752,7 @@
 - {Id: RCS1198, Title: Avoid unnecessary boxing of value type, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: RCS1199, Title: Unnecessary null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1200, Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: RCS1201, Title: Use method chaining, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1201, Title: Use method chaining, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: RCS1202, Title: Avoid NullReferenceException, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1203, Title: Use AttributeUsageAttribute, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RCS1204, Title: Use EventArgs.Empty, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -771,8 +770,8 @@
 - {Id: RCS1214FadeOut, Title: Unnecessary interpolated string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1215, Title: Expression is always equal to true/false, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RCS1216, Title: Unnecessary unsafe context, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: RCS1217, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: RCS1217FadeOut, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1217, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1217FadeOut, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: RCS1218, Title: Simplify code branching, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1220, Title: Use pattern matching instead of combination of 'is' operator and cast operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1221, Title: Use pattern matching instead of combination of 'as' operator and null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -785,7 +784,7 @@
 - {Id: RCS1228, Title: Unused element in a documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1229, Title: Use async/await when necessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1230, Title: Unnecessary explicit use of enumerator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: RCS1231, Title: Make parameter ref read-only, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1231, Title: Make parameter ref read-only, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
 - {Id: RCS1232, Title: Order elements in documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1233, Title: Use short-circuiting operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1234, Title: Duplicate enum value, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -831,7 +830,7 @@
 - {Id: RS1004, Title: Recommend adding language support to diagnostic analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS1005, Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS1006, Title: Invalid type argument for DiagnosticAnalyzer's Register method, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: RS1007, Title: Provide localizable arguments to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisLocalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RS1007, Title: Provide localizable arguments to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisLocalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
 - {Id: RS1008, Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS1009, Title: Only internal implementations of this interface are allowed, Category: MicrosoftCodeAnalysisCompatibility, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS1010, Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -852,7 +851,7 @@
 - {Id: RS1025, Title: Configure generated code analysis, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS1026, Title: Enable concurrent execution, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS1027, Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: RS1028, Title: Provide non-null 'customTags' value to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisDocumentation, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RS1028, Title: Provide non-null 'customTags' value to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisDocumentation, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
 - {Id: RS1029, Title: Do not use reserved diagnostic IDs, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS1030, Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS1031, Title: Define diagnostic title correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -871,7 +870,7 @@
 - {Id: RS2006, Title: Remove duplicate entries for diagnostic ID between analyzer releases, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS2007, Title: Invalid entry in analyzer release file, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RS2008, Title: Enable analyzer release tracking, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: S100, Title: Methods and properties should be named in PascalCase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S100, Title: Methods and properties should be named in PascalCase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: S1006, Title: Method overrides should not change parameter defaults, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S101, Title: Types should be named in PascalCase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S103, Title: Lines should not be too long, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
@@ -891,7 +890,7 @@
 - {Id: S1110, Title: Redundant pairs of parentheses should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S1116, Title: Empty statements should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S1117, Title: Local variables should not shadow class fields or properties, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: S1118, Title: Utility classes should not have public constructors, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1118, Title: Utility classes should not have public constructors, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: S112, Title: General or reserved exceptions should never be thrown, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S1121, Title: Assignments should not be made from within sub-expressions, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S1123, Title: '"Obsolete" attributes should include explanations', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -900,7 +899,7 @@
 - {Id: S113, Title: Files should end with a newline, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: S1133, Title: Deprecated code should be removed, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S1134, Title: Track uses of "FIXME" tags, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: S1135, Title: Track uses of "TODO" tags, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: S1135, Title: Track uses of "TODO" tags, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note, None], IsEverSuppressed: true}
 - {Id: S1144, Title: Unused private types or members should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S1147, Title: Exit methods should not be called, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: S1151, Title: '"switch case" clauses should not have too many lines of code', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
@@ -920,7 +919,7 @@
 - {Id: S122, Title: Statements should be on separate lines, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: S1226, Title: "Method parameters, caught exceptions and foreach variables' initial values should not be ignored", Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: S1227, Title: break statements should not be used except for switch cases, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
-- {Id: S1244, Title: Floating point numbers should not be tested for equality, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1244, Title: Floating point numbers should not be tested for equality, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: S125, Title: Sections of code should not be commented out, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S126, Title: '"if ... else if" constructs should end with "else" clauses', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: S1264, Title: A "while" loop should be used instead of a "for" loop, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1022,9 +1021,9 @@
 - {Id: S2486, Title: Generic exceptions should not be ignored, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S2551, Title: Shared resources should not be used for locking, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S2583, Title: Conditionally executed code should be reachable, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: S2589, Title: Boolean expressions should not be gratuitous, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: S2589, Title: Boolean expressions should not be gratuitous, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S2612, Title: Setting loose file permissions is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: S2629, Title: Logging templates should be constant, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2629, Title: Logging templates should be constant, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: S2674, Title: The length returned from a stream read should be checked, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: S2681, Title: Multiline blocks should be enclosed in curly braces, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S2688, Title: '"NaN" should not be used in comparisons', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1040,7 +1039,7 @@
 - {Id: S2761, Title: Doubled prefix operators "!!" and "~~" should not be used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S2857, Title: SQL keywords should be delimited by whitespace, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S2925, Title: '"Thread.Sleep" should not be used in tests', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: S2930, Title: '"IDisposables" should be disposed', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2930, Title: '"IDisposables" should be disposed', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: S2931, Title: Classes with "IDisposable" members should implement "IDisposable", Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: S2933, Title: Fields that are only assigned in the constructor should be "readonly", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S2934, Title: Property assignments should not be made for "readonly" fields not constrained to reference types, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1290,7 +1289,7 @@
 - {Id: S6588, Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S6602, Title: '"Find" method should be used instead of the "FirstOrDefault" extension', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S6603, Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: S6605, Title: Collection-specific "Exists" method should be used instead of the "Any" extension, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6605, Title: Collection-specific "Exists" method should be used instead of the "Any" extension, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: S6607, Title: The collection should be filtered before sorting by using "Where" before "OrderBy", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S6608, Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S6609, Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1301,7 +1300,7 @@
 - {Id: S6618, Title: '"string.Create" should be used instead of "FormattableString"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S6640, Title: Using unsafe code blocks is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S6664, Title: The code block contains too many logging calls, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
-- {Id: S6667, Title: Logging in a catch clause should pass the caught exception as a parameter., Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6667, Title: Logging in a catch clause should pass the caught exception as a parameter., Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: S6668, Title: Logging arguments should be passed to the correct parameter, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: S6669, Title: Logger field or property name should comply with a naming convention, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: S6670, Title: '"Trace.Write" and "Trace.WriteLine" should not be used', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1351,7 +1350,7 @@
 - {Id: SA1006, Title: Preprocessor keywords should not be preceded by space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1007, Title: Operator keyword should be followed by space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1008, Title: Opening parenthesis should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1009, Title: Closing parenthesis should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1009, Title: Closing parenthesis should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1010, Title: Opening square brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1011, Title: Closing square brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1012, Title: Opening braces should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1381,8 +1380,8 @@
 - {Id: SA1107, Title: Code should not contain multiple statements on one line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1108, Title: Block statements should not contain embedded comments, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1109, Title: Block statements should not contain embedded regions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
-- {Id: SA1110, Title: Opening parenthesis or bracket should be on declaration line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1111, Title: Closing parenthesis should be on line of last parameter, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1110, Title: Opening parenthesis or bracket should be on declaration line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
+- {Id: SA1111, Title: Closing parenthesis should be on line of last parameter, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1112, Title: Closing parenthesis should be on line of opening parenthesis, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1113, Title: Comma should be on the same line as previous parameter, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1114, Title: Parameter list should follow declaration, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1414,14 +1413,14 @@
 - {Id: SA1141, Title: Use tuple syntax, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1142, Title: Refer to tuple fields by name, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1200, Title: Using directives should be placed correctly, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1201, Title: Elements should appear in the correct order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1202, Title: Elements should be ordered by access, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1201, Title: Elements should appear in the correct order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
+- {Id: SA1202, Title: Elements should be ordered by access, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1203, Title: Constants should appear before fields, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1204, Title: Static elements should appear before instance elements, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1204, Title: Static elements should appear before instance elements, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1205, Title: Partial elements should declare access, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1206, Title: Declaration keywords should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1207, Title: Protected should come before internal, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1208, Title: System using directives should be placed before other using directives, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1208, Title: System using directives should be placed before other using directives, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1209, Title: Using alias directives should be placed after other using directives, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1210, Title: Using directives should be ordered alphabetically by namespace, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1211, Title: Using alias directives should be ordered alphabetically by alias name, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1438,14 +1437,14 @@
 - {Id: SA1305, Title: Field names should not use Hungarian notation, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: SA1306, Title: Field names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1307, Title: Accessible fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1308, Title: Variable names should not be prefixed, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1308, Title: Variable names should not be prefixed, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1309, Title: Field names should not begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1310, Title: Field names should not contain underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1311, Title: Static readonly fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1312, Title: Variable names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1313, Title: Parameter names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1314, Title: Type parameter names should begin with T, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1316, Title: Tuple element names should use correct casing, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1316, Title: Tuple element names should use correct casing, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1400, Title: Access modifier should be declared, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1401, Title: Fields should be private, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1402, Title: File may only contain a single type, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1464,7 +1463,7 @@
 - {Id: SA1500, Title: Braces for multi-line statements should not share line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1501, Title: Statement should not be on a single line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1502, Title: Element should not be on a single line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1503, Title: Braces should not be omitted, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: SA1503, Title: Braces should not be omitted, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1504, Title: All accessors should be single-line or multi-line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1505, Title: Opening braces should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1506, Title: Element documentation headers should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1476,14 +1475,14 @@
 - {Id: SA1512, Title: Single-line comments should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1513, Title: Closing brace should be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1514, Title: Element documentation header should be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1515, Title: Single-line comment should be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1515, Title: Single-line comment should be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1516, Title: Elements should be separated by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1517, Title: Code should not contain blank lines at start of file, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1518, Title: Use line endings correctly at end of file, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1519, Title: Braces should not be omitted from multi-line child statement, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1520, Title: Use braces consistently, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
-- {Id: SA1600, Title: Elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
-- {Id: SA1601, Title: Partial elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1600, Title: Elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note, None], IsEverSuppressed: true}
+- {Id: SA1601, Title: Partial elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
 - {Id: SA1602, Title: Enumeration items should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: SA1603, Title: Documentation should contain valid XML, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: SA1604, Title: Element documentation should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
@@ -1537,6 +1536,19 @@
 - {Id: SX1101, Title: Do not prefix local calls with 'this.', Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: SX1309, Title: Field names should begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
 - {Id: SX1309S, Title: Static field names should begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SYSLIB1045, Title: Convert to 'GeneratedRegexAttribute'., Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1054, Title: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1055, Title: Invalid 'CustomMarshallerAttribute' usage, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1056, Title: Specified marshaller type is invalid, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1057, Title: Marshaller type does not have the required shape, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1058, Title: Invalid 'NativeMarshallingAttribute' usage, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1060, Title: Specified marshaller type is invalid, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1061, Title: Marshaller type has incompatible method signatures, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1090, Title: "'GeneratedComInterfaceType' does not support the 'ComInterfaceType' value supplied to 'InterfaceTypeAttribute' on the same type.", Category: ComInterfaceGenerator, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1096, Title: Convert to 'GeneratedComInterface', Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1097, Title: Add 'GeneratedComClassAttribute' to enable passing objects of this type to COM, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1098, Title: .NET COM hosting with 'EnableComHosting' does not support interfaces with the 'GeneratedComInterfaceAttribute', Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1099, Title: COM Interop APIs on 'System.Runtime.InteropServices.Marshal' do not support source-generated COM, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: VSTHRD001, Title: Avoid legacy thread switching APIs, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: VSTHRD002, Title: Avoid problematic synchronous waits, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: VSTHRD003, Title: Avoid awaiting foreign Tasks, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}

--- a/tests/Moq.Analyzers.Benchmarks/SquiggleCop.Baseline.yaml
+++ b/tests/Moq.Analyzers.Benchmarks/SquiggleCop.Baseline.yaml
@@ -357,7 +357,7 @@
 - {Id: IDE0048, Title: Add parentheses for clarity, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0051, Title: Remove unused private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0052, Title: Remove unread private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0053, Title: Use expression body for lambda expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0053, Title: Use expression body for lambdas, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0054, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0055, Title: Fix formatting, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0056, Title: Use index operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -374,7 +374,7 @@
 - {Id: IDE0070, Title: Use 'System.HashCode', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0071, Title: Simplify interpolation, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0072, Title: Add missing cases, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
-- {Id: IDE0073, Title: The file header does not match the required text, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0073, Title: Require file header, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0074, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0075, Title: Simplify conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0076, Title: Invalid global 'SuppressMessageAttribute', Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -412,7 +412,6 @@
 - {Id: IDE0303, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0304, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0305, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0320, Title: Make anonymous function static, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE1005, Title: Delegate invocation can be simplified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE1006, Title: Naming Styles, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE2000, Title: Avoid multiple blank lines, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}

--- a/tests/Moq.Analyzers.Benchmarks/SquiggleCop.Baseline.yaml
+++ b/tests/Moq.Analyzers.Benchmarks/SquiggleCop.Baseline.yaml
@@ -1,0 +1,12627 @@
+- Id: CA1000
+  Title: Do not declare static members on generic types
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1001
+  Title: Types that own disposable fields should be disposable
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1002
+  Title: Do not expose generic lists
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1003
+  Title: Use generic event handler instances
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1005
+  Title: Avoid excessive parameters on generic types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1008
+  Title: Enums should have zero value
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1010
+  Title: Generic interface should also be implemented
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1012
+  Title: Abstract types should not have public constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1014
+  Title: Mark assemblies with CLSCompliant
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1016
+  Title: Mark assemblies with assembly version
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1017
+  Title: Mark assemblies with ComVisible
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1018
+  Title: Mark attributes with AttributeUsageAttribute
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1019
+  Title: Define accessors for attribute arguments
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1021
+  Title: Avoid out parameters
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1024
+  Title: Use properties where appropriate
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1027
+  Title: Mark enums with FlagsAttribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1028
+  Title: Enum Storage should be Int32
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1030
+  Title: Use events where appropriate
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1031
+  Title: Do not catch general exception types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1032
+  Title: Implement standard exception constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1033
+  Title: Interface methods should be callable by child types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1034
+  Title: Nested types should not be visible
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1036
+  Title: Override methods on comparable types
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1040
+  Title: Avoid empty interfaces
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1041
+  Title: Provide ObsoleteAttribute message
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1043
+  Title: Use Integral Or String Argument For Indexers
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1044
+  Title: Properties should not be write only
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1045
+  Title: Do not pass types by reference
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1046
+  Title: Do not overload equality operator on reference types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1050
+  Title: Declare types in namespaces
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1051
+  Title: Do not declare visible instance fields
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1052
+  Title: Static holder types should be Static or NotInheritable
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1054
+  Title: URI-like parameters should not be strings
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1055
+  Title: URI-like return values should not be strings
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1056
+  Title: URI-like properties should not be strings
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1058
+  Title: Types should not extend certain base types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1060
+  Title: Move pinvokes to native methods class
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1061
+  Title: Do not hide base class methods
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1062
+  Title: Validate arguments of public methods
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1063
+  Title: Implement IDisposable Correctly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1064
+  Title: Exceptions should be public
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1065
+  Title: Do not raise exceptions in unexpected locations
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1066
+  Title: Implement IEquatable when overriding Object.Equals
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: CA1067
+  Title: Override Object.Equals(object) when implementing IEquatable<T>
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1068
+  Title: CancellationToken parameters must come last
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1069
+  Title: Enums values should not be duplicated
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1070
+  Title: Do not declare event fields as virtual
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1200
+  Title: Avoid using cref tags with a prefix
+  Category: Documentation
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1303
+  Title: Do not pass literals as localized parameters
+  Category: Globalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1304
+  Title: Specify CultureInfo
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1305
+  Title: Specify IFormatProvider
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1307
+  Title: Specify StringComparison for clarity
+  Category: Globalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1308
+  Title: Normalize strings to uppercase
+  Category: Globalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1309
+  Title: Use ordinal string comparison
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1310
+  Title: Specify StringComparison for correctness
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1311
+  Title: Specify a culture or use an invariant version
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1401
+  Title: P/Invokes should not be visible
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1416
+  Title: Validate platform compatibility
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1417
+  Title: Do not use 'OutAttribute' on string parameters for P/Invokes
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1418
+  Title: Use valid platform string
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1419
+  Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1420
+  Title: Property, type, or attribute requires runtime marshalling
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1421
+  Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1422
+  Title: Validate platform compatibility
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1501
+  Title: Avoid excessive inheritance
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1502
+  Title: Avoid excessive complexity
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1505
+  Title: Avoid unmaintainable code
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1506
+  Title: Avoid excessive class coupling
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1507
+  Title: Use nameof to express symbol names
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1508
+  Title: Avoid dead conditional code
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1509
+  Title: Invalid entry in code metrics rule specification file
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1510
+  Title: Use ArgumentNullException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1511
+  Title: Use ArgumentException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1512
+  Title: Use ArgumentOutOfRangeException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1513
+  Title: Use ObjectDisposedException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1700
+  Title: Do not name enum values 'Reserved'
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1707
+  Title: Identifiers should not contain underscores
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1708
+  Title: Identifiers should differ by more than case
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1710
+  Title: Identifiers should have correct suffix
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1711
+  Title: Identifiers should not have incorrect suffix
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1712
+  Title: Do not prefix enum values with type name
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1713
+  Title: Events should not have 'Before' or 'After' prefix
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1715
+  Title: Identifiers should have correct prefix
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1716
+  Title: Identifiers should not match keywords
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1720
+  Title: Identifier contains type name
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1721
+  Title: Property names should not match get methods
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1724
+  Title: Type names should not match namespaces
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1725
+  Title: Parameter names should match base declaration
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1727
+  Title: Use PascalCase for named placeholders
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1802
+  Title: Use literals where appropriate
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1805
+  Title: Do not initialize unnecessarily
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1806
+  Title: Do not ignore method results
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1810
+  Title: Initialize reference type static fields inline
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1812
+  Title: Avoid uninstantiated internal classes
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1813
+  Title: Avoid unsealed attributes
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1814
+  Title: Prefer jagged arrays over multidimensional
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1815
+  Title: Override equals and operator equals on value types
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1816
+  Title: Dispose methods should call SuppressFinalize
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1819
+  Title: Properties should not return arrays
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1820
+  Title: Test for empty strings using string length
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1821
+  Title: Remove empty Finalizers
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1822
+  Title: Mark members as static
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1823
+  Title: Avoid unused private fields
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1824
+  Title: Mark assemblies with NeutralResourcesLanguageAttribute
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1825
+  Title: Avoid zero-length array allocations
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1826
+  Title: Do not use Enumerable methods on indexable collections
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1827
+  Title: Do not use Count() or LongCount() when Any() can be used
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1828
+  Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1829
+  Title: Use Length/Count property instead of Count() when available
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1830
+  Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1831
+  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1832
+  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1833
+  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1834
+  Title: Consider using 'StringBuilder.Append(char)' when applicable
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1835
+  Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1836
+  Title: Prefer IsEmpty over Count
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1837
+  Title: Use 'Environment.ProcessId'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1838
+  Title: Avoid 'StringBuilder' parameters for P/Invokes
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1839
+  Title: Use 'Environment.ProcessPath'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1840
+  Title: Use 'Environment.CurrentManagedThreadId'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1841
+  Title: Prefer Dictionary.Contains methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1842
+  Title: Do not use 'WhenAll' with a single task
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1843
+  Title: Do not use 'WaitAll' with a single task
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1844
+  Title: Provide memory-based overrides of async methods when subclassing 'Stream'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1845
+  Title: Use span-based 'string.Concat'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1846
+  Title: Prefer 'AsSpan' over 'Substring'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1847
+  Title: Use char literal for a single character lookup
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1848
+  Title: Use the LoggerMessage delegates
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1849
+  Title: Call async methods when in an async method
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1850
+  Title: Prefer static 'HashData' method over 'ComputeHash'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1851
+  Title: Possible multiple enumerations of 'IEnumerable' collection
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1852
+  Title: Seal internal types
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1853
+  Title: Unnecessary call to 'Dictionary.ContainsKey(key)'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1854
+  Title: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1855
+  Title: Prefer 'Clear' over 'Fill'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1856
+  Title: Incorrect usage of ConstantExpected attribute
+  Category: Performance
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1857
+  Title: A constant is expected for the parameter
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1858
+  Title: Use 'StartsWith' instead of 'IndexOf'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1859
+  Title: Use concrete types when possible for improved performance
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1860
+  Title: Avoid using 'Enumerable.Any()' extension method
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1861
+  Title: Avoid constant arrays as arguments
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1862
+  Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1863
+  Title: Use 'CompositeFormat'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1864
+  Title: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1865
+  Title: Use char overload
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1866
+  Title: Use char overload
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1867
+  Title: Use char overload
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: CA1868
+  Title: Unnecessary call to 'Contains(item)'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1869
+  Title: Cache and reuse 'JsonSerializerOptions' instances
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1870
+  Title: Use a cached 'SearchValues' instance
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2000
+  Title: Dispose objects before losing scope
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2002
+  Title: Do not lock on objects with weak identity
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2007
+  Title: Consider calling ConfigureAwait on the awaited task
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2008
+  Title: Do not create tasks without passing a TaskScheduler
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2009
+  Title: Do not call ToImmutableCollection on an ImmutableCollection value
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2011
+  Title: Avoid infinite recursion
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2012
+  Title: Use ValueTasks correctly
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2013
+  Title: Do not use ReferenceEquals with value types
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2014
+  Title: Do not use stackalloc in loops
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2015
+  Title: Do not define finalizers for types derived from MemoryManager<T>
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2016
+  Title: Forward the 'CancellationToken' parameter to methods
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: CA2017
+  Title: Parameter count mismatch
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2018
+  Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument"
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2019
+  Title: Improper 'ThreadStatic' field initialization
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2020
+  Title: Prevent behavioral change
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2021
+  Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2100
+  Title: Review SQL queries for security vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2101
+  Title: Specify marshaling for P/Invoke string arguments
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2119
+  Title: Seal methods that satisfy private interfaces
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2153
+  Title: Do Not Catch Corrupted State Exceptions
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2200
+  Title: Rethrow to preserve stack details
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2201
+  Title: Do not raise reserved exception types
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA2207
+  Title: Initialize value type static fields inline
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2208
+  Title: Instantiate argument exceptions correctly
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2211
+  Title: Non-constant fields should not be visible
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2213
+  Title: Disposable fields should be disposed
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2214
+  Title: Do not call overridable methods in constructors
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2215
+  Title: Dispose methods should call base class dispose
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA2216
+  Title: Disposable types should declare finalizer
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2217
+  Title: Do not mark enums with FlagsAttribute
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2219
+  Title: Do not raise exceptions in finally clauses
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2225
+  Title: Operator overloads have named alternates
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2226
+  Title: Operators should have symmetrical overloads
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2227
+  Title: Collection properties should be read only
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2231
+  Title: Overload operator equals on overriding value type Equals
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2234
+  Title: Pass system uri objects instead of strings
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2235
+  Title: Mark all non-serializable fields
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2237
+  Title: Mark ISerializable types with serializable
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2241
+  Title: Provide correct arguments to formatting methods
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2242
+  Title: Test for NaN correctly
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2243
+  Title: Attribute string literals should parse correctly
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2244
+  Title: Do not duplicate indexed element initializations
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2245
+  Title: Do not assign a property to itself
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2246
+  Title: Assigning symbol and its member in the same statement
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2247
+  Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2248
+  Title: Provide correct 'enum' argument to 'Enum.HasFlag'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2249
+  Title: Consider using 'string.Contains' instead of 'string.IndexOf'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2250
+  Title: Use 'ThrowIfCancellationRequested'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2251
+  Title: Use 'string.Equals'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA2252
+  Title: This API requires opting into preview features
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2253
+  Title: Named placeholders should not be numeric values
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2254
+  Title: Template should be a static expression
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2255
+  Title: The 'ModuleInitializer' attribute should not be used in libraries
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2256
+  Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2257
+  Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2258
+  Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2259
+  Title: "'ThreadStatic' only affects static fields"
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2260
+  Title: Use correct type parameter
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2261
+  Title: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2300
+  Title: Do not use insecure deserializer BinaryFormatter
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2301
+  Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2302
+  Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2305
+  Title: Do not use insecure deserializer LosFormatter
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2310
+  Title: Do not use insecure deserializer NetDataContractSerializer
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2311
+  Title: Do not deserialize without first setting NetDataContractSerializer.Binder
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2312
+  Title: Ensure NetDataContractSerializer.Binder is set before deserializing
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2315
+  Title: Do not use insecure deserializer ObjectStateFormatter
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2321
+  Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2322
+  Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2326
+  Title: Do not use TypeNameHandling values other than None
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2327
+  Title: Do not use insecure JsonSerializerSettings
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2328
+  Title: Ensure that JsonSerializerSettings are secure
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2329
+  Title: Do not deserialize with JsonSerializer using an insecure configuration
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2330
+  Title: Ensure that JsonSerializer has a secure configuration when deserializing
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2350
+  Title: Do not use DataTable.ReadXml() with untrusted data
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2351
+  Title: Do not use DataSet.ReadXml() with untrusted data
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2352
+  Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2353
+  Title: Unsafe DataSet or DataTable in serializable type
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2354
+  Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2355
+  Title: Unsafe DataSet or DataTable type found in deserializable object graph
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2356
+  Title: Unsafe DataSet or DataTable type in web deserializable object graph
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2361
+  Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2362
+  Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3001
+  Title: Review code for SQL injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3002
+  Title: Review code for XSS vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3003
+  Title: Review code for file path injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3004
+  Title: Review code for information disclosure vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3005
+  Title: Review code for LDAP injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3006
+  Title: Review code for process command injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3007
+  Title: Review code for open redirect vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3008
+  Title: Review code for XPath injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3009
+  Title: Review code for XML injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3010
+  Title: Review code for XAML injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3011
+  Title: Review code for DLL injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3012
+  Title: Review code for regex injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3061
+  Title: Do Not Add Schema By URL
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3075
+  Title: Insecure DTD processing in XML
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3076
+  Title: Insecure XSLT script processing
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3077
+  Title: Insecure Processing in API Design, XmlDocument and XmlTextReader
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3147
+  Title: Mark Verb Handlers With Validate Antiforgery Token
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5350
+  Title: Do Not Use Weak Cryptographic Algorithms
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5351
+  Title: Do Not Use Broken Cryptographic Algorithms
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5358
+  Title: Review cipher mode usage with cryptography experts
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5359
+  Title: Do Not Disable Certificate Validation
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5360
+  Title: Do Not Call Dangerous Methods In Deserialization
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5361
+  Title: Do Not Disable SChannel Use of Strong Crypto
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5362
+  Title: Potential reference cycle in deserialized object graph
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5363
+  Title: Do Not Disable Request Validation
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5364
+  Title: Do Not Use Deprecated Security Protocols
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5365
+  Title: Do Not Disable HTTP Header Checking
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5366
+  Title: Use XmlReader for 'DataSet.ReadXml()'
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5367
+  Title: Do Not Serialize Types With Pointer Fields
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5368
+  Title: Set ViewStateUserKey For Classes Derived From Page
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5369
+  Title: Use XmlReader for 'XmlSerializer.Deserialize()'
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5370
+  Title: Use XmlReader for XmlValidatingReader constructor
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5371
+  Title: Use XmlReader for 'XmlSchema.Read()'
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5372
+  Title: Use XmlReader for XPathDocument constructor
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5373
+  Title: Do not use obsolete key derivation function
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5374
+  Title: Do Not Use XslTransform
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5375
+  Title: Do Not Use Account Shared Access Signature
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5376
+  Title: Use SharedAccessProtocol HttpsOnly
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5377
+  Title: Use Container Level Access Policy
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5378
+  Title: Do not disable ServicePointManagerSecurityProtocols
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5379
+  Title: Ensure Key Derivation Function algorithm is sufficiently strong
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5380
+  Title: Do Not Add Certificates To Root Store
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5381
+  Title: Ensure Certificates Are Not Added To Root Store
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5382
+  Title: Use Secure Cookies In ASP.NET Core
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5383
+  Title: Ensure Use Secure Cookies In ASP.NET Core
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5384
+  Title: Do Not Use Digital Signature Algorithm (DSA)
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5385
+  Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5386
+  Title: Avoid hardcoding SecurityProtocolType value
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5387
+  Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5388
+  Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5389
+  Title: Do Not Add Archive Item's Path To The Target File System Path
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5390
+  Title: Do not hard-code encryption key
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5391
+  Title: Use antiforgery tokens in ASP.NET Core MVC controllers
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5392
+  Title: Use DefaultDllImportSearchPaths attribute for P/Invokes
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5393
+  Title: Do not use unsafe DllImportSearchPath value
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5394
+  Title: Do not use insecure randomness
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5395
+  Title: Miss HttpVerb attribute for action methods
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5396
+  Title: Set HttpOnly to true for HttpCookie
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5397
+  Title: Do not use deprecated SslProtocols values
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5398
+  Title: Avoid hardcoded SslProtocols values
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5399
+  Title: HttpClients should enable certificate revocation list checks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5400
+  Title: Ensure HttpClient certificate revocation list check is not disabled
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5401
+  Title: Do not use CreateEncryptor with non-default IV
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5402
+  Title: 'Use CreateEncryptor with the default IV '
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5403
+  Title: Do not hard-code certificate
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5404
+  Title: Do not disable token validation checks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5405
+  Title: Do not always skip token validation in delegates
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: EM0001
+  Title: Switch on Enum Not Exhaustive
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0002
+  Title: Switch on Nullable Enum Not Exhaustive
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0003
+  Title: Switch on Closed Type Not Exhaustive
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0011
+  Title: Concrete Subtype of a Closed Type Must Be a Case
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0012
+  Title: Closed Type Case Must Be a Direct Subtype
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0013
+  Title: Closed Type Case Must Be a Subtype
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0014
+  Title: Concrete Subtype of a Closed Type Must Be a Covered
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0015
+  Title: Open Interface Subtype of a Closed Type Must Be a Case
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0100
+  Title: When Guards Not Supported
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0101
+  Title: Case Pattern Not Supported
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0102
+  Title: Open Type Not Supported
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0103
+  Title: Match Must Be On Case Type
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0104
+  Title: Duplicate Closed Attribute
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0105
+  Title: Duplicate Case Type
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EnableGenerateDocumentationFile
+  Title: Set MSBuild property 'GenerateDocumentationFile' to 'true'
+  Category: Style
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: IDE0004
+  Title: Remove Unnecessary Cast
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0005
+  Title: Using directive is unnecessary.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0005_gen
+  Title: Using directive is unnecessary.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0007
+  Title: Use implicit type
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0008
+  Title: Use explicit type
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0009
+  Title: Member access should be qualified.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0010
+  Title: Add missing cases
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0011
+  Title: Add braces
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0016
+  Title: Use 'throw' expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0017
+  Title: Simplify object initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0018
+  Title: Inline variable declaration
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0019
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0020
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0021
+  Title: Use expression body for constructor
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0022
+  Title: Use expression body for method
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0023
+  Title: Use expression body for conversion operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0024
+  Title: Use expression body for operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0025
+  Title: Use expression body for property
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0026
+  Title: Use expression body for indexer
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0027
+  Title: Use expression body for accessor
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0028
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0029
+  Title: Use coalesce expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0030
+  Title: Use coalesce expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0031
+  Title: Use null propagation
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0032
+  Title: Use auto property
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0033
+  Title: Use explicitly provided tuple name
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0034
+  Title: Simplify 'default' expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0035
+  Title: Unreachable code detected
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0036
+  Title: Order modifiers
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0037
+  Title: Use inferred member name
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0039
+  Title: Use local function
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0040
+  Title: Add accessibility modifiers
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0041
+  Title: Use 'is null' check
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0042
+  Title: Deconstruct variable declaration
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0043
+  Title: Invalid format string
+  Category: Compiler
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0044
+  Title: Add readonly modifier
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0045
+  Title: Convert to conditional expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0046
+  Title: Convert to conditional expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0047
+  Title: Remove unnecessary parentheses
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0048
+  Title: Add parentheses for clarity
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0051
+  Title: Remove unused private members
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0052
+  Title: Remove unread private members
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0053
+  Title: Use expression body for lambda expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0054
+  Title: Use compound assignment
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0055
+  Title: Fix formatting
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0056
+  Title: Use index operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0057
+  Title: Use range operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0058
+  Title: Expression value is never used
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0059
+  Title: Unnecessary assignment of a value
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0060
+  Title: Remove unused parameter
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0061
+  Title: Use expression body for local function
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0062
+  Title: Make local function 'static'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0063
+  Title: Use simple 'using' statement
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0064
+  Title: Make readonly fields writable
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0065
+  Title: Misplaced using directive
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0066
+  Title: Convert switch statement to expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0070
+  Title: Use 'System.HashCode'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0071
+  Title: Simplify interpolation
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0072
+  Title: Add missing cases
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0073
+  Title: The file header does not match the required text
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0074
+  Title: Use compound assignment
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0075
+  Title: Simplify conditional expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0076
+  Title: Invalid global 'SuppressMessageAttribute'
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0077
+  Title: Avoid legacy format target in 'SuppressMessageAttribute'
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0078
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0080
+  Title: Remove unnecessary suppression operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0082
+  Title: "'typeof' can be converted to 'nameof'"
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0083
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0090
+  Title: Use 'new(...)'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0100
+  Title: Remove redundant equality
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0110
+  Title: Remove unnecessary discard
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0120
+  Title: Simplify LINQ expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0130
+  Title: Namespace does not match folder structure
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0150
+  Title: Prefer 'null' check over type check
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0160
+  Title: Convert to block scoped namespace
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0161
+  Title: Convert to file-scoped namespace
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0170
+  Title: Property pattern can be simplified
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0180
+  Title: Use tuple to swap values
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0200
+  Title: Remove unnecessary lambda expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0210
+  Title: Convert to top-level statements
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0211
+  Title: Convert to 'Program.Main' style program
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0220
+  Title: Add explicit cast
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0230
+  Title: Use UTF-8 string literal
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0240
+  Title: Remove redundant nullable directive
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0241
+  Title: Remove unnecessary nullable directive
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0250
+  Title: Make struct 'readonly'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0251
+  Title: Make member 'readonly'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0260
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0270
+  Title: Use coalesce expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0280
+  Title: Use 'nameof'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0290
+  Title: Use primary constructor
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0300
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0301
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0302
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0303
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0304
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0305
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0320
+  Title: Make anonymous function static
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE1005
+  Title: Delegate invocation can be simplified.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE1006
+  Title: Naming Styles
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE2000
+  Title: Avoid multiple blank lines
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2001
+  Title: Embedded statements must be on their own line
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2002
+  Title: Consecutive braces must not have blank line between them
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2003
+  Title: Blank line required between block and subsequent statement
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2004
+  Title: Blank line not allowed after constructor initializer colon
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2005
+  Title: Blank line not allowed after conditional expression token
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2006
+  Title: Blank line not allowed after arrow expression clause token
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0001
+  Title: StringComparison is missing
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0002
+  Title: IEqualityComparer<string> or IComparer<string> is missing
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0003
+  Title: Add parameter name to improve readability
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0004
+  Title: Use Task.ConfigureAwait
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0005
+  Title: Use Array.Empty<T>()
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0006
+  Title: Use String.Equals instead of equality operator
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0007
+  Title: Add a comma after the last value
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0008
+  Title: Add StructLayoutAttribute
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0009
+  Title: Add regex evaluation timeout
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0010
+  Title: Mark attributes with AttributeUsageAttribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0011
+  Title: IFormatProvider is missing
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0012
+  Title: Do not raise reserved exception type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0013
+  Title: Types should not extend System.ApplicationException
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0014
+  Title: Do not raise System.ApplicationException type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0015
+  Title: Specify the parameter name in ArgumentException
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0016
+  Title: Prefer using collection abstraction instead of implementation
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0017
+  Title: Abstract types should not have public or internal constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0018
+  Title: Do not declare static members on generic types (deprecated; use CA1000 instead)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0019
+  Title: Use EventArgs.Empty
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0020
+  Title: Use direct methods instead of LINQ methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0021
+  Title: Use StringComparer.GetHashCode instead of string.GetHashCode
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0022
+  Title: Return Task.FromResult instead of returning null
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0023
+  Title: Add RegexOptions.ExplicitCapture
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0024
+  Title: Use an explicit StringComparer when possible
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0025
+  Title: Implement the functionality instead of throwing NotImplementedException
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0026
+  Title: Fix TODO comment
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - None
+  IsEverSuppressed: true
+- Id: MA0027
+  Title: Prefer rethrowing an exception implicitly
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0028
+  Title: Optimize StringBuilder usage
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0029
+  Title: Combine LINQ methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0030
+  Title: Remove useless OrderBy call
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0031
+  Title: Optimize Enumerable.Count() usage
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0032
+  Title: Use an overload with a CancellationToken argument
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0033
+  Title: Do not tag instance fields with ThreadStaticAttribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0035
+  Title: Do not use dangerous threading methods
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0036
+  Title: Make class static
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0037
+  Title: Remove empty statement
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0038
+  Title: Make method static (deprecated, use CA1822 instead)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0039
+  Title: Do not write your own certificate validation method
+  Category: Security
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0040
+  Title: Forward the CancellationToken parameter to methods that take one
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: MA0041
+  Title: Make property static (deprecated, use CA1822 instead)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0042
+  Title: Do not use blocking calls in an async method
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0043
+  Title: Use nameof operator in ArgumentException
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0044
+  Title: Remove useless ToString call
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0045
+  Title: Do not use blocking calls in a sync method (need to make calling method async)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0046
+  Title: Use EventHandler<T> to declare events
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0047
+  Title: Declare types in namespaces
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0048
+  Title: File name must match type name
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0049
+  Title: Type name should not match containing namespace
+  Category: Design
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0050
+  Title: Validate arguments correctly in iterator methods
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0051
+  Title: Method is too long
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: MA0052
+  Title: Replace constant Enum.ToString with nameof
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0053
+  Title: Make class sealed
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0054
+  Title: Embed the caught exception as innerException
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0055
+  Title: Do not use finalizer
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0056
+  Title: Do not call overridable members in constructor
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0057
+  Title: Class name should end with 'Attribute'
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0058
+  Title: Class name should end with 'Exception'
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0059
+  Title: Class name should end with 'EventArgs'
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0060
+  Title: The value returned by Stream.Read/Stream.ReadAsync is not used
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0061
+  Title: Method overrides should not change default values
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0062
+  Title: Non-flags enums should not be marked with "FlagsAttribute"
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0063
+  Title: Use Where before OrderBy
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0064
+  Title: Avoid locking on publicly accessible instance
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0065
+  Title: Default ValueType.Equals or HashCode is used for struct equality
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0066
+  Title: Hash table unfriendly type is used in a hash table
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0067
+  Title: Use Guid.Empty
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0068
+  Title: Invalid parameter name for nullable attribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0069
+  Title: Non-constant static fields should not be visible
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0070
+  Title: Obsolete attributes should include explanations
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0071
+  Title: Avoid using redundant else
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0072
+  Title: Do not throw from a finally block
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0073
+  Title: Avoid comparison with bool constant
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0074
+  Title: Avoid implicit culture-sensitive methods
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0075
+  Title: Do not use implicit culture-sensitive ToString
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0076
+  Title: Do not use implicit culture-sensitive ToString in interpolated strings
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0077
+  Title: A class that provides Equals(T) should implement IEquatable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0078
+  Title: Use 'Cast' instead of 'Select' to cast
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0079
+  Title: Forward the CancellationToken using .WithCancellation()
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0080
+  Title: Use a cancellation token using .WithCancellation()
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0081
+  Title: Method overrides should not omit params keyword
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0082
+  Title: NaN should not be used in comparisons
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0083
+  Title: ConstructorArgument parameters should exist in constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0084
+  Title: Local variables should not hide other symbols
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0085
+  Title: Anonymous delegates should not be used to unsubscribe from Events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0086
+  Title: Do not throw from a finalizer
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0087
+  Title: Parameters with [DefaultParameterValue] attributes should also be marked [Optional]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0088
+  Title: Use [DefaultParameterValue] instead of [DefaultValue]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0089
+  Title: Optimize string method usage
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0090
+  Title: Remove empty else/finally block
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0091
+  Title: Sender should be 'this' for instance events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0092
+  Title: Sender should be 'null' for static events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0093
+  Title: EventArgs should not be null
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0094
+  Title: A class that provides CompareTo(T) should implement IComparable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0095
+  Title: A class that implements IEquatable<T> should override Equals(object)
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0096
+  Title: A class that implements IComparable<T> should also implement IEquatable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0097
+  Title: A class that implements IComparable<T> or IComparable should override comparison operators
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0098
+  Title: Use indexer instead of LINQ methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0099
+  Title: Use Explicit enum value instead of 0
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0100
+  Title: Await task before disposing of resources
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0101
+  Title: String contains an implicit end of line character
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: MA0102
+  Title: Make member readonly
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0103
+  Title: Use SequenceEqual instead of equality operator
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0104
+  Title: Do not create a type with a name from the BCL
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0105
+  Title: Use the lambda parameters instead of using a closure
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0106
+  Title: Avoid closure by using an overload with the 'factoryArgument' parameter
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0107
+  Title: Do not use culture-sensitive object.ToString
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0108
+  Title: Remove redundant argument value
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0109
+  Title: Consider adding an overload with a Span<T> or Memory<T>
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0110
+  Title: Use the Regex source generator
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0111
+  Title: Use string.Create instead of FormattableString
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0112
+  Title: Use 'Count > 0' instead of 'Any()'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0113
+  Title: Use DateTime.UnixEpoch
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0114
+  Title: Use DateTimeOffset.UnixEpoch
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0115
+  Title: Unknown component parameter
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0116
+  Title: Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0117
+  Title: Parameters with [EditorRequired] attributes should also be marked as [Parameter]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0118
+  Title: '[JSInvokable] methods must be public'
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0119
+  Title: JSRuntime must not be used in OnInitialized or OnInitializedAsync
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0120
+  Title: Use InvokeVoidAsync when the returned value is not used
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0121
+  Title: Do not overwrite parameter value
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0122
+  Title: Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0123
+  Title: Sequence number must be a constant
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0124
+  Title: Log parameter type is not valid
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0125
+  Title: The list of log parameter types contains an invalid type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0126
+  Title: The list of log parameter types contains a duplicate
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0127
+  Title: Use String.Equals instead of is pattern
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0128
+  Title: Use 'is' operator instead of SequenceEqual
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0129
+  Title: Await task in using statement
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0130
+  Title: GetType() should not be used on System.Type instances
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0131
+  Title: ArgumentNullException.ThrowIfNull should not be used with non-nullable types
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0132
+  Title: Do not convert implicitly to DateTimeOffset
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0133
+  Title: Use DateTimeOffset instead of relying on the implicit conversion
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0134
+  Title: Observe result of async calls
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0135
+  Title: The log parameter has no configured type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0136
+  Title: Raw String contains an implicit end of line character
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: MA0137
+  Title: Use 'Async' suffix when a method returns an awaitable type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0138
+  Title: Do not use 'Async' suffix when a method does not return an awaitable type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0139
+  Title: Log parameter type is not valid
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0140
+  Title: Both if and else branch have identical code
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0141
+  Title: Use pattern matching instead of inequality operators for null check
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0142
+  Title: Use pattern matching instead of equality operators for null check
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0143
+  Title: Primary constructor parameters should be readonly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0144
+  Title: Use System.OperatingSystem to check the current OS
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0145
+  Title: Signature for [UnsafeAccessorAttribute] method is not valid
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0146
+  Title: Name must be set explicitly on local functions
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0147
+  Title: Avoid async void method for delegate
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0148
+  Title: Use pattern matching instead of equality operators for discrete value
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0149
+  Title: Use pattern matching instead of inequality operators for discrete value
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0150
+  Title: Do not call the default object.ToString explicitly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0151
+  Title: DebuggerDisplay must contain valid members
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0152
+  Title: Use Unwrap instead of using await twice
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0153
+  Title: Do not log symbols decorated with DataClassificationAttribute directly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0154
+  Title: Use langword in XML comment
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0155
+  Title: Do not use async void methods
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0156
+  Title: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0157
+  Title: Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0158
+  Title: Use System.Threading.Lock
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0159
+  Title: Use 'Order' instead of 'OrderBy'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0160
+  Title: Use ContainsKey instead of TryGetValue
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: POLYSP0003
+  Title: Unsupported C# language version
+  Category: Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1001
+  Title: Add braces (when expression spans over multiple lines)
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1002
+  Title: Remove braces
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1002FadeOut
+  Title: Remove braces
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1003
+  Title: Add braces to if-else (when expression spans over multiple lines)
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1004
+  Title: Remove braces from if-else
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1004FadeOut
+  Title: Remove braces from if-else
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1005
+  Title: Simplify nested using statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1005FadeOut
+  Title: Simplify nested using statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1006
+  Title: Merge 'else' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1006FadeOut
+  Title: Merge 'else' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1007
+  Title: Add braces
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1008
+  Title: "[deprecated] Use explicit type instead of 'var' (when the type is not obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1009
+  Title: "[deprecated] Use explicit type instead of 'var' (foreach variable)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1010
+  Title: "[deprecated] Use 'var' instead of explicit type (when the type is obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1012
+  Title: "[deprecated] Use explicit type instead of 'var' (when the type is obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1013
+  Title: Use predefined type
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1014
+  Title: Use explicitly/implicitly typed array
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1015
+  Title: Use nameof operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1015FadeOut
+  Title: Use nameof operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1016
+  Title: Use block body or expression body
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1018
+  Title: Add/remove accessibility modifiers
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1019
+  Title: Order modifiers
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1020
+  Title: Simplify Nullable<T> to T?
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1021
+  Title: Convert lambda expression body to expression body
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1021FadeOut
+  Title: Convert lambda expression body to expression body
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1031
+  Title: Remove unnecessary braces in switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1031FadeOut
+  Title: Remove unnecessary braces in switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1032
+  Title: Remove redundant parentheses
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1032FadeOut
+  Title: Remove redundant parentheses
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1033
+  Title: Remove redundant boolean literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1034
+  Title: Remove redundant 'sealed' modifier
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1035
+  Title: '[deprecated] Remove redundant comma in initializer'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1036
+  Title: Remove unnecessary blank line
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1037
+  Title: Remove trailing white-space
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1038
+  Title: '[deprecated] Remove empty statement'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1039
+  Title: Remove argument list from attribute
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1040
+  Title: "[deprecated] Remove empty 'else' clause"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1041
+  Title: '[deprecated] Remove empty initializer'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1042
+  Title: Remove enum default underlying type
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1043
+  Title: Remove 'partial' modifier from type with a single part
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1044
+  Title: Remove original exception from throw statement
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1046
+  Title: Asynchronous method name should end with 'Async'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1047
+  Title: Non-asynchronous method name should not end with 'Async'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1047FadeOut
+  Title: Non-asynchronous method name should not end with 'Async'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1048
+  Title: Use lambda expression instead of anonymous method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1048FadeOut
+  Title: Use lambda expression instead of anonymous method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1049
+  Title: Simplify boolean comparison
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1049FadeOut
+  Title: Simplify boolean comparison
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1050
+  Title: Include/omit parentheses when creating new object
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1051
+  Title: Add/remove parentheses from condition in conditional operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1052
+  Title: Declare each attribute separately
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1055
+  Title: Unnecessary semicolon at the end of declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1056
+  Title: Avoid usage of using alias directive
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1058
+  Title: Use compound assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1058FadeOut
+  Title: Use compound assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1059
+  Title: Avoid locking on publicly accessible instance
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1060
+  Title: Declare each type in separate file
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1061
+  Title: Merge 'if' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1061FadeOut
+  Title: Merge 'if' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1063
+  Title: '[deprecated] Avoid usage of do statement to create an infinite loop'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1064
+  Title: '[deprecated] Avoid usage of for statement to create an infinite loop'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1065
+  Title: '[deprecated] Avoid usage of while statement to create an infinite loop'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1066
+  Title: "[deprecated] Remove empty 'finally' clause"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1066FadeOut
+  Title: "[deprecated] Remove empty 'finally' clause"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1068
+  Title: Simplify logical negation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1069
+  Title: Remove unnecessary case label
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1070
+  Title: Remove redundant default switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1071
+  Title: Remove redundant base constructor call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1072
+  Title: '[deprecated] Remove empty namespace declaration'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1073
+  Title: Convert 'if' to 'return' statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1073FadeOut
+  Title: Convert 'if' to 'return' statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1074
+  Title: Remove redundant constructor
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1075
+  Title: Avoid empty catch clause that catches System.Exception
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1077
+  Title: Optimize LINQ method call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1078
+  Title: Use "" or 'string.Empty'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1079
+  Title: Throwing of new NotImplementedException
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1080
+  Title: Use 'Count/Length' property instead of 'Any' method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1081
+  Title: Split variable declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1084
+  Title: Use coalesce expression instead of conditional expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1085
+  Title: Use auto-implemented property
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1085FadeOut
+  Title: Use auto-implemented property
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1089
+  Title: Use --/++ operator instead of assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1089FadeOut
+  Title: Use --/++ operator instead of assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1090
+  Title: Add/remove 'ConfigureAwait(false)' call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1091
+  Title: '[deprecated] Remove empty region'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1091FadeOut
+  Title: '[deprecated] Remove empty region'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1093
+  Title: File contains no code
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1094
+  Title: Declare using directive on top level
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1096
+  Title: Use 'HasFlag' method or bitwise operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1097
+  Title: Remove redundant 'ToString' call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1098
+  Title: Constant values should be placed on right side of comparisons
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1099
+  Title: Default label should be the last label in a switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1100
+  Title: '[deprecated] Format documentation summary on a single line'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1101
+  Title: '[deprecated] Format documentation summary on multiple lines'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1102
+  Title: Make class static
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1103
+  Title: Convert 'if' to assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1104
+  Title: Simplify conditional expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1105
+  Title: Unnecessary interpolation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1106
+  Title: '[deprecated] Remove empty destructor'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1107
+  Title: Remove redundant 'ToCharArray' call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1108
+  Title: Add 'static' modifier to all partial class declarations
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1110
+  Title: Declare type inside namespace
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1111
+  Title: Add braces to switch section with multiple statements
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1112
+  Title: Combine 'Enumerable.Where' method chain
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1112FadeOut
+  Title: Combine 'Enumerable.Where' method chain
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1113
+  Title: Use 'string.IsNullOrEmpty' method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1114
+  Title: Remove redundant delegate creation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1114FadeOut
+  Title: Remove redundant delegate creation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1118
+  Title: Mark local variable as const
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1123
+  Title: Add parentheses when necessary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1124
+  Title: Inline local variable
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1124FadeOut
+  Title: Inline local variable
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1126
+  Title: Add braces to if-else
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1128
+  Title: Use coalesce expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1129
+  Title: Remove redundant field initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1130
+  Title: Bitwise operation on enum without Flags attribute
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1132
+  Title: Remove redundant overriding member
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1133
+  Title: Remove redundant Dispose/Close call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1134
+  Title: Remove redundant statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1135
+  Title: Declare enum member with zero value (when enum has FlagsAttribute)
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1136
+  Title: Merge switch sections with equivalent content
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1138
+  Title: Add summary to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1139
+  Title: Add summary element to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1140
+  Title: Add exception to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1141
+  Title: Add 'param' element to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1142
+  Title: Add 'typeparam' element to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1143
+  Title: Simplify coalesce expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1145
+  Title: Remove redundant 'as' operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1146
+  Title: Use conditional access
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1151
+  Title: Remove redundant cast
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1154
+  Title: Sort enum members
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1155
+  Title: Use StringComparison when comparing strings
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1156
+  Title: Use string.Length instead of comparison with empty string
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1157
+  Title: Composite enum value contains undefined flag
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1158
+  Title: Static member in generic type should use a type parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1159
+  Title: Use EventHandler<T>
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1160
+  Title: Abstract type should not have public constructors
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1161
+  Title: Enum should declare explicit values
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1162
+  Title: Avoid chain of assignments
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1163
+  Title: Unused parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1164
+  Title: Unused type parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1165
+  Title: Unconstrained type parameter checked for null
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1166
+  Title: Value type object is never equal to null
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1168
+  Title: Parameter name differs from base name
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1169
+  Title: Make field read-only
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1170
+  Title: Use read-only auto-implemented property
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1171
+  Title: Simplify lazy initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1172
+  Title: Use 'is' operator instead of 'as' operator
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1173
+  Title: Use coalesce expression instead of 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1174
+  Title: Remove redundant async/await
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1174FadeOut
+  Title: Remove redundant async/await
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1175
+  Title: Unused 'this' parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1176
+  Title: "[deprecated] Use 'var' instead of explicit type (when the type is not obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1177
+  Title: "[deprecated] Use 'var' instead of explicit type (in foreach)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1179
+  Title: Unnecessary assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1180
+  Title: Inline lazy initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1181
+  Title: Convert comment to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1182
+  Title: Remove redundant base interface
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1186
+  Title: Use Regex instance instead of static method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1187
+  Title: Use constant instead of field
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1188
+  Title: Remove redundant auto-property initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1189
+  Title: Add or remove region name
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1190
+  Title: Join string expressions
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1191
+  Title: Declare enum value as combination of names
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1192
+  Title: Unnecessary usage of verbatim string literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1193
+  Title: Overriding member should not change 'params' modifier
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1194
+  Title: Implement exception constructors
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1195
+  Title: Use ^ operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1196
+  Title: Call extension method as instance method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1197
+  Title: Optimize StringBuilder.Append/AppendLine call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1198
+  Title: Avoid unnecessary boxing of value type
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1199
+  Title: Unnecessary null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1200
+  Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1201
+  Title: Use method chaining
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1202
+  Title: Avoid NullReferenceException
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1203
+  Title: Use AttributeUsageAttribute
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1204
+  Title: Use EventArgs.Empty
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1205
+  Title: Order named arguments according to the order of parameters
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1206
+  Title: Use conditional access instead of conditional expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1207
+  Title: Use anonymous function or method group
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1208
+  Title: Reduce 'if' nesting
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1209
+  Title: Order type parameter constraints
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1210
+  Title: Return completed task instead of returning null
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1211
+  Title: Remove unnecessary 'else'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1212
+  Title: Remove redundant assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1212FadeOut
+  Title: Remove redundant assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1213
+  Title: Remove unused member declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1214
+  Title: Unnecessary interpolated string
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1214FadeOut
+  Title: Unnecessary interpolated string
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1215
+  Title: Expression is always equal to true/false
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1216
+  Title: Unnecessary unsafe context
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1217
+  Title: Convert interpolated string to concatenation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1217FadeOut
+  Title: Convert interpolated string to concatenation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1218
+  Title: Simplify code branching
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1220
+  Title: Use pattern matching instead of combination of 'is' operator and cast operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1221
+  Title: Use pattern matching instead of combination of 'as' operator and null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1222
+  Title: Merge preprocessor directives
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1223
+  Title: Mark publicly visible type with DebuggerDisplay attribute
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1224
+  Title: Make method an extension method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1225
+  Title: Make class sealed
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1226
+  Title: Add paragraph to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1227
+  Title: Validate arguments correctly
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1228
+  Title: Unused element in a documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1229
+  Title: Use async/await when necessary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1230
+  Title: Unnecessary explicit use of enumerator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1231
+  Title: Make parameter ref read-only
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1232
+  Title: Order elements in documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1233
+  Title: Use short-circuiting operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1234
+  Title: Duplicate enum value
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1235
+  Title: Optimize method call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1236
+  Title: Use exception filter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1237
+  Title: '[deprecated] Use bit shift operator'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1238
+  Title: 'Avoid nested ?: operators'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1239
+  Title: Use 'for' statement instead of 'while' statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1240
+  Title: Operator is unnecessary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1241
+  Title: Implement non-generic counterpart
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1242
+  Title: Do not pass non-read-only struct by read-only reference
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1243
+  Title: Duplicate word in a comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1244
+  Title: Simplify 'default' expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1246
+  Title: Use element access
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1247
+  Title: Fix documentation comment tag
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1248
+  Title: Normalize null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1249
+  Title: Unnecessary null-forgiving operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1250
+  Title: Use implicit/explicit object creation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1251
+  Title: Remove unnecessary braces from record declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1252
+  Title: Normalize usage of infinite loop
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1253
+  Title: Format documentation comment summary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1254
+  Title: Normalize format of enum flag value
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1255
+  Title: Simplify argument null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1256
+  Title: Invalid argument null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1257
+  Title: Use enum field explicitly
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1258
+  Title: Unnecessary enum flag
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1259
+  Title: Remove empty syntax
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1260
+  Title: Add/remove trailing comma
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1261
+  Title: Resource can be disposed asynchronously
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1262
+  Title: Unnecessary raw string literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1263
+  Title: Invalid reference in a documentation comment
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1264
+  Title: Use 'var' or explicit type
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1265
+  Title: Remove redundant catch block
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1266
+  Title: Use raw string literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1267
+  Title: Use string interpolation instead of 'string.Concat'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1268
+  Title: Simplify numeric comparison
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RemoveUnnecessaryImportsFixable
+  Title: ''
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: ROS0002
+  Title: Analyzer option is obsolete
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: ROS0003
+  Title: Analyzer requires config option to be specified
+  Category: ''
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RS1001
+  Title: Missing diagnostic analyzer attribute
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1002
+  Title: Missing kind argument when registering an analyzer action
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1003
+  Title: Unsupported SymbolKind argument when registering a symbol analyzer action
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1004
+  Title: Recommend adding language support to diagnostic analyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1005
+  Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1006
+  Title: Invalid type argument for DiagnosticAnalyzer's Register method
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1007
+  Title: Provide localizable arguments to diagnostic descriptor constructor
+  Category: MicrosoftCodeAnalysisLocalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1008
+  Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1009
+  Title: Only internal implementations of this interface are allowed
+  Category: MicrosoftCodeAnalysisCompatibility
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1010
+  Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support
+  Category: Correctness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1011
+  Title: Use code actions that have a unique EquivalenceKey for FixAll occurrences support
+  Category: Correctness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1012
+  Title: Start action has no registered actions
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1013
+  Title: Start action has no registered non-end actions
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1014
+  Title: Do not ignore values returned by methods on immutable objects
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1015
+  Title: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor
+  Category: MicrosoftCodeAnalysisDocumentation
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1016
+  Title: Code fix providers should provide FixAll support
+  Category: Correctness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1017
+  Title: DiagnosticId for analyzers must be a non-null constant
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1018
+  Title: DiagnosticId for analyzers must be in specified format
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1019
+  Title: DiagnosticId must be unique across analyzers
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1020
+  Title: Category for analyzers must be from the specified values
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1021
+  Title: Invalid entry in analyzer category and diagnostic ID range specification file
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1022
+  Title: Do not use types from Workspaces assembly in an analyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1023
+  Title: Upgrade MSBuildWorkspace
+  Category: Library
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1024
+  Title: Symbols should be compared for equality
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1025
+  Title: Configure generated code analysis
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1026
+  Title: Enable concurrent execution
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1027
+  Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1028
+  Title: Provide non-null 'customTags' value to diagnostic descriptor constructor
+  Category: MicrosoftCodeAnalysisDocumentation
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1029
+  Title: Do not use reserved diagnostic IDs
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1030
+  Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1031
+  Title: Define diagnostic title correctly
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1032
+  Title: Define diagnostic message correctly
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1033
+  Title: Define diagnostic description correctly
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1034
+  Title: Prefer 'IsKind' for checking syntax kinds
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1035
+  Title: Do not use APIs banned for analyzers
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1036
+  Title: Specify analyzer banned API enforcement setting
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1037
+  Title: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2000
+  Title: Add analyzer diagnostic IDs to analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2001
+  Title: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2002
+  Title: Do not add removed analyzer diagnostic IDs to unshipped analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2003
+  Title: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2004
+  Title: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2005
+  Title: Remove duplicate entries for diagnostic ID in the same analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2006
+  Title: Remove duplicate entries for diagnostic ID between analyzer releases
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2007
+  Title: Invalid entry in analyzer release file
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2008
+  Title: Enable analyzer release tracking
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S100
+  Title: Methods and properties should be named in PascalCase
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S1006
+  Title: Method overrides should not change parameter defaults
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S101
+  Title: Types should be named in PascalCase
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S103
+  Title: Lines should not be too long
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S104
+  Title: Files should not have too many lines of code
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1048
+  Title: Finalizers should not throw exceptions
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S105
+  Title: Tabulation characters should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S106
+  Title: Standard outputs should not be used directly to log anything
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1066
+  Title: Mergeable "if" statements should be combined
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1067
+  Title: Expressions should not be too complex
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S107
+  Title: Methods should not have too many parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1075
+  Title: URIs should not be hardcoded
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S108
+  Title: Nested blocks of code should not be left empty
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S109
+  Title: Magic numbers should not be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S110
+  Title: Inheritance tree of classes should not be too deep
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1104
+  Title: Fields should not have public accessibility
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1109
+  Title: A close curly brace should be located at the beginning of a line
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1110
+  Title: Redundant pairs of parentheses should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1116
+  Title: Empty statements should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1117
+  Title: Local variables should not shadow class fields or properties
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1118
+  Title: Utility classes should not have public constructors
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S112
+  Title: General or reserved exceptions should never be thrown
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1121
+  Title: Assignments should not be made from within sub-expressions
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1123
+  Title: '"Obsolete" attributes should include explanations'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1125
+  Title: Boolean literals should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1128
+  Title: Unnecessary "using" should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S113
+  Title: Files should end with a newline
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1133
+  Title: Deprecated code should be removed
+  Category: Info Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1134
+  Title: Track uses of "FIXME" tags
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1135
+  Title: Track uses of "TODO" tags
+  Category: Info Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: S1144
+  Title: Unused private types or members should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1147
+  Title: Exit methods should not be called
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1151
+  Title: '"switch case" clauses should not have too many lines of code'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1155
+  Title: '"Any()" should be used to test for emptiness'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1163
+  Title: Exceptions should not be thrown in finally blocks
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1168
+  Title: Empty arrays and collections should be returned instead of null
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1172
+  Title: Unused method parameters should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1185
+  Title: Overriding members should do more than simply call the same member in the base class
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1186
+  Title: Methods should not be empty
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1192
+  Title: String literals should not be duplicated
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1199
+  Title: Nested code blocks should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1200
+  Title: Classes should not be coupled to too many other classes
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1206
+  Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S121
+  Title: Control structures should use curly braces
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1210
+  Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1215
+  Title: '"GC.Collect" should not be called'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S122
+  Title: Statements should be on separate lines
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1226
+  Title: Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1227
+  Title: break statements should not be used except for switch cases
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1244
+  Title: Floating point numbers should not be tested for equality
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S125
+  Title: Sections of code should not be commented out
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S126
+  Title: '"if ... else if" constructs should end with "else" clauses'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1264
+  Title: A "while" loop should be used instead of a "for" loop
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S127
+  Title: '"for" loop stop conditions should be invariant'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1301
+  Title: '"switch" statements should have at least 3 "case" clauses'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1309
+  Title: Track uses of in-source issue suppressions
+  Category: Info Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S131
+  Title: '"switch/Select" statements should contain a "default/Case Else" clauses'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1312
+  Title: Logger fields should be "private static readonly"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1313
+  Title: Using hardcoded IP addresses is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S134
+  Title: Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S138
+  Title: Functions should not have too many lines of code
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1449
+  Title: Culture should be specified for "string" operations
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1450
+  Title: Private fields only used as local variables in methods should become local variables
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1451
+  Title: Track lack of copyright and license headers
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1479
+  Title: '"switch" statements with many "case" clauses should have only one statement'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1481
+  Title: Unused local variables should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1541
+  Title: Methods and properties should not be too complex
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1607
+  Title: Tests should not be ignored
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1643
+  Title: Strings should not be concatenated using '+' in a loop
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1656
+  Title: Variables should not be self-assigned
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1659
+  Title: Multiple variables should not be declared on the same line
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1694
+  Title: An abstract class should have both abstract and concrete methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1696
+  Title: NullReferenceException should not be caught
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1698
+  Title: '"==" should not be used when "Equals" is overridden'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1699
+  Title: Constructors should only call non-overridable methods
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1751
+  Title: Loops with at most one iteration should be refactored
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1764
+  Title: Identical expressions should not be used on both sides of operators
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1821
+  Title: '"switch" statements should not be nested'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1848
+  Title: Objects should not be created to be dropped immediately without being used
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1854
+  Title: Unused assignments should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1858
+  Title: '"ToString()" calls should not be redundant'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1862
+  Title: Related "if/else if" statements should not have the same condition
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1871
+  Title: Two branches in a conditional structure should not have exactly the same implementation
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1905
+  Title: Redundant casts should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1939
+  Title: Inheritance list should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1940
+  Title: Boolean checks should not be inverted
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1944
+  Title: Invalid casts should be avoided
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1994
+  Title: "\"for\" loop increment clauses should modify the loops' counters"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2053
+  Title: Password hashing functions should use an unpredictable salt
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2068
+  Title: Hard-coded credentials are security-sensitive
+  Category: Blocker Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2077
+  Title: Formatting SQL queries is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2092
+  Title: Creating cookies without the "secure" flag is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2094
+  Title: Classes should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2114
+  Title: Collections should not be passed as arguments to their own methods
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2115
+  Title: A secure password should be used when connecting to a database
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2123
+  Title: Values should not be uselessly incremented
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2139
+  Title: Exceptions should be either logged or rethrown but not both
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2148
+  Title: Underscores should be used to make large numbers readable
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2156
+  Title: '"sealed" classes should not have "protected" members'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2166
+  Title: Classes named like "Exception" should extend "Exception" or a subclass
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2178
+  Title: Short-circuit logic should be used in boolean contexts
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2183
+  Title: Integral numbers should not be shifted by zero or more than their number of bits-1
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2184
+  Title: Results of integer division should not be assigned to floating point variables
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2187
+  Title: Test classes should contain at least one test case
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2190
+  Title: Loops and recursions should not be infinite
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2197
+  Title: Modulus results should not be checked for direct equality
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2198
+  Title: Unnecessary mathematical comparisons should not be made
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2201
+  Title: Methods without side effects should not have their return values ignored
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2219
+  Title: Runtime type checking should be simplified
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2221
+  Title: '"Exception" should not be caught'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2222
+  Title: Locks should be released on all paths
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2223
+  Title: Non-constant static fields should not be visible
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2225
+  Title: '"ToString()" method should not return null'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2234
+  Title: Arguments should be passed in the same order as the method parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2245
+  Title: Using pseudorandom number generators (PRNGs) is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2251
+  Title: A "for" loop update clause should move the counter in the right direction
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2252
+  Title: For-loop conditions should be true at least once
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2257
+  Title: Using non-standard cryptographic algorithms is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2259
+  Title: Null pointers should not be dereferenced
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2275
+  Title: Composite format strings should not lead to unexpected behavior at runtime
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2290
+  Title: Field-like events should not be virtual
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2291
+  Title: Overflow checking should not be disabled for "Enumerable.Sum"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2292
+  Title: Trivial properties should be auto-implemented
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2302
+  Title: '"nameof" should be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2306
+  Title: '"async" and "await" should not be used as identifiers'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2325
+  Title: Methods and properties that don't access instance data should be static
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2326
+  Title: Unused type parameters should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2327
+  Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2328
+  Title: '"GetHashCode" should not reference mutable fields'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2330
+  Title: Array covariance should not be used
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2333
+  Title: Redundant modifiers should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2339
+  Title: Public constant members should not be used
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2342
+  Title: Enumeration types should comply with a naming convention
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2344
+  Title: Enumeration type names should not have "Flags" or "Enum" suffixes
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2345
+  Title: Flags enumerations should explicitly initialize all their members
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2346
+  Title: Flags enumerations zero-value members should be named "None"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2357
+  Title: Fields should be private
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2360
+  Title: Optional parameters should not be used
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2365
+  Title: Properties should not make collection or array copies
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2368
+  Title: Public methods should not have multidimensional array parameters
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2372
+  Title: Exceptions should not be thrown from property getters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2376
+  Title: Write-only properties should not be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2386
+  Title: Mutable fields should not be "public static"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2387
+  Title: Child class fields should not shadow parent class fields
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2436
+  Title: Types and methods should not have too many generic parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2437
+  Title: Unnecessary bit operations should not be performed
+  Category: Blocker Code Smell
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: S2445
+  Title: Blocks should be synchronized on read-only fields
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2479
+  Title: Whitespace and control characters in string literals should be explicit
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2486
+  Title: Generic exceptions should not be ignored
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2551
+  Title: Shared resources should not be used for locking
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2583
+  Title: Conditionally executed code should be reachable
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2589
+  Title: Boolean expressions should not be gratuitous
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2612
+  Title: Setting loose file permissions is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2629
+  Title: Logging templates should be constant
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2674
+  Title: The length returned from a stream read should be checked
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2681
+  Title: Multiline blocks should be enclosed in curly braces
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2688
+  Title: '"NaN" should not be used in comparisons'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2692
+  Title: '"IndexOf" checks should not be for positive numbers'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2696
+  Title: Instance members should not write to "static" fields
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2699
+  Title: Tests should include assertions
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2701
+  Title: Literal boolean values should not be used in assertions
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2737
+  Title: '"catch" clauses should do more than rethrow'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2743
+  Title: Static fields should not be used in generic types
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2755
+  Title: XML parsers should not be vulnerable to XXE attacks
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2757
+  Title: Non-existent operators like "=+" should not be used
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2760
+  Title: Sequential tests should not check the same condition
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2761
+  Title: Doubled prefix operators "!!" and "~~" should not be used
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2857
+  Title: SQL keywords should be delimited by whitespace
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2925
+  Title: '"Thread.Sleep" should not be used in tests'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2930
+  Title: '"IDisposables" should be disposed'
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2931
+  Title: Classes with "IDisposable" members should implement "IDisposable"
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2933
+  Title: Fields that are only assigned in the constructor should be "readonly"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2934
+  Title: Property assignments should not be made for "readonly" fields not constrained to reference types
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2952
+  Title: Classes should "Dispose" of members from the classes' own "Dispose" methods
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2953
+  Title: Methods named "Dispose" should implement "IDisposable.Dispose"
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2955
+  Title: Generic parameters not constrained to reference types should not be compared to "null"
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2970
+  Title: Assertions should be complete
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2971
+  Title: LINQ expressions should be simplified
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2995
+  Title: '"Object.ReferenceEquals" should not be used for value types'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2996
+  Title: '"ThreadStatic" fields should not be initialized'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2997
+  Title: '"IDisposables" created in a "using" statement should not be returned'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3005
+  Title: '"ThreadStatic" should not be used on non-static fields'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3010
+  Title: Static fields should not be updated in constructors
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3011
+  Title: Reflection should not be used to increase accessibility of classes, methods, or fields
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3052
+  Title: Members should not be initialized to default values
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3059
+  Title: Types should not have members with visibility set higher than the type's visibility
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3060
+  Title: '"is" should not be used with "this"'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3063
+  Title: '"StringBuilder" data should be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3168
+  Title: '"async" methods should not return "void"'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3169
+  Title: Multiple "OrderBy" calls should not be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3172
+  Title: Delegates should not be subtracted
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3215
+  Title: '"interface" instances should not be cast to concrete types'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3216
+  Title: '"ConfigureAwait(false)" should be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3217
+  Title: '"Explicit" conversions of "foreach" loops should not be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3218
+  Title: Inner class members should not shadow outer class "static" or type members
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3220
+  Title: Method calls should not resolve ambiguously to overloads with "params"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3234
+  Title: '"GC.SuppressFinalize" should not be invoked for types without destructors'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3235
+  Title: Redundant parentheses should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3236
+  Title: Caller information arguments should not be provided explicitly
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3237
+  Title: '"value" contextual keyword should be used'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3240
+  Title: The simplest possible condition syntax should be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3241
+  Title: Methods should not return values that are never used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3242
+  Title: Method parameters should be declared with base types
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3244
+  Title: Anonymous delegates should not be used to unsubscribe from Events
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3246
+  Title: Generic type parameters should be co/contravariant when possible
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3247
+  Title: Duplicate casts should not be made
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3249
+  Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3251
+  Title: Implementations should be provided for "partial" methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3253
+  Title: Constructor and destructor declarations should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3254
+  Title: Default parameter values should not be passed as arguments
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3256
+  Title: '"string.IsNullOrEmpty" should be used'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3257
+  Title: Declarations and initializations should be as concise as possible
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3260
+  Title: Non-derived "private" classes and records should be "sealed"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3261
+  Title: Namespaces should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3262
+  Title: '"params" should be used on overrides'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3263
+  Title: 'Static fields should appear in the order they must be initialized '
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3264
+  Title: Events should be invoked
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3265
+  Title: Non-flags enums should not be used in bitwise operations
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3267
+  Title: Loops should be simplified with "LINQ" expressions
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3329
+  Title: Cipher Block Chaining IVs should be unpredictable
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3330
+  Title: Creating cookies without the "HttpOnly" flag is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3343
+  Title: Caller information parameters should come at the end of the parameter list
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3346
+  Title: Expressions used in "Debug.Assert" should not produce side effects
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3353
+  Title: Unchanged variables should be marked as "const"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3358
+  Title: Ternary operators should not be nested
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3363
+  Title: Date and time should not be used as a type for primary keys
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3366
+  Title: '"this" should not be exposed from constructors'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3376
+  Title: Attribute, EventArgs, and Exception type names should end with the type being extended
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3397
+  Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3398
+  Title: '"private" methods called only by inner classes should be moved to those classes'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3400
+  Title: Methods should not return constants
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3415
+  Title: Assertion arguments should be passed in the correct order
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3416
+  Title: Loggers should be named for their enclosing types
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3427
+  Title: Method overloads with default parameter values should not overlap
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3431
+  Title: '"[ExpectedException]" should not be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3433
+  Title: Test method signatures should be correct
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3440
+  Title: Variables should not be checked against the values they're about to be assigned
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3441
+  Title: Redundant property names should be omitted in anonymous classes
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3442
+  Title: '"abstract" classes should not have "public" constructors'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3443
+  Title: Type should not be examined on "System.Type" instances
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3444
+  Title: Interfaces should not simply inherit from base interfaces with colliding members
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3445
+  Title: Exceptions should not be explicitly rethrown
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3447
+  Title: '"[Optional]" should not be used on "ref" or "out" parameters'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3449
+  Title: Right operands of shift operators should be integers
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3450
+  Title: Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3451
+  Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3453
+  Title: Classes should not have only "private" constructors
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3456
+  Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3457
+  Title: Composite format strings should be used correctly
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3458
+  Title: Empty "case" clauses that fall through to the "default" should be omitted
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3459
+  Title: Unassigned members should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3464
+  Title: Type inheritance should not be recursive
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3466
+  Title: Optional parameters should be passed to "base" calls
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3532
+  Title: Empty "default" clauses should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3597
+  Title: '"ServiceContract" and "OperationContract" attributes should be used together'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3598
+  Title: One-way "OperationContract" methods should have "void" return type
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3600
+  Title: '"params" should not be introduced on overrides'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3603
+  Title: 'Methods with "Pure" attribute should return a value '
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3604
+  Title: Member initializer values should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3610
+  Title: Nullable type comparison should not be redundant
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3626
+  Title: Jump statements should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3655
+  Title: Empty nullable value should not be accessed
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3717
+  Title: Track use of "NotImplementedException"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3776
+  Title: Cognitive Complexity of methods should not be too high
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3869
+  Title: '"SafeHandle.DangerousGetHandle" should not be called'
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3871
+  Title: Exception types should be "public"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3872
+  Title: Parameter names should not duplicate the names of their methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3874
+  Title: '"out" and "ref" parameters should not be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3875
+  Title: '"operator==" should not be overloaded on reference types'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3876
+  Title: Strings or integral types should be used for indexers
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3877
+  Title: Exceptions should not be thrown from unexpected methods
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3878
+  Title: Arrays should not be created for params parameters
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3880
+  Title: Finalizers should not be empty
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3881
+  Title: '"IDisposable" should be implemented correctly'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3884
+  Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used'
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3885
+  Title: '"Assembly.Load" should be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3887
+  Title: Mutable, non-private fields should not be "readonly"
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3889
+  Title: '"Thread.Resume" and "Thread.Suspend" should not be used'
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3897
+  Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3898
+  Title: Value types should implement "IEquatable<T>"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3900
+  Title: Arguments of public methods should be validated against null
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S3902
+  Title: '"Assembly.GetExecutingAssembly" should not be called'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3903
+  Title: Types should be defined in named namespaces
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3904
+  Title: Assemblies should have version information
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3906
+  Title: Event Handlers should have the correct signature
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3908
+  Title: Generic event handlers should be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3909
+  Title: Collections should implement the generic interface
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3923
+  Title: All branches in a conditional structure should not have exactly the same implementation
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3925
+  Title: '"ISerializable" should be implemented correctly'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3926
+  Title: Deserialization methods should be provided for "OptionalField" members
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3927
+  Title: Serialization event handlers should be implemented correctly
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3928
+  Title: 'Parameter names used into ArgumentException constructors should match an existing one '
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3937
+  Title: Number patterns should be regular
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3949
+  Title: Calculations should not overflow
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3956
+  Title: '"Generic.List" instances should not be part of public APIs'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3962
+  Title: '"static readonly" constants should be "const" instead'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3963
+  Title: '"static" fields should be initialized inline'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3966
+  Title: Objects should not be disposed more than once
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3967
+  Title: Multidimensional arrays should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3971
+  Title: '"GC.SuppressFinalize" should not be called'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3972
+  Title: Conditionals should start on new lines
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3973
+  Title: A conditionally executed single line should be denoted by indentation
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3981
+  Title: Collection sizes and array length comparisons should make sense
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3984
+  Title: Exceptions should not be created without being thrown
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3990
+  Title: Assemblies should be marked as CLS compliant
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3992
+  Title: Assemblies should explicitly specify COM visibility
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3993
+  Title: Custom attributes should be marked with "System.AttributeUsageAttribute"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3994
+  Title: URI Parameters should not be strings
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3995
+  Title: URI return values should not be strings
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3996
+  Title: URI properties should not be strings
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3997
+  Title: String URI overloads should call "System.Uri" overloads
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3998
+  Title: Threads should not lock on objects with weak identity
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4000
+  Title: Pointers to unmanaged memory should not be visible
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4002
+  Title: Disposable types should declare finalizers
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4004
+  Title: Collection properties should be readonly
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4005
+  Title: '"System.Uri" arguments should be used instead of strings'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4015
+  Title: Inherited member visibility should not be decreased
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4016
+  Title: Enumeration members should not be named "Reserved"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4017
+  Title: Method signatures should not contain nested generic types
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4018
+  Title: All type parameters should be used in the parameter list to enable type inference
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4019
+  Title: Base class methods should not be hidden
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4022
+  Title: Enumerations should have "Int32" storage
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4023
+  Title: Interfaces should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4025
+  Title: Child class fields should not differ from parent class fields only by capitalization
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4026
+  Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4027
+  Title: Exceptions should provide standard constructors
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4035
+  Title: Classes implementing "IEquatable<T>" should be sealed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4036
+  Title: Searching OS commands in PATH is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4039
+  Title: Interface methods should be callable by derived types
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4040
+  Title: Strings should be normalized to uppercase
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4041
+  Title: Type names should not match namespaces
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4047
+  Title: Generics should be used when appropriate
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4049
+  Title: Properties should be preferred
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4050
+  Title: Operators should be overloaded consistently
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4052
+  Title: Types should not extend outdated base types
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4055
+  Title: Literals should not be passed as localized parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4056
+  Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4057
+  Title: Locales should be set for data types
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4058
+  Title: Overloads with a "StringComparison" parameter should be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4059
+  Title: Property names should not match get methods
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4060
+  Title: Non-abstract attributes should be sealed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4061
+  Title: '"params" should be used instead of "varargs"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4069
+  Title: Operator overloads should have named alternatives
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4070
+  Title: Non-flags enums should not be marked with "FlagsAttribute"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4136
+  Title: Method overloads should be grouped together
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4143
+  Title: Collection elements should not be replaced unconditionally
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4144
+  Title: Methods should not have identical implementations
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4158
+  Title: Empty collections should not be accessed or iterated
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4159
+  Title: Classes should implement their "ExportAttribute" interfaces
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4200
+  Title: Native methods should be wrapped
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4201
+  Title: Null checks should not be combined with "is" operator checks
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4210
+  Title: Windows Forms entry points should be marked with STAThread
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4211
+  Title: Members should not have conflicting transparency annotations
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4212
+  Title: Serialization constructors should be secured
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4214
+  Title: '"P/Invoke" methods should not be visible'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4220
+  Title: Events should have proper arguments
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4225
+  Title: Extension methods should not extend "object"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4226
+  Title: Extensions should be in separate namespaces
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4260
+  Title: '"ConstructorArgument" parameters should exist in constructors'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4261
+  Title: Methods should be named according to their synchronicities
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4275
+  Title: Getters and setters should access the expected fields
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4277
+  Title: '"Shared" parts should not be created with "new"'
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4347
+  Title: Secure random number generators should not output predictable values
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4423
+  Title: Weak SSL/TLS protocols should not be used
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4426
+  Title: Cryptographic keys should be robust
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4428
+  Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4433
+  Title: LDAP connections should be authenticated
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4456
+  Title: Parameter validation in yielding methods should be wrapped
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4457
+  Title: Parameter validation in "async"/"await" methods should be wrapped
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4462
+  Title: Calls to "async" methods should not be blocking
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4487
+  Title: Unread "private" fields should be removed
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4502
+  Title: Disabling CSRF protections is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4507
+  Title: Delivering code in production with debug features activated is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4524
+  Title: '"default" clauses should be first or last'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4545
+  Title: '"DebuggerDisplayAttribute" strings should reference existing members'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4581
+  Title: '"new Guid()" should not be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4583
+  Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4586
+  Title: Non-async "Task/Task<T>" methods should not return null
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4635
+  Title: Start index should be used instead of calling Substring
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4663
+  Title: Comments should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4790
+  Title: Using weak hashing algorithms is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4792
+  Title: Configuring loggers is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4830
+  Title: Server certificates should be verified during SSL/TLS connections
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5034
+  Title: '"ValueTask" should be consumed correctly'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5042
+  Title: Expanding archive files without controlling resource consumption is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5122
+  Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5332
+  Title: Using clear-text protocols is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5344
+  Title: Passwords should not be stored in plaintext or with a fast hashing algorithm
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5443
+  Title: Using publicly writable directories is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5445
+  Title: Insecure temporary file creation methods should not be used
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5542
+  Title: Encryption algorithms should be used with secure mode and padding scheme
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5547
+  Title: Cipher algorithms should be robust
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5659
+  Title: JWT should be signed and verified with strong cipher algorithms
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5693
+  Title: Allowing requests with excessive content length is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5753
+  Title: Disabling ASP.NET "Request Validation" feature is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5766
+  Title: Deserializing objects without performing data validation is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5773
+  Title: Types allowed to be deserialized should be restricted
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5856
+  Title: Regular expressions should be syntactically valid
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6354
+  Title: Use a testable date/time provider
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6377
+  Title: XML signatures should be validated securely
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6419
+  Title: Azure Functions should be stateless
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6420
+  Title: Client instances should not be recreated on each Azure Function invocation
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6421
+  Title: Azure Functions should use Structured Error Handling
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6422
+  Title: Calls to "async" methods should not be blocking in Azure Functions
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6423
+  Title: Azure Functions should log all failures
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6424
+  Title: Interfaces for durable entities should satisfy the restrictions
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6444
+  Title: Not specifying a timeout for regular expressions is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6507
+  Title: Blocks should not be synchronized on local variables
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S6513
+  Title: '"ExcludeFromCodeCoverage" attributes should include a justification'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6561
+  Title: Avoid using "DateTime.Now" for benchmarking or timing operations
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6562
+  Title: Always set the "DateTimeKind" when creating new "DateTime" instances
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6563
+  Title: Use UTC when recording DateTime instants
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6566
+  Title: Use "DateTimeOffset" instead of "DateTime"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6575
+  Title: Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6580
+  Title: Use a format provider when parsing date and time
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6585
+  Title: Don't hardcode the format when turning dates and times to strings
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6588
+  Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6602
+  Title: '"Find" method should be used instead of the "FirstOrDefault" extension'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6603
+  Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6605
+  Title: Collection-specific "Exists" method should be used instead of the "Any" extension
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6607
+  Title: The collection should be filtered before sorting by using "Where" before "OrderBy"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6608
+  Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6609
+  Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6610
+  Title: '"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6612
+  Title: The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6613
+  Title: '"First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6617
+  Title: '"Contains" should be used instead of "Any" for simple equality checks'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6618
+  Title: '"string.Create" should be used instead of "FormattableString"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6640
+  Title: Using unsafe code blocks is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6664
+  Title: The code block contains too many logging calls
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6667
+  Title: Logging in a catch clause should pass the caught exception as a parameter.
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6668
+  Title: Logging arguments should be passed to the correct parameter
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6669
+  Title: Logger field or property name should comply with a naming convention
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6670
+  Title: '"Trace.Write" and "Trace.WriteLine" should not be used'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6672
+  Title: Generic logger injection should match enclosing type
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6673
+  Title: Log message template placeholders should be in the right order
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6674
+  Title: Log message template should be syntactically correct
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6675
+  Title: '"Trace.WriteLineIf" should not be used with "TraceSwitch" levels'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6677
+  Title: Message template placeholders should be unique
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6678
+  Title: Use PascalCase for named placeholders
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6781
+  Title: JWT secret keys should not be disclosed
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6797
+  Title: Blazor query parameter type should be supported
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6798
+  Title: '[JSInvokable] attribute should only be used on public methods'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6800
+  Title: Component parameter type should match the route parameter type constraint
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6802
+  Title: Using lambda expressions in loops should be avoided in Blazor markup section
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6803
+  Title: Parameters with SupplyParameterFromQuery attribute should be used only in routable components
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S6930
+  Title: Backslash should be avoided in route templates
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6931
+  Title: ASP.NET controller actions should not have a route template starting with "/"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6932
+  Title: Use model binding instead of reading raw request data
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6934
+  Title: A Route attribute should be added to the controller when a route template is specified at the action level
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6960
+  Title: Controllers should not have mixed responsibilities
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6961
+  Title: API Controllers should derive from ControllerBase instead of Controller
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6962
+  Title: You should pool HTTP connections with HttpClientFactory
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6964
+  Title: Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6965
+  Title: REST API actions should be annotated with an HTTP verb attribute
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6966
+  Title: Awaitable method should be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6967
+  Title: ModelState.IsValid should be called in controller actions
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6968
+  Title: Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S818
+  Title: Literal suffixes should be upper case
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S881
+  Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S907
+  Title: '"goto" statement should not be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S927
+  Title: Parameter names should match base declaration and other partial definitions
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S9999-cpd
+  Title: Copy-paste token calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-log
+  Title: Log generator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-metadata
+  Title: File metadata generator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-metrics
+  Title: Metrics calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-symbolRef
+  Title: Symbol reference calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-token-type
+  Title: Token type calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-warning
+  Title: Analysis Warning generator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: SA0001
+  Title: XML comment analysis disabled
+  Category: StyleCop.CSharp.SpecialRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA0002
+  Title: Invalid settings file
+  Category: StyleCop.CSharp.SpecialRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1000
+  Title: Keywords should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1001
+  Title: Commas should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1002
+  Title: Semicolons should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1003
+  Title: Symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1004
+  Title: Documentation lines should begin with single space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1005
+  Title: Single line comments should begin with single space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1006
+  Title: Preprocessor keywords should not be preceded by space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1007
+  Title: Operator keyword should be followed by space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1008
+  Title: Opening parenthesis should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1009
+  Title: Closing parenthesis should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1010
+  Title: Opening square brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1011
+  Title: Closing square brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1012
+  Title: Opening braces should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1013
+  Title: Closing braces should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1014
+  Title: Opening generic brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1015
+  Title: Closing generic brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1016
+  Title: Opening attribute brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1017
+  Title: Closing attribute brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1018
+  Title: Nullable type symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1019
+  Title: Member access symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1020
+  Title: Increment decrement symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1021
+  Title: Negative signs should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1022
+  Title: Positive signs should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1023
+  Title: Dereference and access of symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1024
+  Title: Colons Should Be Spaced Correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1025
+  Title: Code should not contain multiple whitespace in a row
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1026
+  Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1027
+  Title: Use tabs correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1028
+  Title: Code should not contain trailing whitespace
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1100
+  Title: Do not prefix calls with base unless local implementation exists
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1101
+  Title: Prefix local calls with this
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1102
+  Title: Query clause should follow previous clause
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1103
+  Title: Query clauses should be on separate lines or all on one line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1104
+  Title: Query clause should begin on new line when previous clause spans multiple lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1105
+  Title: Query clauses spanning multiple lines should begin on own line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1106
+  Title: Code should not contain empty statements
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1107
+  Title: Code should not contain multiple statements on one line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1108
+  Title: Block statements should not contain embedded comments
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1109
+  Title: Block statements should not contain embedded regions
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1110
+  Title: Opening parenthesis or bracket should be on declaration line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1111
+  Title: Closing parenthesis should be on line of last parameter
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1112
+  Title: Closing parenthesis should be on line of opening parenthesis
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1113
+  Title: Comma should be on the same line as previous parameter
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1114
+  Title: Parameter list should follow declaration
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1115
+  Title: Parameter should follow comma
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1116
+  Title: Split parameters should start on line after declaration
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1117
+  Title: Parameters should be on same line or separate lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1118
+  Title: Parameter should not span multiple lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1119
+  Title: Statement should not use unnecessary parenthesis
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1119_p
+  Title: Statement should not use unnecessary parenthesis
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SA1120
+  Title: Comments should contain text
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1121
+  Title: Use built-in type alias
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1122
+  Title: Use string.Empty for empty strings
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1123
+  Title: Do not place regions within elements
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1124
+  Title: Do not use regions
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1125
+  Title: Use shorthand for nullable types
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1126
+  Title: Prefix calls correctly
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1127
+  Title: Generic type constraints should be on their own line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1128
+  Title: Put constructor initializers on their own line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1129
+  Title: Do not use default value type constructor
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1130
+  Title: Use lambda syntax
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1131
+  Title: Use readable conditions
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1132
+  Title: Do not combine fields
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1133
+  Title: Do not combine attributes
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1134
+  Title: Attributes should not share line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1135
+  Title: Using directives should be qualified
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1136
+  Title: Enum values should be on separate lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1137
+  Title: Elements should have the same indentation
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1139
+  Title: Use literal suffix notation instead of casting
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1141
+  Title: Use tuple syntax
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1142
+  Title: Refer to tuple fields by name
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1200
+  Title: Using directives should be placed correctly
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1201
+  Title: Elements should appear in the correct order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1202
+  Title: Elements should be ordered by access
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1203
+  Title: Constants should appear before fields
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1204
+  Title: Static elements should appear before instance elements
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1205
+  Title: Partial elements should declare access
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1206
+  Title: Declaration keywords should follow order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1207
+  Title: Protected should come before internal
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1208
+  Title: System using directives should be placed before other using directives
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1209
+  Title: Using alias directives should be placed after other using directives
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1210
+  Title: Using directives should be ordered alphabetically by namespace
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1211
+  Title: Using alias directives should be ordered alphabetically by alias name
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1212
+  Title: Property accessors should follow order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1213
+  Title: Event accessors should follow order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1214
+  Title: Readonly fields should appear before non-readonly fields
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1216
+  Title: Using static directives should be placed at the correct location
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1217
+  Title: Using static directives should be ordered alphabetically
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1300
+  Title: Element should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1301
+  Title: Element should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1302
+  Title: Interface names should begin with I
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1303
+  Title: Const field names should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1304
+  Title: Non-private readonly fields should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1305
+  Title: Field names should not use Hungarian notation
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1306
+  Title: Field names should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1307
+  Title: Accessible fields should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1308
+  Title: Variable names should not be prefixed
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1309
+  Title: Field names should not begin with underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - None
+  IsEverSuppressed: true
+- Id: SA1310
+  Title: Field names should not contain underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1311
+  Title: Static readonly fields should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1312
+  Title: Variable names should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1313
+  Title: Parameter names should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1314
+  Title: Type parameter names should begin with T
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1316
+  Title: Tuple element names should use correct casing
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1400
+  Title: Access modifier should be declared
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1401
+  Title: Fields should be private
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1402
+  Title: File may only contain a single type
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1403
+  Title: File may only contain a single namespace
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1404
+  Title: Code analysis suppression should have justification
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1405
+  Title: Debug.Assert should provide message text
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1406
+  Title: Debug.Fail should provide message text
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1407
+  Title: Arithmetic expressions should declare precedence
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1408
+  Title: Conditional expressions should declare precedence
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1409
+  Title: Remove unnecessary code
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1410
+  Title: Remove delegate parenthesis when possible
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1411
+  Title: Attribute constructor should not use unnecessary parenthesis
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1412
+  Title: Store files as UTF-8 with byte order mark
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1413
+  Title: Use trailing comma in multi-line initializers
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1414
+  Title: Tuple types in signatures should have element names
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1500
+  Title: Braces for multi-line statements should not share line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1501
+  Title: Statement should not be on a single line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1502
+  Title: Element should not be on a single line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1503
+  Title: Braces should not be omitted
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1504
+  Title: All accessors should be single-line or multi-line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1505
+  Title: Opening braces should not be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1506
+  Title: Element documentation headers should not be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1507
+  Title: Code should not contain multiple blank lines in a row
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1508
+  Title: Closing braces should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1509
+  Title: Opening braces should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1510
+  Title: Chained statement blocks should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1511
+  Title: While-do footer should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1512
+  Title: Single-line comments should not be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1513
+  Title: Closing brace should be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1514
+  Title: Element documentation header should be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1515
+  Title: Single-line comment should be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1516
+  Title: Elements should be separated by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1517
+  Title: Code should not contain blank lines at start of file
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1518
+  Title: Use line endings correctly at end of file
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1519
+  Title: Braces should not be omitted from multi-line child statement
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1520
+  Title: Use braces consistently
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1600
+  Title: Elements should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1601
+  Title: Partial elements should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: SA1602
+  Title: Enumeration items should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1603
+  Title: Documentation should contain valid XML
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1604
+  Title: Element documentation should have summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1605
+  Title: Partial element documentation should have summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1606
+  Title: Element documentation should have summary text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1607
+  Title: Partial element documentation should have summary text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1608
+  Title: Element documentation should not have default summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1609
+  Title: Property documentation should have value
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1610
+  Title: Property documentation should have value text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1611
+  Title: Element parameters should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1612
+  Title: Element parameter documentation should match element parameters
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1613
+  Title: Element parameter documentation should declare parameter name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1614
+  Title: Element parameter documentation should have text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1615
+  Title: Element return value should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1616
+  Title: Element return value documentation should have text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1617
+  Title: Void return value should not be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1618
+  Title: Generic type parameters should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1619
+  Title: Generic type parameters should be documented partial class
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1620
+  Title: Generic type parameter documentation should match type parameters
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1621
+  Title: Generic type parameter documentation should declare parameter name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1622
+  Title: Generic type parameter documentation should have text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1623
+  Title: Property summary documentation should match accessors
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1624
+  Title: Property summary documentation should omit accessor with restricted access
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1625
+  Title: Element documentation should not be copied and pasted
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1626
+  Title: Single-line comments should not use documentation style slashes
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1627
+  Title: Documentation text should not be empty
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1628
+  Title: Documentation text should begin with a capital letter
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1629
+  Title: Documentation text should end with a period
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1630
+  Title: Documentation text should contain whitespace
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1631
+  Title: Documentation should meet character percentage
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1632
+  Title: Documentation text should meet minimum character length
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1633
+  Title: File should have header
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1634
+  Title: File header should show copyright
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1635
+  Title: File header should have copyright text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1636
+  Title: File header copyright text should match
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1637
+  Title: File header should contain file name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1638
+  Title: File header file name documentation should match file name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1639
+  Title: File header should have summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: SA1640
+  Title: File header should have valid company text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1641
+  Title: File header company name text should match
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1642
+  Title: Constructor summary documentation should begin with standard text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1643
+  Title: Destructor summary documentation should begin with standard text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1644
+  Title: Documentation headers should not contain blank lines
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1645
+  Title: Included documentation file does not exist
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1646
+  Title: Included documentation XPath does not exist
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1647
+  Title: Include node does not contain valid file and path
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1648
+  Title: inheritdoc should be used with inheriting class
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1649
+  Title: File name should match first type name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1650
+  Title: Element documentation should be spelled correctly
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1651
+  Title: Do not use placeholder elements
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SX1101
+  Title: Do not prefix local calls with 'this.'
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SX1309
+  Title: Field names should begin with underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SX1309S
+  Title: Static field names should begin with underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SYSLIB1045
+  Title: Convert to 'GeneratedRegexAttribute'.
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SYSLIB1054
+  Title: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SYSLIB1055
+  Title: Invalid 'CustomMarshallerAttribute' usage
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1056
+  Title: Specified marshaller type is invalid
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1057
+  Title: Marshaller type does not have the required shape
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1058
+  Title: Invalid 'NativeMarshallingAttribute' usage
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1060
+  Title: Specified marshaller type is invalid
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1061
+  Title: Marshaller type has incompatible method signatures
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1090
+  Title: "'GeneratedComInterfaceType' does not support the 'ComInterfaceType' value supplied to 'InterfaceTypeAttribute' on the same type."
+  Category: ComInterfaceGenerator
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1096
+  Title: Convert to 'GeneratedComInterface'
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SYSLIB1097
+  Title: Add 'GeneratedComClassAttribute' to enable passing objects of this type to COM
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SYSLIB1098
+  Title: .NET COM hosting with 'EnableComHosting' does not support interfaces with the 'GeneratedComInterfaceAttribute'
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1099
+  Title: COM Interop APIs on 'System.Runtime.InteropServices.Marshal' do not support source-generated COM
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD001
+  Title: Avoid legacy thread switching APIs
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD002
+  Title: Avoid problematic synchronous waits
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: true
+- Id: VSTHRD003
+  Title: Avoid awaiting foreign Tasks
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD004
+  Title: Await SwitchToMainThreadAsync
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD010
+  Title: Invoke single-threaded types on Main thread
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD011
+  Title: Use AsyncLazy<T>
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD012
+  Title: Provide JoinableTaskFactory where allowed
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD100
+  Title: Avoid async void methods
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD101
+  Title: Avoid unsupported async delegates
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD102
+  Title: Implement internal logic asynchronously
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD103
+  Title: Call async methods when in an async method
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD104
+  Title: Offer async methods
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD105
+  Title: Avoid method overloads that assume TaskScheduler.Current
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD106
+  Title: Use InvokeAsync to raise async events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD107
+  Title: Await Task within using expression
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD108
+  Title: Assert thread affinity unconditionally
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD109
+  Title: Switch instead of assert in async methods
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD110
+  Title: Observe result of async calls
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD111
+  Title: Use ConfigureAwait(bool)
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: VSTHRD112
+  Title: Implement System.IAsyncDisposable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD113
+  Title: Check for System.IAsyncDisposable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD114
+  Title: Avoid returning a null Task
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD200
+  Title: Use "Async" suffix for async methods
+  Category: Style
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - None
+  IsEverSuppressed: true
+- Id: CS8762
+  Title: Parameter must have a non-null value when exiting in some condition.
+  Category: Compiler
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: true
+- Id: CS1591
+  Title: Missing XML comment for publicly visible type or member
+  Category: Compiler
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false

--- a/tests/Moq.Analyzers.Benchmarks/SquiggleCop.Baseline.yaml
+++ b/tests/Moq.Analyzers.Benchmarks/SquiggleCop.Baseline.yaml
@@ -1,12627 +1,1577 @@
-- Id: CA1000
-  Title: Do not declare static members on generic types
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1001
-  Title: Types that own disposable fields should be disposable
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1002
-  Title: Do not expose generic lists
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1003
-  Title: Use generic event handler instances
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1005
-  Title: Avoid excessive parameters on generic types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1008
-  Title: Enums should have zero value
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1010
-  Title: Generic interface should also be implemented
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1012
-  Title: Abstract types should not have public constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1014
-  Title: Mark assemblies with CLSCompliant
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1016
-  Title: Mark assemblies with assembly version
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1017
-  Title: Mark assemblies with ComVisible
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1018
-  Title: Mark attributes with AttributeUsageAttribute
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1019
-  Title: Define accessors for attribute arguments
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1021
-  Title: Avoid out parameters
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1024
-  Title: Use properties where appropriate
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1027
-  Title: Mark enums with FlagsAttribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1028
-  Title: Enum Storage should be Int32
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1030
-  Title: Use events where appropriate
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1031
-  Title: Do not catch general exception types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1032
-  Title: Implement standard exception constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1033
-  Title: Interface methods should be callable by child types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1034
-  Title: Nested types should not be visible
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1036
-  Title: Override methods on comparable types
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1040
-  Title: Avoid empty interfaces
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1041
-  Title: Provide ObsoleteAttribute message
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1043
-  Title: Use Integral Or String Argument For Indexers
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1044
-  Title: Properties should not be write only
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1045
-  Title: Do not pass types by reference
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1046
-  Title: Do not overload equality operator on reference types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1050
-  Title: Declare types in namespaces
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1051
-  Title: Do not declare visible instance fields
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1052
-  Title: Static holder types should be Static or NotInheritable
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1054
-  Title: URI-like parameters should not be strings
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1055
-  Title: URI-like return values should not be strings
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1056
-  Title: URI-like properties should not be strings
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1058
-  Title: Types should not extend certain base types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1060
-  Title: Move pinvokes to native methods class
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1061
-  Title: Do not hide base class methods
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1062
-  Title: Validate arguments of public methods
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1063
-  Title: Implement IDisposable Correctly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1064
-  Title: Exceptions should be public
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1065
-  Title: Do not raise exceptions in unexpected locations
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1066
-  Title: Implement IEquatable when overriding Object.Equals
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: CA1067
-  Title: Override Object.Equals(object) when implementing IEquatable<T>
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1068
-  Title: CancellationToken parameters must come last
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1069
-  Title: Enums values should not be duplicated
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1070
-  Title: Do not declare event fields as virtual
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1200
-  Title: Avoid using cref tags with a prefix
-  Category: Documentation
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1303
-  Title: Do not pass literals as localized parameters
-  Category: Globalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1304
-  Title: Specify CultureInfo
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1305
-  Title: Specify IFormatProvider
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1307
-  Title: Specify StringComparison for clarity
-  Category: Globalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1308
-  Title: Normalize strings to uppercase
-  Category: Globalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1309
-  Title: Use ordinal string comparison
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1310
-  Title: Specify StringComparison for correctness
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1311
-  Title: Specify a culture or use an invariant version
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1401
-  Title: P/Invokes should not be visible
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1416
-  Title: Validate platform compatibility
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1417
-  Title: Do not use 'OutAttribute' on string parameters for P/Invokes
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1418
-  Title: Use valid platform string
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1419
-  Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1420
-  Title: Property, type, or attribute requires runtime marshalling
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1421
-  Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1422
-  Title: Validate platform compatibility
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1501
-  Title: Avoid excessive inheritance
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1502
-  Title: Avoid excessive complexity
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1505
-  Title: Avoid unmaintainable code
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1506
-  Title: Avoid excessive class coupling
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1507
-  Title: Use nameof to express symbol names
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1508
-  Title: Avoid dead conditional code
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1509
-  Title: Invalid entry in code metrics rule specification file
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1510
-  Title: Use ArgumentNullException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1511
-  Title: Use ArgumentException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1512
-  Title: Use ArgumentOutOfRangeException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1513
-  Title: Use ObjectDisposedException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1700
-  Title: Do not name enum values 'Reserved'
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1707
-  Title: Identifiers should not contain underscores
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1708
-  Title: Identifiers should differ by more than case
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1710
-  Title: Identifiers should have correct suffix
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1711
-  Title: Identifiers should not have incorrect suffix
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1712
-  Title: Do not prefix enum values with type name
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1713
-  Title: Events should not have 'Before' or 'After' prefix
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1715
-  Title: Identifiers should have correct prefix
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1716
-  Title: Identifiers should not match keywords
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1720
-  Title: Identifier contains type name
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1721
-  Title: Property names should not match get methods
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1724
-  Title: Type names should not match namespaces
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1725
-  Title: Parameter names should match base declaration
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1727
-  Title: Use PascalCase for named placeholders
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1802
-  Title: Use literals where appropriate
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1805
-  Title: Do not initialize unnecessarily
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1806
-  Title: Do not ignore method results
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1810
-  Title: Initialize reference type static fields inline
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1812
-  Title: Avoid uninstantiated internal classes
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1813
-  Title: Avoid unsealed attributes
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1814
-  Title: Prefer jagged arrays over multidimensional
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1815
-  Title: Override equals and operator equals on value types
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1816
-  Title: Dispose methods should call SuppressFinalize
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1819
-  Title: Properties should not return arrays
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1820
-  Title: Test for empty strings using string length
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1821
-  Title: Remove empty Finalizers
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1822
-  Title: Mark members as static
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1823
-  Title: Avoid unused private fields
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1824
-  Title: Mark assemblies with NeutralResourcesLanguageAttribute
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1825
-  Title: Avoid zero-length array allocations
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1826
-  Title: Do not use Enumerable methods on indexable collections
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1827
-  Title: Do not use Count() or LongCount() when Any() can be used
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1828
-  Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1829
-  Title: Use Length/Count property instead of Count() when available
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1830
-  Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1831
-  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1832
-  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1833
-  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1834
-  Title: Consider using 'StringBuilder.Append(char)' when applicable
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1835
-  Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1836
-  Title: Prefer IsEmpty over Count
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1837
-  Title: Use 'Environment.ProcessId'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1838
-  Title: Avoid 'StringBuilder' parameters for P/Invokes
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1839
-  Title: Use 'Environment.ProcessPath'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1840
-  Title: Use 'Environment.CurrentManagedThreadId'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1841
-  Title: Prefer Dictionary.Contains methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1842
-  Title: Do not use 'WhenAll' with a single task
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1843
-  Title: Do not use 'WaitAll' with a single task
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1844
-  Title: Provide memory-based overrides of async methods when subclassing 'Stream'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1845
-  Title: Use span-based 'string.Concat'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1846
-  Title: Prefer 'AsSpan' over 'Substring'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1847
-  Title: Use char literal for a single character lookup
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1848
-  Title: Use the LoggerMessage delegates
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1849
-  Title: Call async methods when in an async method
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1850
-  Title: Prefer static 'HashData' method over 'ComputeHash'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1851
-  Title: Possible multiple enumerations of 'IEnumerable' collection
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1852
-  Title: Seal internal types
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1853
-  Title: Unnecessary call to 'Dictionary.ContainsKey(key)'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1854
-  Title: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1855
-  Title: Prefer 'Clear' over 'Fill'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1856
-  Title: Incorrect usage of ConstantExpected attribute
-  Category: Performance
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1857
-  Title: A constant is expected for the parameter
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1858
-  Title: Use 'StartsWith' instead of 'IndexOf'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1859
-  Title: Use concrete types when possible for improved performance
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1860
-  Title: Avoid using 'Enumerable.Any()' extension method
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1861
-  Title: Avoid constant arrays as arguments
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1862
-  Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1863
-  Title: Use 'CompositeFormat'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1864
-  Title: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1865
-  Title: Use char overload
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1866
-  Title: Use char overload
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1867
-  Title: Use char overload
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: CA1868
-  Title: Unnecessary call to 'Contains(item)'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1869
-  Title: Cache and reuse 'JsonSerializerOptions' instances
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1870
-  Title: Use a cached 'SearchValues' instance
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2000
-  Title: Dispose objects before losing scope
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2002
-  Title: Do not lock on objects with weak identity
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2007
-  Title: Consider calling ConfigureAwait on the awaited task
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2008
-  Title: Do not create tasks without passing a TaskScheduler
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2009
-  Title: Do not call ToImmutableCollection on an ImmutableCollection value
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2011
-  Title: Avoid infinite recursion
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2012
-  Title: Use ValueTasks correctly
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2013
-  Title: Do not use ReferenceEquals with value types
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2014
-  Title: Do not use stackalloc in loops
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2015
-  Title: Do not define finalizers for types derived from MemoryManager<T>
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2016
-  Title: Forward the 'CancellationToken' parameter to methods
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: CA2017
-  Title: Parameter count mismatch
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2018
-  Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument"
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2019
-  Title: Improper 'ThreadStatic' field initialization
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2020
-  Title: Prevent behavioral change
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2021
-  Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2100
-  Title: Review SQL queries for security vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2101
-  Title: Specify marshaling for P/Invoke string arguments
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2119
-  Title: Seal methods that satisfy private interfaces
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2153
-  Title: Do Not Catch Corrupted State Exceptions
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2200
-  Title: Rethrow to preserve stack details
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2201
-  Title: Do not raise reserved exception types
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA2207
-  Title: Initialize value type static fields inline
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2208
-  Title: Instantiate argument exceptions correctly
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2211
-  Title: Non-constant fields should not be visible
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2213
-  Title: Disposable fields should be disposed
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2214
-  Title: Do not call overridable methods in constructors
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2215
-  Title: Dispose methods should call base class dispose
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA2216
-  Title: Disposable types should declare finalizer
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2217
-  Title: Do not mark enums with FlagsAttribute
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2219
-  Title: Do not raise exceptions in finally clauses
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2225
-  Title: Operator overloads have named alternates
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2226
-  Title: Operators should have symmetrical overloads
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2227
-  Title: Collection properties should be read only
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2231
-  Title: Overload operator equals on overriding value type Equals
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2234
-  Title: Pass system uri objects instead of strings
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2235
-  Title: Mark all non-serializable fields
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2237
-  Title: Mark ISerializable types with serializable
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2241
-  Title: Provide correct arguments to formatting methods
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2242
-  Title: Test for NaN correctly
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2243
-  Title: Attribute string literals should parse correctly
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2244
-  Title: Do not duplicate indexed element initializations
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2245
-  Title: Do not assign a property to itself
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2246
-  Title: Assigning symbol and its member in the same statement
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2247
-  Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2248
-  Title: Provide correct 'enum' argument to 'Enum.HasFlag'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2249
-  Title: Consider using 'string.Contains' instead of 'string.IndexOf'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2250
-  Title: Use 'ThrowIfCancellationRequested'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2251
-  Title: Use 'string.Equals'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA2252
-  Title: This API requires opting into preview features
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2253
-  Title: Named placeholders should not be numeric values
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2254
-  Title: Template should be a static expression
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2255
-  Title: The 'ModuleInitializer' attribute should not be used in libraries
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2256
-  Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2257
-  Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2258
-  Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2259
-  Title: "'ThreadStatic' only affects static fields"
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2260
-  Title: Use correct type parameter
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2261
-  Title: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2300
-  Title: Do not use insecure deserializer BinaryFormatter
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2301
-  Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2302
-  Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2305
-  Title: Do not use insecure deserializer LosFormatter
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2310
-  Title: Do not use insecure deserializer NetDataContractSerializer
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2311
-  Title: Do not deserialize without first setting NetDataContractSerializer.Binder
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2312
-  Title: Ensure NetDataContractSerializer.Binder is set before deserializing
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2315
-  Title: Do not use insecure deserializer ObjectStateFormatter
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2321
-  Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2322
-  Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2326
-  Title: Do not use TypeNameHandling values other than None
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2327
-  Title: Do not use insecure JsonSerializerSettings
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2328
-  Title: Ensure that JsonSerializerSettings are secure
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2329
-  Title: Do not deserialize with JsonSerializer using an insecure configuration
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2330
-  Title: Ensure that JsonSerializer has a secure configuration when deserializing
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2350
-  Title: Do not use DataTable.ReadXml() with untrusted data
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2351
-  Title: Do not use DataSet.ReadXml() with untrusted data
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2352
-  Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2353
-  Title: Unsafe DataSet or DataTable in serializable type
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2354
-  Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2355
-  Title: Unsafe DataSet or DataTable type found in deserializable object graph
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2356
-  Title: Unsafe DataSet or DataTable type in web deserializable object graph
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2361
-  Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2362
-  Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3001
-  Title: Review code for SQL injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3002
-  Title: Review code for XSS vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3003
-  Title: Review code for file path injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3004
-  Title: Review code for information disclosure vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3005
-  Title: Review code for LDAP injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3006
-  Title: Review code for process command injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3007
-  Title: Review code for open redirect vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3008
-  Title: Review code for XPath injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3009
-  Title: Review code for XML injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3010
-  Title: Review code for XAML injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3011
-  Title: Review code for DLL injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3012
-  Title: Review code for regex injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3061
-  Title: Do Not Add Schema By URL
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3075
-  Title: Insecure DTD processing in XML
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3076
-  Title: Insecure XSLT script processing
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3077
-  Title: Insecure Processing in API Design, XmlDocument and XmlTextReader
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3147
-  Title: Mark Verb Handlers With Validate Antiforgery Token
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5350
-  Title: Do Not Use Weak Cryptographic Algorithms
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5351
-  Title: Do Not Use Broken Cryptographic Algorithms
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5358
-  Title: Review cipher mode usage with cryptography experts
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5359
-  Title: Do Not Disable Certificate Validation
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5360
-  Title: Do Not Call Dangerous Methods In Deserialization
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5361
-  Title: Do Not Disable SChannel Use of Strong Crypto
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5362
-  Title: Potential reference cycle in deserialized object graph
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5363
-  Title: Do Not Disable Request Validation
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5364
-  Title: Do Not Use Deprecated Security Protocols
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5365
-  Title: Do Not Disable HTTP Header Checking
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5366
-  Title: Use XmlReader for 'DataSet.ReadXml()'
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5367
-  Title: Do Not Serialize Types With Pointer Fields
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5368
-  Title: Set ViewStateUserKey For Classes Derived From Page
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5369
-  Title: Use XmlReader for 'XmlSerializer.Deserialize()'
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5370
-  Title: Use XmlReader for XmlValidatingReader constructor
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5371
-  Title: Use XmlReader for 'XmlSchema.Read()'
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5372
-  Title: Use XmlReader for XPathDocument constructor
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5373
-  Title: Do not use obsolete key derivation function
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5374
-  Title: Do Not Use XslTransform
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5375
-  Title: Do Not Use Account Shared Access Signature
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5376
-  Title: Use SharedAccessProtocol HttpsOnly
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5377
-  Title: Use Container Level Access Policy
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5378
-  Title: Do not disable ServicePointManagerSecurityProtocols
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5379
-  Title: Ensure Key Derivation Function algorithm is sufficiently strong
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5380
-  Title: Do Not Add Certificates To Root Store
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5381
-  Title: Ensure Certificates Are Not Added To Root Store
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5382
-  Title: Use Secure Cookies In ASP.NET Core
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5383
-  Title: Ensure Use Secure Cookies In ASP.NET Core
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5384
-  Title: Do Not Use Digital Signature Algorithm (DSA)
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5385
-  Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5386
-  Title: Avoid hardcoding SecurityProtocolType value
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5387
-  Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5388
-  Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5389
-  Title: Do Not Add Archive Item's Path To The Target File System Path
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5390
-  Title: Do not hard-code encryption key
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5391
-  Title: Use antiforgery tokens in ASP.NET Core MVC controllers
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5392
-  Title: Use DefaultDllImportSearchPaths attribute for P/Invokes
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5393
-  Title: Do not use unsafe DllImportSearchPath value
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5394
-  Title: Do not use insecure randomness
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5395
-  Title: Miss HttpVerb attribute for action methods
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5396
-  Title: Set HttpOnly to true for HttpCookie
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5397
-  Title: Do not use deprecated SslProtocols values
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5398
-  Title: Avoid hardcoded SslProtocols values
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5399
-  Title: HttpClients should enable certificate revocation list checks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5400
-  Title: Ensure HttpClient certificate revocation list check is not disabled
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5401
-  Title: Do not use CreateEncryptor with non-default IV
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5402
-  Title: 'Use CreateEncryptor with the default IV '
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5403
-  Title: Do not hard-code certificate
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5404
-  Title: Do not disable token validation checks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5405
-  Title: Do not always skip token validation in delegates
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: EM0001
-  Title: Switch on Enum Not Exhaustive
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0002
-  Title: Switch on Nullable Enum Not Exhaustive
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0003
-  Title: Switch on Closed Type Not Exhaustive
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0011
-  Title: Concrete Subtype of a Closed Type Must Be a Case
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0012
-  Title: Closed Type Case Must Be a Direct Subtype
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0013
-  Title: Closed Type Case Must Be a Subtype
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0014
-  Title: Concrete Subtype of a Closed Type Must Be a Covered
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0015
-  Title: Open Interface Subtype of a Closed Type Must Be a Case
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0100
-  Title: When Guards Not Supported
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0101
-  Title: Case Pattern Not Supported
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0102
-  Title: Open Type Not Supported
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0103
-  Title: Match Must Be On Case Type
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0104
-  Title: Duplicate Closed Attribute
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0105
-  Title: Duplicate Case Type
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EnableGenerateDocumentationFile
-  Title: Set MSBuild property 'GenerateDocumentationFile' to 'true'
-  Category: Style
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: IDE0004
-  Title: Remove Unnecessary Cast
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0005
-  Title: Using directive is unnecessary.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0005_gen
-  Title: Using directive is unnecessary.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0007
-  Title: Use implicit type
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0008
-  Title: Use explicit type
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0009
-  Title: Member access should be qualified.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0010
-  Title: Add missing cases
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0011
-  Title: Add braces
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0016
-  Title: Use 'throw' expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0017
-  Title: Simplify object initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0018
-  Title: Inline variable declaration
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0019
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0020
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0021
-  Title: Use expression body for constructor
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0022
-  Title: Use expression body for method
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0023
-  Title: Use expression body for conversion operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0024
-  Title: Use expression body for operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0025
-  Title: Use expression body for property
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0026
-  Title: Use expression body for indexer
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0027
-  Title: Use expression body for accessor
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0028
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0029
-  Title: Use coalesce expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0030
-  Title: Use coalesce expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0031
-  Title: Use null propagation
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0032
-  Title: Use auto property
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0033
-  Title: Use explicitly provided tuple name
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0034
-  Title: Simplify 'default' expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0035
-  Title: Unreachable code detected
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0036
-  Title: Order modifiers
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0037
-  Title: Use inferred member name
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0039
-  Title: Use local function
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0040
-  Title: Add accessibility modifiers
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0041
-  Title: Use 'is null' check
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0042
-  Title: Deconstruct variable declaration
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0043
-  Title: Invalid format string
-  Category: Compiler
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0044
-  Title: Add readonly modifier
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0045
-  Title: Convert to conditional expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0046
-  Title: Convert to conditional expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0047
-  Title: Remove unnecessary parentheses
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0048
-  Title: Add parentheses for clarity
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0051
-  Title: Remove unused private members
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0052
-  Title: Remove unread private members
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0053
-  Title: Use expression body for lambda expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0054
-  Title: Use compound assignment
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0055
-  Title: Fix formatting
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0056
-  Title: Use index operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0057
-  Title: Use range operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0058
-  Title: Expression value is never used
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0059
-  Title: Unnecessary assignment of a value
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0060
-  Title: Remove unused parameter
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0061
-  Title: Use expression body for local function
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0062
-  Title: Make local function 'static'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0063
-  Title: Use simple 'using' statement
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0064
-  Title: Make readonly fields writable
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0065
-  Title: Misplaced using directive
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0066
-  Title: Convert switch statement to expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0070
-  Title: Use 'System.HashCode'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0071
-  Title: Simplify interpolation
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0072
-  Title: Add missing cases
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0073
-  Title: The file header does not match the required text
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0074
-  Title: Use compound assignment
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0075
-  Title: Simplify conditional expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0076
-  Title: Invalid global 'SuppressMessageAttribute'
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0077
-  Title: Avoid legacy format target in 'SuppressMessageAttribute'
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0078
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0080
-  Title: Remove unnecessary suppression operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0082
-  Title: "'typeof' can be converted to 'nameof'"
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0083
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0090
-  Title: Use 'new(...)'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0100
-  Title: Remove redundant equality
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0110
-  Title: Remove unnecessary discard
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0120
-  Title: Simplify LINQ expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0130
-  Title: Namespace does not match folder structure
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0150
-  Title: Prefer 'null' check over type check
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0160
-  Title: Convert to block scoped namespace
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0161
-  Title: Convert to file-scoped namespace
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0170
-  Title: Property pattern can be simplified
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0180
-  Title: Use tuple to swap values
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0200
-  Title: Remove unnecessary lambda expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0210
-  Title: Convert to top-level statements
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0211
-  Title: Convert to 'Program.Main' style program
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0220
-  Title: Add explicit cast
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0230
-  Title: Use UTF-8 string literal
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0240
-  Title: Remove redundant nullable directive
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0241
-  Title: Remove unnecessary nullable directive
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0250
-  Title: Make struct 'readonly'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0251
-  Title: Make member 'readonly'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0260
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0270
-  Title: Use coalesce expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0280
-  Title: Use 'nameof'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0290
-  Title: Use primary constructor
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0300
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0301
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0302
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0303
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0304
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0305
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0320
-  Title: Make anonymous function static
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE1005
-  Title: Delegate invocation can be simplified.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE1006
-  Title: Naming Styles
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE2000
-  Title: Avoid multiple blank lines
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2001
-  Title: Embedded statements must be on their own line
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2002
-  Title: Consecutive braces must not have blank line between them
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2003
-  Title: Blank line required between block and subsequent statement
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2004
-  Title: Blank line not allowed after constructor initializer colon
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2005
-  Title: Blank line not allowed after conditional expression token
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2006
-  Title: Blank line not allowed after arrow expression clause token
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0001
-  Title: StringComparison is missing
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0002
-  Title: IEqualityComparer<string> or IComparer<string> is missing
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0003
-  Title: Add parameter name to improve readability
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0004
-  Title: Use Task.ConfigureAwait
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0005
-  Title: Use Array.Empty<T>()
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0006
-  Title: Use String.Equals instead of equality operator
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0007
-  Title: Add a comma after the last value
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0008
-  Title: Add StructLayoutAttribute
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0009
-  Title: Add regex evaluation timeout
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0010
-  Title: Mark attributes with AttributeUsageAttribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0011
-  Title: IFormatProvider is missing
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0012
-  Title: Do not raise reserved exception type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0013
-  Title: Types should not extend System.ApplicationException
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0014
-  Title: Do not raise System.ApplicationException type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0015
-  Title: Specify the parameter name in ArgumentException
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0016
-  Title: Prefer using collection abstraction instead of implementation
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0017
-  Title: Abstract types should not have public or internal constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0018
-  Title: Do not declare static members on generic types (deprecated; use CA1000 instead)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0019
-  Title: Use EventArgs.Empty
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0020
-  Title: Use direct methods instead of LINQ methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0021
-  Title: Use StringComparer.GetHashCode instead of string.GetHashCode
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0022
-  Title: Return Task.FromResult instead of returning null
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0023
-  Title: Add RegexOptions.ExplicitCapture
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0024
-  Title: Use an explicit StringComparer when possible
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0025
-  Title: Implement the functionality instead of throwing NotImplementedException
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0026
-  Title: Fix TODO comment
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - None
-  IsEverSuppressed: true
-- Id: MA0027
-  Title: Prefer rethrowing an exception implicitly
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0028
-  Title: Optimize StringBuilder usage
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0029
-  Title: Combine LINQ methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0030
-  Title: Remove useless OrderBy call
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0031
-  Title: Optimize Enumerable.Count() usage
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0032
-  Title: Use an overload with a CancellationToken argument
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0033
-  Title: Do not tag instance fields with ThreadStaticAttribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0035
-  Title: Do not use dangerous threading methods
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0036
-  Title: Make class static
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0037
-  Title: Remove empty statement
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0038
-  Title: Make method static (deprecated, use CA1822 instead)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0039
-  Title: Do not write your own certificate validation method
-  Category: Security
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0040
-  Title: Forward the CancellationToken parameter to methods that take one
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: MA0041
-  Title: Make property static (deprecated, use CA1822 instead)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0042
-  Title: Do not use blocking calls in an async method
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0043
-  Title: Use nameof operator in ArgumentException
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0044
-  Title: Remove useless ToString call
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0045
-  Title: Do not use blocking calls in a sync method (need to make calling method async)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0046
-  Title: Use EventHandler<T> to declare events
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0047
-  Title: Declare types in namespaces
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0048
-  Title: File name must match type name
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0049
-  Title: Type name should not match containing namespace
-  Category: Design
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0050
-  Title: Validate arguments correctly in iterator methods
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0051
-  Title: Method is too long
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: MA0052
-  Title: Replace constant Enum.ToString with nameof
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0053
-  Title: Make class sealed
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0054
-  Title: Embed the caught exception as innerException
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0055
-  Title: Do not use finalizer
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0056
-  Title: Do not call overridable members in constructor
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0057
-  Title: Class name should end with 'Attribute'
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0058
-  Title: Class name should end with 'Exception'
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0059
-  Title: Class name should end with 'EventArgs'
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0060
-  Title: The value returned by Stream.Read/Stream.ReadAsync is not used
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0061
-  Title: Method overrides should not change default values
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0062
-  Title: Non-flags enums should not be marked with "FlagsAttribute"
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0063
-  Title: Use Where before OrderBy
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0064
-  Title: Avoid locking on publicly accessible instance
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0065
-  Title: Default ValueType.Equals or HashCode is used for struct equality
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0066
-  Title: Hash table unfriendly type is used in a hash table
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0067
-  Title: Use Guid.Empty
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0068
-  Title: Invalid parameter name for nullable attribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0069
-  Title: Non-constant static fields should not be visible
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0070
-  Title: Obsolete attributes should include explanations
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0071
-  Title: Avoid using redundant else
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0072
-  Title: Do not throw from a finally block
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0073
-  Title: Avoid comparison with bool constant
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0074
-  Title: Avoid implicit culture-sensitive methods
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0075
-  Title: Do not use implicit culture-sensitive ToString
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0076
-  Title: Do not use implicit culture-sensitive ToString in interpolated strings
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0077
-  Title: A class that provides Equals(T) should implement IEquatable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0078
-  Title: Use 'Cast' instead of 'Select' to cast
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0079
-  Title: Forward the CancellationToken using .WithCancellation()
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0080
-  Title: Use a cancellation token using .WithCancellation()
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0081
-  Title: Method overrides should not omit params keyword
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0082
-  Title: NaN should not be used in comparisons
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0083
-  Title: ConstructorArgument parameters should exist in constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0084
-  Title: Local variables should not hide other symbols
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0085
-  Title: Anonymous delegates should not be used to unsubscribe from Events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0086
-  Title: Do not throw from a finalizer
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0087
-  Title: Parameters with [DefaultParameterValue] attributes should also be marked [Optional]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0088
-  Title: Use [DefaultParameterValue] instead of [DefaultValue]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0089
-  Title: Optimize string method usage
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0090
-  Title: Remove empty else/finally block
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0091
-  Title: Sender should be 'this' for instance events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0092
-  Title: Sender should be 'null' for static events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0093
-  Title: EventArgs should not be null
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0094
-  Title: A class that provides CompareTo(T) should implement IComparable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0095
-  Title: A class that implements IEquatable<T> should override Equals(object)
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0096
-  Title: A class that implements IComparable<T> should also implement IEquatable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0097
-  Title: A class that implements IComparable<T> or IComparable should override comparison operators
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0098
-  Title: Use indexer instead of LINQ methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0099
-  Title: Use Explicit enum value instead of 0
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0100
-  Title: Await task before disposing of resources
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0101
-  Title: String contains an implicit end of line character
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: MA0102
-  Title: Make member readonly
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0103
-  Title: Use SequenceEqual instead of equality operator
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0104
-  Title: Do not create a type with a name from the BCL
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0105
-  Title: Use the lambda parameters instead of using a closure
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0106
-  Title: Avoid closure by using an overload with the 'factoryArgument' parameter
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0107
-  Title: Do not use culture-sensitive object.ToString
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0108
-  Title: Remove redundant argument value
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0109
-  Title: Consider adding an overload with a Span<T> or Memory<T>
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0110
-  Title: Use the Regex source generator
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0111
-  Title: Use string.Create instead of FormattableString
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0112
-  Title: Use 'Count > 0' instead of 'Any()'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0113
-  Title: Use DateTime.UnixEpoch
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0114
-  Title: Use DateTimeOffset.UnixEpoch
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0115
-  Title: Unknown component parameter
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0116
-  Title: Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0117
-  Title: Parameters with [EditorRequired] attributes should also be marked as [Parameter]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0118
-  Title: '[JSInvokable] methods must be public'
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0119
-  Title: JSRuntime must not be used in OnInitialized or OnInitializedAsync
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0120
-  Title: Use InvokeVoidAsync when the returned value is not used
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0121
-  Title: Do not overwrite parameter value
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0122
-  Title: Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0123
-  Title: Sequence number must be a constant
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0124
-  Title: Log parameter type is not valid
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0125
-  Title: The list of log parameter types contains an invalid type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0126
-  Title: The list of log parameter types contains a duplicate
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0127
-  Title: Use String.Equals instead of is pattern
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0128
-  Title: Use 'is' operator instead of SequenceEqual
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0129
-  Title: Await task in using statement
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0130
-  Title: GetType() should not be used on System.Type instances
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0131
-  Title: ArgumentNullException.ThrowIfNull should not be used with non-nullable types
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0132
-  Title: Do not convert implicitly to DateTimeOffset
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0133
-  Title: Use DateTimeOffset instead of relying on the implicit conversion
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0134
-  Title: Observe result of async calls
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0135
-  Title: The log parameter has no configured type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0136
-  Title: Raw String contains an implicit end of line character
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: MA0137
-  Title: Use 'Async' suffix when a method returns an awaitable type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0138
-  Title: Do not use 'Async' suffix when a method does not return an awaitable type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0139
-  Title: Log parameter type is not valid
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0140
-  Title: Both if and else branch have identical code
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0141
-  Title: Use pattern matching instead of inequality operators for null check
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0142
-  Title: Use pattern matching instead of equality operators for null check
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0143
-  Title: Primary constructor parameters should be readonly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0144
-  Title: Use System.OperatingSystem to check the current OS
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0145
-  Title: Signature for [UnsafeAccessorAttribute] method is not valid
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0146
-  Title: Name must be set explicitly on local functions
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0147
-  Title: Avoid async void method for delegate
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0148
-  Title: Use pattern matching instead of equality operators for discrete value
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0149
-  Title: Use pattern matching instead of inequality operators for discrete value
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0150
-  Title: Do not call the default object.ToString explicitly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0151
-  Title: DebuggerDisplay must contain valid members
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0152
-  Title: Use Unwrap instead of using await twice
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0153
-  Title: Do not log symbols decorated with DataClassificationAttribute directly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0154
-  Title: Use langword in XML comment
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0155
-  Title: Do not use async void methods
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0156
-  Title: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0157
-  Title: Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0158
-  Title: Use System.Threading.Lock
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0159
-  Title: Use 'Order' instead of 'OrderBy'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0160
-  Title: Use ContainsKey instead of TryGetValue
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: POLYSP0003
-  Title: Unsupported C# language version
-  Category: Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1001
-  Title: Add braces (when expression spans over multiple lines)
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1002
-  Title: Remove braces
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1002FadeOut
-  Title: Remove braces
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1003
-  Title: Add braces to if-else (when expression spans over multiple lines)
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1004
-  Title: Remove braces from if-else
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1004FadeOut
-  Title: Remove braces from if-else
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1005
-  Title: Simplify nested using statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1005FadeOut
-  Title: Simplify nested using statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1006
-  Title: Merge 'else' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1006FadeOut
-  Title: Merge 'else' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1007
-  Title: Add braces
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1008
-  Title: "[deprecated] Use explicit type instead of 'var' (when the type is not obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1009
-  Title: "[deprecated] Use explicit type instead of 'var' (foreach variable)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1010
-  Title: "[deprecated] Use 'var' instead of explicit type (when the type is obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1012
-  Title: "[deprecated] Use explicit type instead of 'var' (when the type is obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1013
-  Title: Use predefined type
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1014
-  Title: Use explicitly/implicitly typed array
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1015
-  Title: Use nameof operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1015FadeOut
-  Title: Use nameof operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1016
-  Title: Use block body or expression body
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1018
-  Title: Add/remove accessibility modifiers
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1019
-  Title: Order modifiers
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1020
-  Title: Simplify Nullable<T> to T?
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1021
-  Title: Convert lambda expression body to expression body
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1021FadeOut
-  Title: Convert lambda expression body to expression body
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1031
-  Title: Remove unnecessary braces in switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1031FadeOut
-  Title: Remove unnecessary braces in switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1032
-  Title: Remove redundant parentheses
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1032FadeOut
-  Title: Remove redundant parentheses
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1033
-  Title: Remove redundant boolean literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1034
-  Title: Remove redundant 'sealed' modifier
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1035
-  Title: '[deprecated] Remove redundant comma in initializer'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1036
-  Title: Remove unnecessary blank line
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1037
-  Title: Remove trailing white-space
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1038
-  Title: '[deprecated] Remove empty statement'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1039
-  Title: Remove argument list from attribute
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1040
-  Title: "[deprecated] Remove empty 'else' clause"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1041
-  Title: '[deprecated] Remove empty initializer'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1042
-  Title: Remove enum default underlying type
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1043
-  Title: Remove 'partial' modifier from type with a single part
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1044
-  Title: Remove original exception from throw statement
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1046
-  Title: Asynchronous method name should end with 'Async'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1047
-  Title: Non-asynchronous method name should not end with 'Async'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1047FadeOut
-  Title: Non-asynchronous method name should not end with 'Async'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1048
-  Title: Use lambda expression instead of anonymous method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1048FadeOut
-  Title: Use lambda expression instead of anonymous method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1049
-  Title: Simplify boolean comparison
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1049FadeOut
-  Title: Simplify boolean comparison
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1050
-  Title: Include/omit parentheses when creating new object
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1051
-  Title: Add/remove parentheses from condition in conditional operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1052
-  Title: Declare each attribute separately
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1055
-  Title: Unnecessary semicolon at the end of declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1056
-  Title: Avoid usage of using alias directive
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1058
-  Title: Use compound assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1058FadeOut
-  Title: Use compound assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1059
-  Title: Avoid locking on publicly accessible instance
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1060
-  Title: Declare each type in separate file
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1061
-  Title: Merge 'if' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1061FadeOut
-  Title: Merge 'if' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1063
-  Title: '[deprecated] Avoid usage of do statement to create an infinite loop'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1064
-  Title: '[deprecated] Avoid usage of for statement to create an infinite loop'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1065
-  Title: '[deprecated] Avoid usage of while statement to create an infinite loop'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1066
-  Title: "[deprecated] Remove empty 'finally' clause"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1066FadeOut
-  Title: "[deprecated] Remove empty 'finally' clause"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1068
-  Title: Simplify logical negation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1069
-  Title: Remove unnecessary case label
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1070
-  Title: Remove redundant default switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1071
-  Title: Remove redundant base constructor call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1072
-  Title: '[deprecated] Remove empty namespace declaration'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1073
-  Title: Convert 'if' to 'return' statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1073FadeOut
-  Title: Convert 'if' to 'return' statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1074
-  Title: Remove redundant constructor
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1075
-  Title: Avoid empty catch clause that catches System.Exception
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1077
-  Title: Optimize LINQ method call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1078
-  Title: Use "" or 'string.Empty'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1079
-  Title: Throwing of new NotImplementedException
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1080
-  Title: Use 'Count/Length' property instead of 'Any' method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1081
-  Title: Split variable declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1084
-  Title: Use coalesce expression instead of conditional expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1085
-  Title: Use auto-implemented property
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1085FadeOut
-  Title: Use auto-implemented property
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1089
-  Title: Use --/++ operator instead of assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1089FadeOut
-  Title: Use --/++ operator instead of assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1090
-  Title: Add/remove 'ConfigureAwait(false)' call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1091
-  Title: '[deprecated] Remove empty region'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1091FadeOut
-  Title: '[deprecated] Remove empty region'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1093
-  Title: File contains no code
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1094
-  Title: Declare using directive on top level
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1096
-  Title: Use 'HasFlag' method or bitwise operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1097
-  Title: Remove redundant 'ToString' call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1098
-  Title: Constant values should be placed on right side of comparisons
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1099
-  Title: Default label should be the last label in a switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1100
-  Title: '[deprecated] Format documentation summary on a single line'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1101
-  Title: '[deprecated] Format documentation summary on multiple lines'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1102
-  Title: Make class static
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1103
-  Title: Convert 'if' to assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1104
-  Title: Simplify conditional expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1105
-  Title: Unnecessary interpolation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1106
-  Title: '[deprecated] Remove empty destructor'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1107
-  Title: Remove redundant 'ToCharArray' call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1108
-  Title: Add 'static' modifier to all partial class declarations
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1110
-  Title: Declare type inside namespace
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1111
-  Title: Add braces to switch section with multiple statements
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1112
-  Title: Combine 'Enumerable.Where' method chain
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1112FadeOut
-  Title: Combine 'Enumerable.Where' method chain
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1113
-  Title: Use 'string.IsNullOrEmpty' method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1114
-  Title: Remove redundant delegate creation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1114FadeOut
-  Title: Remove redundant delegate creation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1118
-  Title: Mark local variable as const
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1123
-  Title: Add parentheses when necessary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1124
-  Title: Inline local variable
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1124FadeOut
-  Title: Inline local variable
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1126
-  Title: Add braces to if-else
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1128
-  Title: Use coalesce expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1129
-  Title: Remove redundant field initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1130
-  Title: Bitwise operation on enum without Flags attribute
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1132
-  Title: Remove redundant overriding member
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1133
-  Title: Remove redundant Dispose/Close call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1134
-  Title: Remove redundant statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1135
-  Title: Declare enum member with zero value (when enum has FlagsAttribute)
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1136
-  Title: Merge switch sections with equivalent content
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1138
-  Title: Add summary to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1139
-  Title: Add summary element to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1140
-  Title: Add exception to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1141
-  Title: Add 'param' element to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1142
-  Title: Add 'typeparam' element to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1143
-  Title: Simplify coalesce expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1145
-  Title: Remove redundant 'as' operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1146
-  Title: Use conditional access
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1151
-  Title: Remove redundant cast
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1154
-  Title: Sort enum members
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1155
-  Title: Use StringComparison when comparing strings
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1156
-  Title: Use string.Length instead of comparison with empty string
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1157
-  Title: Composite enum value contains undefined flag
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1158
-  Title: Static member in generic type should use a type parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1159
-  Title: Use EventHandler<T>
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1160
-  Title: Abstract type should not have public constructors
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1161
-  Title: Enum should declare explicit values
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1162
-  Title: Avoid chain of assignments
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1163
-  Title: Unused parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1164
-  Title: Unused type parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1165
-  Title: Unconstrained type parameter checked for null
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1166
-  Title: Value type object is never equal to null
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1168
-  Title: Parameter name differs from base name
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1169
-  Title: Make field read-only
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1170
-  Title: Use read-only auto-implemented property
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1171
-  Title: Simplify lazy initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1172
-  Title: Use 'is' operator instead of 'as' operator
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1173
-  Title: Use coalesce expression instead of 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1174
-  Title: Remove redundant async/await
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1174FadeOut
-  Title: Remove redundant async/await
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1175
-  Title: Unused 'this' parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1176
-  Title: "[deprecated] Use 'var' instead of explicit type (when the type is not obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1177
-  Title: "[deprecated] Use 'var' instead of explicit type (in foreach)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1179
-  Title: Unnecessary assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1180
-  Title: Inline lazy initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1181
-  Title: Convert comment to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1182
-  Title: Remove redundant base interface
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1186
-  Title: Use Regex instance instead of static method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1187
-  Title: Use constant instead of field
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1188
-  Title: Remove redundant auto-property initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1189
-  Title: Add or remove region name
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1190
-  Title: Join string expressions
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1191
-  Title: Declare enum value as combination of names
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1192
-  Title: Unnecessary usage of verbatim string literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1193
-  Title: Overriding member should not change 'params' modifier
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1194
-  Title: Implement exception constructors
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1195
-  Title: Use ^ operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1196
-  Title: Call extension method as instance method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1197
-  Title: Optimize StringBuilder.Append/AppendLine call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1198
-  Title: Avoid unnecessary boxing of value type
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1199
-  Title: Unnecessary null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1200
-  Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1201
-  Title: Use method chaining
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1202
-  Title: Avoid NullReferenceException
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1203
-  Title: Use AttributeUsageAttribute
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1204
-  Title: Use EventArgs.Empty
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1205
-  Title: Order named arguments according to the order of parameters
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1206
-  Title: Use conditional access instead of conditional expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1207
-  Title: Use anonymous function or method group
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1208
-  Title: Reduce 'if' nesting
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1209
-  Title: Order type parameter constraints
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1210
-  Title: Return completed task instead of returning null
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1211
-  Title: Remove unnecessary 'else'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1212
-  Title: Remove redundant assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1212FadeOut
-  Title: Remove redundant assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1213
-  Title: Remove unused member declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1214
-  Title: Unnecessary interpolated string
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1214FadeOut
-  Title: Unnecessary interpolated string
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1215
-  Title: Expression is always equal to true/false
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1216
-  Title: Unnecessary unsafe context
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1217
-  Title: Convert interpolated string to concatenation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1217FadeOut
-  Title: Convert interpolated string to concatenation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1218
-  Title: Simplify code branching
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1220
-  Title: Use pattern matching instead of combination of 'is' operator and cast operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1221
-  Title: Use pattern matching instead of combination of 'as' operator and null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1222
-  Title: Merge preprocessor directives
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1223
-  Title: Mark publicly visible type with DebuggerDisplay attribute
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1224
-  Title: Make method an extension method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1225
-  Title: Make class sealed
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1226
-  Title: Add paragraph to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1227
-  Title: Validate arguments correctly
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1228
-  Title: Unused element in a documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1229
-  Title: Use async/await when necessary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1230
-  Title: Unnecessary explicit use of enumerator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1231
-  Title: Make parameter ref read-only
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1232
-  Title: Order elements in documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1233
-  Title: Use short-circuiting operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1234
-  Title: Duplicate enum value
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1235
-  Title: Optimize method call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1236
-  Title: Use exception filter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1237
-  Title: '[deprecated] Use bit shift operator'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1238
-  Title: 'Avoid nested ?: operators'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1239
-  Title: Use 'for' statement instead of 'while' statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1240
-  Title: Operator is unnecessary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1241
-  Title: Implement non-generic counterpart
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1242
-  Title: Do not pass non-read-only struct by read-only reference
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1243
-  Title: Duplicate word in a comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1244
-  Title: Simplify 'default' expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1246
-  Title: Use element access
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1247
-  Title: Fix documentation comment tag
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1248
-  Title: Normalize null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1249
-  Title: Unnecessary null-forgiving operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1250
-  Title: Use implicit/explicit object creation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1251
-  Title: Remove unnecessary braces from record declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1252
-  Title: Normalize usage of infinite loop
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1253
-  Title: Format documentation comment summary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1254
-  Title: Normalize format of enum flag value
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1255
-  Title: Simplify argument null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1256
-  Title: Invalid argument null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1257
-  Title: Use enum field explicitly
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1258
-  Title: Unnecessary enum flag
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1259
-  Title: Remove empty syntax
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1260
-  Title: Add/remove trailing comma
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1261
-  Title: Resource can be disposed asynchronously
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1262
-  Title: Unnecessary raw string literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1263
-  Title: Invalid reference in a documentation comment
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1264
-  Title: Use 'var' or explicit type
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1265
-  Title: Remove redundant catch block
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1266
-  Title: Use raw string literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1267
-  Title: Use string interpolation instead of 'string.Concat'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1268
-  Title: Simplify numeric comparison
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RemoveUnnecessaryImportsFixable
-  Title: ''
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: ROS0002
-  Title: Analyzer option is obsolete
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: ROS0003
-  Title: Analyzer requires config option to be specified
-  Category: ''
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RS1001
-  Title: Missing diagnostic analyzer attribute
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1002
-  Title: Missing kind argument when registering an analyzer action
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1003
-  Title: Unsupported SymbolKind argument when registering a symbol analyzer action
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1004
-  Title: Recommend adding language support to diagnostic analyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1005
-  Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1006
-  Title: Invalid type argument for DiagnosticAnalyzer's Register method
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1007
-  Title: Provide localizable arguments to diagnostic descriptor constructor
-  Category: MicrosoftCodeAnalysisLocalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1008
-  Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1009
-  Title: Only internal implementations of this interface are allowed
-  Category: MicrosoftCodeAnalysisCompatibility
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1010
-  Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support
-  Category: Correctness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1011
-  Title: Use code actions that have a unique EquivalenceKey for FixAll occurrences support
-  Category: Correctness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1012
-  Title: Start action has no registered actions
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1013
-  Title: Start action has no registered non-end actions
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1014
-  Title: Do not ignore values returned by methods on immutable objects
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1015
-  Title: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor
-  Category: MicrosoftCodeAnalysisDocumentation
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1016
-  Title: Code fix providers should provide FixAll support
-  Category: Correctness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1017
-  Title: DiagnosticId for analyzers must be a non-null constant
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1018
-  Title: DiagnosticId for analyzers must be in specified format
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1019
-  Title: DiagnosticId must be unique across analyzers
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1020
-  Title: Category for analyzers must be from the specified values
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1021
-  Title: Invalid entry in analyzer category and diagnostic ID range specification file
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1022
-  Title: Do not use types from Workspaces assembly in an analyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1023
-  Title: Upgrade MSBuildWorkspace
-  Category: Library
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1024
-  Title: Symbols should be compared for equality
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1025
-  Title: Configure generated code analysis
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1026
-  Title: Enable concurrent execution
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1027
-  Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1028
-  Title: Provide non-null 'customTags' value to diagnostic descriptor constructor
-  Category: MicrosoftCodeAnalysisDocumentation
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1029
-  Title: Do not use reserved diagnostic IDs
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1030
-  Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1031
-  Title: Define diagnostic title correctly
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1032
-  Title: Define diagnostic message correctly
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1033
-  Title: Define diagnostic description correctly
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1034
-  Title: Prefer 'IsKind' for checking syntax kinds
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1035
-  Title: Do not use APIs banned for analyzers
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1036
-  Title: Specify analyzer banned API enforcement setting
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1037
-  Title: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2000
-  Title: Add analyzer diagnostic IDs to analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2001
-  Title: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2002
-  Title: Do not add removed analyzer diagnostic IDs to unshipped analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2003
-  Title: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2004
-  Title: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2005
-  Title: Remove duplicate entries for diagnostic ID in the same analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2006
-  Title: Remove duplicate entries for diagnostic ID between analyzer releases
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2007
-  Title: Invalid entry in analyzer release file
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2008
-  Title: Enable analyzer release tracking
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S100
-  Title: Methods and properties should be named in PascalCase
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S1006
-  Title: Method overrides should not change parameter defaults
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S101
-  Title: Types should be named in PascalCase
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S103
-  Title: Lines should not be too long
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S104
-  Title: Files should not have too many lines of code
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1048
-  Title: Finalizers should not throw exceptions
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S105
-  Title: Tabulation characters should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S106
-  Title: Standard outputs should not be used directly to log anything
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1066
-  Title: Mergeable "if" statements should be combined
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1067
-  Title: Expressions should not be too complex
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S107
-  Title: Methods should not have too many parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1075
-  Title: URIs should not be hardcoded
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S108
-  Title: Nested blocks of code should not be left empty
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S109
-  Title: Magic numbers should not be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S110
-  Title: Inheritance tree of classes should not be too deep
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1104
-  Title: Fields should not have public accessibility
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1109
-  Title: A close curly brace should be located at the beginning of a line
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1110
-  Title: Redundant pairs of parentheses should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1116
-  Title: Empty statements should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1117
-  Title: Local variables should not shadow class fields or properties
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1118
-  Title: Utility classes should not have public constructors
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S112
-  Title: General or reserved exceptions should never be thrown
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1121
-  Title: Assignments should not be made from within sub-expressions
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1123
-  Title: '"Obsolete" attributes should include explanations'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1125
-  Title: Boolean literals should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1128
-  Title: Unnecessary "using" should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S113
-  Title: Files should end with a newline
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1133
-  Title: Deprecated code should be removed
-  Category: Info Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1134
-  Title: Track uses of "FIXME" tags
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1135
-  Title: Track uses of "TODO" tags
-  Category: Info Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: S1144
-  Title: Unused private types or members should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1147
-  Title: Exit methods should not be called
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1151
-  Title: '"switch case" clauses should not have too many lines of code'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1155
-  Title: '"Any()" should be used to test for emptiness'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1163
-  Title: Exceptions should not be thrown in finally blocks
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1168
-  Title: Empty arrays and collections should be returned instead of null
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1172
-  Title: Unused method parameters should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1185
-  Title: Overriding members should do more than simply call the same member in the base class
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1186
-  Title: Methods should not be empty
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1192
-  Title: String literals should not be duplicated
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1199
-  Title: Nested code blocks should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1200
-  Title: Classes should not be coupled to too many other classes
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1206
-  Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S121
-  Title: Control structures should use curly braces
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1210
-  Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1215
-  Title: '"GC.Collect" should not be called'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S122
-  Title: Statements should be on separate lines
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1226
-  Title: Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1227
-  Title: break statements should not be used except for switch cases
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1244
-  Title: Floating point numbers should not be tested for equality
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S125
-  Title: Sections of code should not be commented out
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S126
-  Title: '"if ... else if" constructs should end with "else" clauses'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1264
-  Title: A "while" loop should be used instead of a "for" loop
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S127
-  Title: '"for" loop stop conditions should be invariant'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1301
-  Title: '"switch" statements should have at least 3 "case" clauses'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1309
-  Title: Track uses of in-source issue suppressions
-  Category: Info Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S131
-  Title: '"switch/Select" statements should contain a "default/Case Else" clauses'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1312
-  Title: Logger fields should be "private static readonly"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1313
-  Title: Using hardcoded IP addresses is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S134
-  Title: Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S138
-  Title: Functions should not have too many lines of code
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1449
-  Title: Culture should be specified for "string" operations
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1450
-  Title: Private fields only used as local variables in methods should become local variables
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1451
-  Title: Track lack of copyright and license headers
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1479
-  Title: '"switch" statements with many "case" clauses should have only one statement'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1481
-  Title: Unused local variables should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1541
-  Title: Methods and properties should not be too complex
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1607
-  Title: Tests should not be ignored
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1643
-  Title: Strings should not be concatenated using '+' in a loop
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1656
-  Title: Variables should not be self-assigned
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1659
-  Title: Multiple variables should not be declared on the same line
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1694
-  Title: An abstract class should have both abstract and concrete methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1696
-  Title: NullReferenceException should not be caught
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1698
-  Title: '"==" should not be used when "Equals" is overridden'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1699
-  Title: Constructors should only call non-overridable methods
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1751
-  Title: Loops with at most one iteration should be refactored
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1764
-  Title: Identical expressions should not be used on both sides of operators
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1821
-  Title: '"switch" statements should not be nested'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1848
-  Title: Objects should not be created to be dropped immediately without being used
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1854
-  Title: Unused assignments should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1858
-  Title: '"ToString()" calls should not be redundant'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1862
-  Title: Related "if/else if" statements should not have the same condition
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1871
-  Title: Two branches in a conditional structure should not have exactly the same implementation
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1905
-  Title: Redundant casts should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1939
-  Title: Inheritance list should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1940
-  Title: Boolean checks should not be inverted
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1944
-  Title: Invalid casts should be avoided
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1994
-  Title: "\"for\" loop increment clauses should modify the loops' counters"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2053
-  Title: Password hashing functions should use an unpredictable salt
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2068
-  Title: Hard-coded credentials are security-sensitive
-  Category: Blocker Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2077
-  Title: Formatting SQL queries is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2092
-  Title: Creating cookies without the "secure" flag is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2094
-  Title: Classes should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2114
-  Title: Collections should not be passed as arguments to their own methods
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2115
-  Title: A secure password should be used when connecting to a database
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2123
-  Title: Values should not be uselessly incremented
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2139
-  Title: Exceptions should be either logged or rethrown but not both
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2148
-  Title: Underscores should be used to make large numbers readable
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2156
-  Title: '"sealed" classes should not have "protected" members'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2166
-  Title: Classes named like "Exception" should extend "Exception" or a subclass
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2178
-  Title: Short-circuit logic should be used in boolean contexts
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2183
-  Title: Integral numbers should not be shifted by zero or more than their number of bits-1
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2184
-  Title: Results of integer division should not be assigned to floating point variables
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2187
-  Title: Test classes should contain at least one test case
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2190
-  Title: Loops and recursions should not be infinite
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2197
-  Title: Modulus results should not be checked for direct equality
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2198
-  Title: Unnecessary mathematical comparisons should not be made
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2201
-  Title: Methods without side effects should not have their return values ignored
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2219
-  Title: Runtime type checking should be simplified
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2221
-  Title: '"Exception" should not be caught'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2222
-  Title: Locks should be released on all paths
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2223
-  Title: Non-constant static fields should not be visible
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2225
-  Title: '"ToString()" method should not return null'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2234
-  Title: Arguments should be passed in the same order as the method parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2245
-  Title: Using pseudorandom number generators (PRNGs) is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2251
-  Title: A "for" loop update clause should move the counter in the right direction
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2252
-  Title: For-loop conditions should be true at least once
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2257
-  Title: Using non-standard cryptographic algorithms is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2259
-  Title: Null pointers should not be dereferenced
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2275
-  Title: Composite format strings should not lead to unexpected behavior at runtime
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2290
-  Title: Field-like events should not be virtual
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2291
-  Title: Overflow checking should not be disabled for "Enumerable.Sum"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2292
-  Title: Trivial properties should be auto-implemented
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2302
-  Title: '"nameof" should be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2306
-  Title: '"async" and "await" should not be used as identifiers'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2325
-  Title: Methods and properties that don't access instance data should be static
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2326
-  Title: Unused type parameters should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2327
-  Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2328
-  Title: '"GetHashCode" should not reference mutable fields'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2330
-  Title: Array covariance should not be used
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2333
-  Title: Redundant modifiers should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2339
-  Title: Public constant members should not be used
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2342
-  Title: Enumeration types should comply with a naming convention
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2344
-  Title: Enumeration type names should not have "Flags" or "Enum" suffixes
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2345
-  Title: Flags enumerations should explicitly initialize all their members
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2346
-  Title: Flags enumerations zero-value members should be named "None"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2357
-  Title: Fields should be private
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2360
-  Title: Optional parameters should not be used
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2365
-  Title: Properties should not make collection or array copies
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2368
-  Title: Public methods should not have multidimensional array parameters
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2372
-  Title: Exceptions should not be thrown from property getters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2376
-  Title: Write-only properties should not be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2386
-  Title: Mutable fields should not be "public static"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2387
-  Title: Child class fields should not shadow parent class fields
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2436
-  Title: Types and methods should not have too many generic parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2437
-  Title: Unnecessary bit operations should not be performed
-  Category: Blocker Code Smell
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: S2445
-  Title: Blocks should be synchronized on read-only fields
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2479
-  Title: Whitespace and control characters in string literals should be explicit
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2486
-  Title: Generic exceptions should not be ignored
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2551
-  Title: Shared resources should not be used for locking
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2583
-  Title: Conditionally executed code should be reachable
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2589
-  Title: Boolean expressions should not be gratuitous
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2612
-  Title: Setting loose file permissions is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2629
-  Title: Logging templates should be constant
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2674
-  Title: The length returned from a stream read should be checked
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2681
-  Title: Multiline blocks should be enclosed in curly braces
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2688
-  Title: '"NaN" should not be used in comparisons'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2692
-  Title: '"IndexOf" checks should not be for positive numbers'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2696
-  Title: Instance members should not write to "static" fields
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2699
-  Title: Tests should include assertions
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2701
-  Title: Literal boolean values should not be used in assertions
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2737
-  Title: '"catch" clauses should do more than rethrow'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2743
-  Title: Static fields should not be used in generic types
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2755
-  Title: XML parsers should not be vulnerable to XXE attacks
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2757
-  Title: Non-existent operators like "=+" should not be used
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2760
-  Title: Sequential tests should not check the same condition
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2761
-  Title: Doubled prefix operators "!!" and "~~" should not be used
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2857
-  Title: SQL keywords should be delimited by whitespace
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2925
-  Title: '"Thread.Sleep" should not be used in tests'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2930
-  Title: '"IDisposables" should be disposed'
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2931
-  Title: Classes with "IDisposable" members should implement "IDisposable"
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2933
-  Title: Fields that are only assigned in the constructor should be "readonly"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2934
-  Title: Property assignments should not be made for "readonly" fields not constrained to reference types
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2952
-  Title: Classes should "Dispose" of members from the classes' own "Dispose" methods
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2953
-  Title: Methods named "Dispose" should implement "IDisposable.Dispose"
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2955
-  Title: Generic parameters not constrained to reference types should not be compared to "null"
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2970
-  Title: Assertions should be complete
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2971
-  Title: LINQ expressions should be simplified
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2995
-  Title: '"Object.ReferenceEquals" should not be used for value types'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2996
-  Title: '"ThreadStatic" fields should not be initialized'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2997
-  Title: '"IDisposables" created in a "using" statement should not be returned'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3005
-  Title: '"ThreadStatic" should not be used on non-static fields'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3010
-  Title: Static fields should not be updated in constructors
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3011
-  Title: Reflection should not be used to increase accessibility of classes, methods, or fields
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3052
-  Title: Members should not be initialized to default values
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3059
-  Title: Types should not have members with visibility set higher than the type's visibility
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3060
-  Title: '"is" should not be used with "this"'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3063
-  Title: '"StringBuilder" data should be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3168
-  Title: '"async" methods should not return "void"'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3169
-  Title: Multiple "OrderBy" calls should not be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3172
-  Title: Delegates should not be subtracted
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3215
-  Title: '"interface" instances should not be cast to concrete types'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3216
-  Title: '"ConfigureAwait(false)" should be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3217
-  Title: '"Explicit" conversions of "foreach" loops should not be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3218
-  Title: Inner class members should not shadow outer class "static" or type members
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3220
-  Title: Method calls should not resolve ambiguously to overloads with "params"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3234
-  Title: '"GC.SuppressFinalize" should not be invoked for types without destructors'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3235
-  Title: Redundant parentheses should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3236
-  Title: Caller information arguments should not be provided explicitly
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3237
-  Title: '"value" contextual keyword should be used'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3240
-  Title: The simplest possible condition syntax should be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3241
-  Title: Methods should not return values that are never used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3242
-  Title: Method parameters should be declared with base types
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3244
-  Title: Anonymous delegates should not be used to unsubscribe from Events
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3246
-  Title: Generic type parameters should be co/contravariant when possible
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3247
-  Title: Duplicate casts should not be made
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3249
-  Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3251
-  Title: Implementations should be provided for "partial" methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3253
-  Title: Constructor and destructor declarations should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3254
-  Title: Default parameter values should not be passed as arguments
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3256
-  Title: '"string.IsNullOrEmpty" should be used'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3257
-  Title: Declarations and initializations should be as concise as possible
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3260
-  Title: Non-derived "private" classes and records should be "sealed"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3261
-  Title: Namespaces should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3262
-  Title: '"params" should be used on overrides'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3263
-  Title: 'Static fields should appear in the order they must be initialized '
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3264
-  Title: Events should be invoked
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3265
-  Title: Non-flags enums should not be used in bitwise operations
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3267
-  Title: Loops should be simplified with "LINQ" expressions
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3329
-  Title: Cipher Block Chaining IVs should be unpredictable
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3330
-  Title: Creating cookies without the "HttpOnly" flag is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3343
-  Title: Caller information parameters should come at the end of the parameter list
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3346
-  Title: Expressions used in "Debug.Assert" should not produce side effects
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3353
-  Title: Unchanged variables should be marked as "const"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3358
-  Title: Ternary operators should not be nested
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3363
-  Title: Date and time should not be used as a type for primary keys
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3366
-  Title: '"this" should not be exposed from constructors'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3376
-  Title: Attribute, EventArgs, and Exception type names should end with the type being extended
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3397
-  Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3398
-  Title: '"private" methods called only by inner classes should be moved to those classes'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3400
-  Title: Methods should not return constants
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3415
-  Title: Assertion arguments should be passed in the correct order
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3416
-  Title: Loggers should be named for their enclosing types
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3427
-  Title: Method overloads with default parameter values should not overlap
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3431
-  Title: '"[ExpectedException]" should not be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3433
-  Title: Test method signatures should be correct
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3440
-  Title: Variables should not be checked against the values they're about to be assigned
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3441
-  Title: Redundant property names should be omitted in anonymous classes
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3442
-  Title: '"abstract" classes should not have "public" constructors'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3443
-  Title: Type should not be examined on "System.Type" instances
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3444
-  Title: Interfaces should not simply inherit from base interfaces with colliding members
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3445
-  Title: Exceptions should not be explicitly rethrown
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3447
-  Title: '"[Optional]" should not be used on "ref" or "out" parameters'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3449
-  Title: Right operands of shift operators should be integers
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3450
-  Title: Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3451
-  Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3453
-  Title: Classes should not have only "private" constructors
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3456
-  Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3457
-  Title: Composite format strings should be used correctly
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3458
-  Title: Empty "case" clauses that fall through to the "default" should be omitted
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3459
-  Title: Unassigned members should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3464
-  Title: Type inheritance should not be recursive
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3466
-  Title: Optional parameters should be passed to "base" calls
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3532
-  Title: Empty "default" clauses should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3597
-  Title: '"ServiceContract" and "OperationContract" attributes should be used together'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3598
-  Title: One-way "OperationContract" methods should have "void" return type
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3600
-  Title: '"params" should not be introduced on overrides'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3603
-  Title: 'Methods with "Pure" attribute should return a value '
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3604
-  Title: Member initializer values should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3610
-  Title: Nullable type comparison should not be redundant
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3626
-  Title: Jump statements should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3655
-  Title: Empty nullable value should not be accessed
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3717
-  Title: Track use of "NotImplementedException"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3776
-  Title: Cognitive Complexity of methods should not be too high
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3869
-  Title: '"SafeHandle.DangerousGetHandle" should not be called'
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3871
-  Title: Exception types should be "public"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3872
-  Title: Parameter names should not duplicate the names of their methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3874
-  Title: '"out" and "ref" parameters should not be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3875
-  Title: '"operator==" should not be overloaded on reference types'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3876
-  Title: Strings or integral types should be used for indexers
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3877
-  Title: Exceptions should not be thrown from unexpected methods
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3878
-  Title: Arrays should not be created for params parameters
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3880
-  Title: Finalizers should not be empty
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3881
-  Title: '"IDisposable" should be implemented correctly'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3884
-  Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used'
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3885
-  Title: '"Assembly.Load" should be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3887
-  Title: Mutable, non-private fields should not be "readonly"
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3889
-  Title: '"Thread.Resume" and "Thread.Suspend" should not be used'
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3897
-  Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3898
-  Title: Value types should implement "IEquatable<T>"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3900
-  Title: Arguments of public methods should be validated against null
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S3902
-  Title: '"Assembly.GetExecutingAssembly" should not be called'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3903
-  Title: Types should be defined in named namespaces
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3904
-  Title: Assemblies should have version information
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3906
-  Title: Event Handlers should have the correct signature
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3908
-  Title: Generic event handlers should be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3909
-  Title: Collections should implement the generic interface
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3923
-  Title: All branches in a conditional structure should not have exactly the same implementation
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3925
-  Title: '"ISerializable" should be implemented correctly'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3926
-  Title: Deserialization methods should be provided for "OptionalField" members
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3927
-  Title: Serialization event handlers should be implemented correctly
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3928
-  Title: 'Parameter names used into ArgumentException constructors should match an existing one '
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3937
-  Title: Number patterns should be regular
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3949
-  Title: Calculations should not overflow
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3956
-  Title: '"Generic.List" instances should not be part of public APIs'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3962
-  Title: '"static readonly" constants should be "const" instead'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3963
-  Title: '"static" fields should be initialized inline'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3966
-  Title: Objects should not be disposed more than once
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3967
-  Title: Multidimensional arrays should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3971
-  Title: '"GC.SuppressFinalize" should not be called'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3972
-  Title: Conditionals should start on new lines
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3973
-  Title: A conditionally executed single line should be denoted by indentation
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3981
-  Title: Collection sizes and array length comparisons should make sense
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3984
-  Title: Exceptions should not be created without being thrown
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3990
-  Title: Assemblies should be marked as CLS compliant
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3992
-  Title: Assemblies should explicitly specify COM visibility
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3993
-  Title: Custom attributes should be marked with "System.AttributeUsageAttribute"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3994
-  Title: URI Parameters should not be strings
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3995
-  Title: URI return values should not be strings
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3996
-  Title: URI properties should not be strings
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3997
-  Title: String URI overloads should call "System.Uri" overloads
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3998
-  Title: Threads should not lock on objects with weak identity
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4000
-  Title: Pointers to unmanaged memory should not be visible
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4002
-  Title: Disposable types should declare finalizers
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4004
-  Title: Collection properties should be readonly
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4005
-  Title: '"System.Uri" arguments should be used instead of strings'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4015
-  Title: Inherited member visibility should not be decreased
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4016
-  Title: Enumeration members should not be named "Reserved"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4017
-  Title: Method signatures should not contain nested generic types
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4018
-  Title: All type parameters should be used in the parameter list to enable type inference
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4019
-  Title: Base class methods should not be hidden
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4022
-  Title: Enumerations should have "Int32" storage
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4023
-  Title: Interfaces should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4025
-  Title: Child class fields should not differ from parent class fields only by capitalization
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4026
-  Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4027
-  Title: Exceptions should provide standard constructors
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4035
-  Title: Classes implementing "IEquatable<T>" should be sealed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4036
-  Title: Searching OS commands in PATH is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4039
-  Title: Interface methods should be callable by derived types
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4040
-  Title: Strings should be normalized to uppercase
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4041
-  Title: Type names should not match namespaces
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4047
-  Title: Generics should be used when appropriate
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4049
-  Title: Properties should be preferred
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4050
-  Title: Operators should be overloaded consistently
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4052
-  Title: Types should not extend outdated base types
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4055
-  Title: Literals should not be passed as localized parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4056
-  Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4057
-  Title: Locales should be set for data types
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4058
-  Title: Overloads with a "StringComparison" parameter should be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4059
-  Title: Property names should not match get methods
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4060
-  Title: Non-abstract attributes should be sealed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4061
-  Title: '"params" should be used instead of "varargs"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4069
-  Title: Operator overloads should have named alternatives
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4070
-  Title: Non-flags enums should not be marked with "FlagsAttribute"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4136
-  Title: Method overloads should be grouped together
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4143
-  Title: Collection elements should not be replaced unconditionally
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4144
-  Title: Methods should not have identical implementations
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4158
-  Title: Empty collections should not be accessed or iterated
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4159
-  Title: Classes should implement their "ExportAttribute" interfaces
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4200
-  Title: Native methods should be wrapped
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4201
-  Title: Null checks should not be combined with "is" operator checks
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4210
-  Title: Windows Forms entry points should be marked with STAThread
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4211
-  Title: Members should not have conflicting transparency annotations
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4212
-  Title: Serialization constructors should be secured
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4214
-  Title: '"P/Invoke" methods should not be visible'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4220
-  Title: Events should have proper arguments
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4225
-  Title: Extension methods should not extend "object"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4226
-  Title: Extensions should be in separate namespaces
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4260
-  Title: '"ConstructorArgument" parameters should exist in constructors'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4261
-  Title: Methods should be named according to their synchronicities
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4275
-  Title: Getters and setters should access the expected fields
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4277
-  Title: '"Shared" parts should not be created with "new"'
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4347
-  Title: Secure random number generators should not output predictable values
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4423
-  Title: Weak SSL/TLS protocols should not be used
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4426
-  Title: Cryptographic keys should be robust
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4428
-  Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4433
-  Title: LDAP connections should be authenticated
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4456
-  Title: Parameter validation in yielding methods should be wrapped
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4457
-  Title: Parameter validation in "async"/"await" methods should be wrapped
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4462
-  Title: Calls to "async" methods should not be blocking
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4487
-  Title: Unread "private" fields should be removed
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4502
-  Title: Disabling CSRF protections is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4507
-  Title: Delivering code in production with debug features activated is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4524
-  Title: '"default" clauses should be first or last'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4545
-  Title: '"DebuggerDisplayAttribute" strings should reference existing members'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4581
-  Title: '"new Guid()" should not be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4583
-  Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4586
-  Title: Non-async "Task/Task<T>" methods should not return null
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4635
-  Title: Start index should be used instead of calling Substring
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4663
-  Title: Comments should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4790
-  Title: Using weak hashing algorithms is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4792
-  Title: Configuring loggers is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4830
-  Title: Server certificates should be verified during SSL/TLS connections
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5034
-  Title: '"ValueTask" should be consumed correctly'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5042
-  Title: Expanding archive files without controlling resource consumption is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5122
-  Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5332
-  Title: Using clear-text protocols is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5344
-  Title: Passwords should not be stored in plaintext or with a fast hashing algorithm
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5443
-  Title: Using publicly writable directories is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5445
-  Title: Insecure temporary file creation methods should not be used
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5542
-  Title: Encryption algorithms should be used with secure mode and padding scheme
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5547
-  Title: Cipher algorithms should be robust
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5659
-  Title: JWT should be signed and verified with strong cipher algorithms
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5693
-  Title: Allowing requests with excessive content length is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5753
-  Title: Disabling ASP.NET "Request Validation" feature is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5766
-  Title: Deserializing objects without performing data validation is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5773
-  Title: Types allowed to be deserialized should be restricted
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5856
-  Title: Regular expressions should be syntactically valid
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6354
-  Title: Use a testable date/time provider
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6377
-  Title: XML signatures should be validated securely
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6419
-  Title: Azure Functions should be stateless
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6420
-  Title: Client instances should not be recreated on each Azure Function invocation
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6421
-  Title: Azure Functions should use Structured Error Handling
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6422
-  Title: Calls to "async" methods should not be blocking in Azure Functions
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6423
-  Title: Azure Functions should log all failures
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6424
-  Title: Interfaces for durable entities should satisfy the restrictions
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6444
-  Title: Not specifying a timeout for regular expressions is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6507
-  Title: Blocks should not be synchronized on local variables
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S6513
-  Title: '"ExcludeFromCodeCoverage" attributes should include a justification'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6561
-  Title: Avoid using "DateTime.Now" for benchmarking or timing operations
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6562
-  Title: Always set the "DateTimeKind" when creating new "DateTime" instances
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6563
-  Title: Use UTC when recording DateTime instants
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6566
-  Title: Use "DateTimeOffset" instead of "DateTime"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6575
-  Title: Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6580
-  Title: Use a format provider when parsing date and time
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6585
-  Title: Don't hardcode the format when turning dates and times to strings
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6588
-  Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6602
-  Title: '"Find" method should be used instead of the "FirstOrDefault" extension'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6603
-  Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6605
-  Title: Collection-specific "Exists" method should be used instead of the "Any" extension
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6607
-  Title: The collection should be filtered before sorting by using "Where" before "OrderBy"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6608
-  Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6609
-  Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6610
-  Title: '"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6612
-  Title: The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6613
-  Title: '"First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6617
-  Title: '"Contains" should be used instead of "Any" for simple equality checks'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6618
-  Title: '"string.Create" should be used instead of "FormattableString"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6640
-  Title: Using unsafe code blocks is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6664
-  Title: The code block contains too many logging calls
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6667
-  Title: Logging in a catch clause should pass the caught exception as a parameter.
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6668
-  Title: Logging arguments should be passed to the correct parameter
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6669
-  Title: Logger field or property name should comply with a naming convention
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6670
-  Title: '"Trace.Write" and "Trace.WriteLine" should not be used'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6672
-  Title: Generic logger injection should match enclosing type
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6673
-  Title: Log message template placeholders should be in the right order
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6674
-  Title: Log message template should be syntactically correct
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6675
-  Title: '"Trace.WriteLineIf" should not be used with "TraceSwitch" levels'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6677
-  Title: Message template placeholders should be unique
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6678
-  Title: Use PascalCase for named placeholders
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6781
-  Title: JWT secret keys should not be disclosed
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6797
-  Title: Blazor query parameter type should be supported
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6798
-  Title: '[JSInvokable] attribute should only be used on public methods'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6800
-  Title: Component parameter type should match the route parameter type constraint
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6802
-  Title: Using lambda expressions in loops should be avoided in Blazor markup section
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6803
-  Title: Parameters with SupplyParameterFromQuery attribute should be used only in routable components
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S6930
-  Title: Backslash should be avoided in route templates
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6931
-  Title: ASP.NET controller actions should not have a route template starting with "/"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6932
-  Title: Use model binding instead of reading raw request data
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6934
-  Title: A Route attribute should be added to the controller when a route template is specified at the action level
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6960
-  Title: Controllers should not have mixed responsibilities
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6961
-  Title: API Controllers should derive from ControllerBase instead of Controller
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6962
-  Title: You should pool HTTP connections with HttpClientFactory
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6964
-  Title: Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6965
-  Title: REST API actions should be annotated with an HTTP verb attribute
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6966
-  Title: Awaitable method should be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6967
-  Title: ModelState.IsValid should be called in controller actions
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6968
-  Title: Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S818
-  Title: Literal suffixes should be upper case
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S881
-  Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S907
-  Title: '"goto" statement should not be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S927
-  Title: Parameter names should match base declaration and other partial definitions
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S9999-cpd
-  Title: Copy-paste token calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-log
-  Title: Log generator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-metadata
-  Title: File metadata generator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-metrics
-  Title: Metrics calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-symbolRef
-  Title: Symbol reference calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-token-type
-  Title: Token type calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-warning
-  Title: Analysis Warning generator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: SA0001
-  Title: XML comment analysis disabled
-  Category: StyleCop.CSharp.SpecialRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA0002
-  Title: Invalid settings file
-  Category: StyleCop.CSharp.SpecialRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1000
-  Title: Keywords should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1001
-  Title: Commas should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1002
-  Title: Semicolons should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1003
-  Title: Symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1004
-  Title: Documentation lines should begin with single space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1005
-  Title: Single line comments should begin with single space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1006
-  Title: Preprocessor keywords should not be preceded by space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1007
-  Title: Operator keyword should be followed by space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1008
-  Title: Opening parenthesis should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1009
-  Title: Closing parenthesis should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1010
-  Title: Opening square brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1011
-  Title: Closing square brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1012
-  Title: Opening braces should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1013
-  Title: Closing braces should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1014
-  Title: Opening generic brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1015
-  Title: Closing generic brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1016
-  Title: Opening attribute brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1017
-  Title: Closing attribute brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1018
-  Title: Nullable type symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1019
-  Title: Member access symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1020
-  Title: Increment decrement symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1021
-  Title: Negative signs should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1022
-  Title: Positive signs should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1023
-  Title: Dereference and access of symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1024
-  Title: Colons Should Be Spaced Correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1025
-  Title: Code should not contain multiple whitespace in a row
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1026
-  Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1027
-  Title: Use tabs correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1028
-  Title: Code should not contain trailing whitespace
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1100
-  Title: Do not prefix calls with base unless local implementation exists
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1101
-  Title: Prefix local calls with this
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1102
-  Title: Query clause should follow previous clause
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1103
-  Title: Query clauses should be on separate lines or all on one line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1104
-  Title: Query clause should begin on new line when previous clause spans multiple lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1105
-  Title: Query clauses spanning multiple lines should begin on own line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1106
-  Title: Code should not contain empty statements
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1107
-  Title: Code should not contain multiple statements on one line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1108
-  Title: Block statements should not contain embedded comments
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1109
-  Title: Block statements should not contain embedded regions
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1110
-  Title: Opening parenthesis or bracket should be on declaration line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1111
-  Title: Closing parenthesis should be on line of last parameter
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1112
-  Title: Closing parenthesis should be on line of opening parenthesis
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1113
-  Title: Comma should be on the same line as previous parameter
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1114
-  Title: Parameter list should follow declaration
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1115
-  Title: Parameter should follow comma
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1116
-  Title: Split parameters should start on line after declaration
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1117
-  Title: Parameters should be on same line or separate lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1118
-  Title: Parameter should not span multiple lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1119
-  Title: Statement should not use unnecessary parenthesis
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1119_p
-  Title: Statement should not use unnecessary parenthesis
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SA1120
-  Title: Comments should contain text
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1121
-  Title: Use built-in type alias
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1122
-  Title: Use string.Empty for empty strings
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1123
-  Title: Do not place regions within elements
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1124
-  Title: Do not use regions
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1125
-  Title: Use shorthand for nullable types
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1126
-  Title: Prefix calls correctly
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1127
-  Title: Generic type constraints should be on their own line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1128
-  Title: Put constructor initializers on their own line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1129
-  Title: Do not use default value type constructor
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1130
-  Title: Use lambda syntax
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1131
-  Title: Use readable conditions
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1132
-  Title: Do not combine fields
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1133
-  Title: Do not combine attributes
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1134
-  Title: Attributes should not share line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1135
-  Title: Using directives should be qualified
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1136
-  Title: Enum values should be on separate lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1137
-  Title: Elements should have the same indentation
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1139
-  Title: Use literal suffix notation instead of casting
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1141
-  Title: Use tuple syntax
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1142
-  Title: Refer to tuple fields by name
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1200
-  Title: Using directives should be placed correctly
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1201
-  Title: Elements should appear in the correct order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1202
-  Title: Elements should be ordered by access
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1203
-  Title: Constants should appear before fields
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1204
-  Title: Static elements should appear before instance elements
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1205
-  Title: Partial elements should declare access
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1206
-  Title: Declaration keywords should follow order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1207
-  Title: Protected should come before internal
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1208
-  Title: System using directives should be placed before other using directives
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1209
-  Title: Using alias directives should be placed after other using directives
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1210
-  Title: Using directives should be ordered alphabetically by namespace
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1211
-  Title: Using alias directives should be ordered alphabetically by alias name
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1212
-  Title: Property accessors should follow order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1213
-  Title: Event accessors should follow order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1214
-  Title: Readonly fields should appear before non-readonly fields
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1216
-  Title: Using static directives should be placed at the correct location
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1217
-  Title: Using static directives should be ordered alphabetically
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1300
-  Title: Element should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1301
-  Title: Element should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1302
-  Title: Interface names should begin with I
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1303
-  Title: Const field names should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1304
-  Title: Non-private readonly fields should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1305
-  Title: Field names should not use Hungarian notation
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1306
-  Title: Field names should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1307
-  Title: Accessible fields should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1308
-  Title: Variable names should not be prefixed
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1309
-  Title: Field names should not begin with underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - None
-  IsEverSuppressed: true
-- Id: SA1310
-  Title: Field names should not contain underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1311
-  Title: Static readonly fields should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1312
-  Title: Variable names should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1313
-  Title: Parameter names should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1314
-  Title: Type parameter names should begin with T
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1316
-  Title: Tuple element names should use correct casing
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1400
-  Title: Access modifier should be declared
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1401
-  Title: Fields should be private
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1402
-  Title: File may only contain a single type
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1403
-  Title: File may only contain a single namespace
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1404
-  Title: Code analysis suppression should have justification
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1405
-  Title: Debug.Assert should provide message text
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1406
-  Title: Debug.Fail should provide message text
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1407
-  Title: Arithmetic expressions should declare precedence
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1408
-  Title: Conditional expressions should declare precedence
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1409
-  Title: Remove unnecessary code
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1410
-  Title: Remove delegate parenthesis when possible
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1411
-  Title: Attribute constructor should not use unnecessary parenthesis
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1412
-  Title: Store files as UTF-8 with byte order mark
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1413
-  Title: Use trailing comma in multi-line initializers
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1414
-  Title: Tuple types in signatures should have element names
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1500
-  Title: Braces for multi-line statements should not share line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1501
-  Title: Statement should not be on a single line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1502
-  Title: Element should not be on a single line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1503
-  Title: Braces should not be omitted
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1504
-  Title: All accessors should be single-line or multi-line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1505
-  Title: Opening braces should not be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1506
-  Title: Element documentation headers should not be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1507
-  Title: Code should not contain multiple blank lines in a row
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1508
-  Title: Closing braces should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1509
-  Title: Opening braces should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1510
-  Title: Chained statement blocks should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1511
-  Title: While-do footer should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1512
-  Title: Single-line comments should not be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1513
-  Title: Closing brace should be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1514
-  Title: Element documentation header should be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1515
-  Title: Single-line comment should be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1516
-  Title: Elements should be separated by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1517
-  Title: Code should not contain blank lines at start of file
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1518
-  Title: Use line endings correctly at end of file
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1519
-  Title: Braces should not be omitted from multi-line child statement
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1520
-  Title: Use braces consistently
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1600
-  Title: Elements should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1601
-  Title: Partial elements should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: SA1602
-  Title: Enumeration items should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1603
-  Title: Documentation should contain valid XML
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1604
-  Title: Element documentation should have summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1605
-  Title: Partial element documentation should have summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1606
-  Title: Element documentation should have summary text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1607
-  Title: Partial element documentation should have summary text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1608
-  Title: Element documentation should not have default summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1609
-  Title: Property documentation should have value
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1610
-  Title: Property documentation should have value text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1611
-  Title: Element parameters should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1612
-  Title: Element parameter documentation should match element parameters
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1613
-  Title: Element parameter documentation should declare parameter name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1614
-  Title: Element parameter documentation should have text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1615
-  Title: Element return value should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1616
-  Title: Element return value documentation should have text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1617
-  Title: Void return value should not be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1618
-  Title: Generic type parameters should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1619
-  Title: Generic type parameters should be documented partial class
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1620
-  Title: Generic type parameter documentation should match type parameters
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1621
-  Title: Generic type parameter documentation should declare parameter name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1622
-  Title: Generic type parameter documentation should have text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1623
-  Title: Property summary documentation should match accessors
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1624
-  Title: Property summary documentation should omit accessor with restricted access
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1625
-  Title: Element documentation should not be copied and pasted
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1626
-  Title: Single-line comments should not use documentation style slashes
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1627
-  Title: Documentation text should not be empty
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1628
-  Title: Documentation text should begin with a capital letter
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1629
-  Title: Documentation text should end with a period
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1630
-  Title: Documentation text should contain whitespace
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1631
-  Title: Documentation should meet character percentage
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1632
-  Title: Documentation text should meet minimum character length
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1633
-  Title: File should have header
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1634
-  Title: File header should show copyright
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1635
-  Title: File header should have copyright text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1636
-  Title: File header copyright text should match
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1637
-  Title: File header should contain file name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1638
-  Title: File header file name documentation should match file name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1639
-  Title: File header should have summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: SA1640
-  Title: File header should have valid company text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1641
-  Title: File header company name text should match
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1642
-  Title: Constructor summary documentation should begin with standard text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1643
-  Title: Destructor summary documentation should begin with standard text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1644
-  Title: Documentation headers should not contain blank lines
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1645
-  Title: Included documentation file does not exist
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1646
-  Title: Included documentation XPath does not exist
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1647
-  Title: Include node does not contain valid file and path
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1648
-  Title: inheritdoc should be used with inheriting class
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1649
-  Title: File name should match first type name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1650
-  Title: Element documentation should be spelled correctly
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1651
-  Title: Do not use placeholder elements
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SX1101
-  Title: Do not prefix local calls with 'this.'
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SX1309
-  Title: Field names should begin with underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SX1309S
-  Title: Static field names should begin with underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SYSLIB1045
-  Title: Convert to 'GeneratedRegexAttribute'.
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SYSLIB1054
-  Title: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SYSLIB1055
-  Title: Invalid 'CustomMarshallerAttribute' usage
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1056
-  Title: Specified marshaller type is invalid
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1057
-  Title: Marshaller type does not have the required shape
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1058
-  Title: Invalid 'NativeMarshallingAttribute' usage
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1060
-  Title: Specified marshaller type is invalid
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1061
-  Title: Marshaller type has incompatible method signatures
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1090
-  Title: "'GeneratedComInterfaceType' does not support the 'ComInterfaceType' value supplied to 'InterfaceTypeAttribute' on the same type."
-  Category: ComInterfaceGenerator
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1096
-  Title: Convert to 'GeneratedComInterface'
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SYSLIB1097
-  Title: Add 'GeneratedComClassAttribute' to enable passing objects of this type to COM
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SYSLIB1098
-  Title: .NET COM hosting with 'EnableComHosting' does not support interfaces with the 'GeneratedComInterfaceAttribute'
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1099
-  Title: COM Interop APIs on 'System.Runtime.InteropServices.Marshal' do not support source-generated COM
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD001
-  Title: Avoid legacy thread switching APIs
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD002
-  Title: Avoid problematic synchronous waits
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: true
-- Id: VSTHRD003
-  Title: Avoid awaiting foreign Tasks
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD004
-  Title: Await SwitchToMainThreadAsync
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD010
-  Title: Invoke single-threaded types on Main thread
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD011
-  Title: Use AsyncLazy<T>
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD012
-  Title: Provide JoinableTaskFactory where allowed
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD100
-  Title: Avoid async void methods
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD101
-  Title: Avoid unsupported async delegates
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD102
-  Title: Implement internal logic asynchronously
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD103
-  Title: Call async methods when in an async method
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD104
-  Title: Offer async methods
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD105
-  Title: Avoid method overloads that assume TaskScheduler.Current
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD106
-  Title: Use InvokeAsync to raise async events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD107
-  Title: Await Task within using expression
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD108
-  Title: Assert thread affinity unconditionally
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD109
-  Title: Switch instead of assert in async methods
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD110
-  Title: Observe result of async calls
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD111
-  Title: Use ConfigureAwait(bool)
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: VSTHRD112
-  Title: Implement System.IAsyncDisposable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD113
-  Title: Check for System.IAsyncDisposable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD114
-  Title: Avoid returning a null Task
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD200
-  Title: Use "Async" suffix for async methods
-  Category: Style
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - None
-  IsEverSuppressed: true
-- Id: CS8762
-  Title: Parameter must have a non-null value when exiting in some condition.
-  Category: Compiler
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: true
-- Id: CS1591
-  Title: Missing XML comment for publicly visible type or member
-  Category: Compiler
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
+- {Id: CA1000, Title: Do not declare static members on generic types, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1001, Title: Types that own disposable fields should be disposable, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1002, Title: Do not expose generic lists, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1003, Title: Use generic event handler instances, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1005, Title: Avoid excessive parameters on generic types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1008, Title: Enums should have zero value, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1010, Title: Generic interface should also be implemented, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1012, Title: Abstract types should not have public constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1014, Title: Mark assemblies with CLSCompliant, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1016, Title: Mark assemblies with assembly version, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1017, Title: Mark assemblies with ComVisible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1018, Title: Mark attributes with AttributeUsageAttribute, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1019, Title: Define accessors for attribute arguments, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1021, Title: Avoid out parameters, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1024, Title: Use properties where appropriate, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1027, Title: Mark enums with FlagsAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1028, Title: Enum Storage should be Int32, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1030, Title: Use events where appropriate, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1031, Title: Do not catch general exception types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1032, Title: Implement standard exception constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1033, Title: Interface methods should be callable by child types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1034, Title: Nested types should not be visible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1036, Title: Override methods on comparable types, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1040, Title: Avoid empty interfaces, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1041, Title: Provide ObsoleteAttribute message, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1043, Title: Use Integral Or String Argument For Indexers, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1044, Title: Properties should not be write only, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1045, Title: Do not pass types by reference, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1046, Title: Do not overload equality operator on reference types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1050, Title: Declare types in namespaces, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1051, Title: Do not declare visible instance fields, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1052, Title: Static holder types should be Static or NotInheritable, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1054, Title: URI-like parameters should not be strings, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1055, Title: URI-like return values should not be strings, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1056, Title: URI-like properties should not be strings, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1058, Title: Types should not extend certain base types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1060, Title: Move pinvokes to native methods class, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1061, Title: Do not hide base class methods, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1062, Title: Validate arguments of public methods, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1063, Title: Implement IDisposable Correctly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1064, Title: Exceptions should be public, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1065, Title: Do not raise exceptions in unexpected locations, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1066, Title: Implement IEquatable when overriding Object.Equals, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: CA1067, Title: Override Object.Equals(object) when implementing IEquatable<T>, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1068, Title: CancellationToken parameters must come last, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1069, Title: Enums values should not be duplicated, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1070, Title: Do not declare event fields as virtual, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1200, Title: Avoid using cref tags with a prefix, Category: Documentation, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1303, Title: Do not pass literals as localized parameters, Category: Globalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1304, Title: Specify CultureInfo, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1305, Title: Specify IFormatProvider, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1307, Title: Specify StringComparison for clarity, Category: Globalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1308, Title: Normalize strings to uppercase, Category: Globalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1309, Title: Use ordinal string comparison, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1310, Title: Specify StringComparison for correctness, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1311, Title: Specify a culture or use an invariant version, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1401, Title: P/Invokes should not be visible, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1416, Title: Validate platform compatibility, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1417, Title: Do not use 'OutAttribute' on string parameters for P/Invokes, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1418, Title: Use valid platform string, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1419, Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle', Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1420, Title: 'Property, type, or attribute requires runtime marshalling', Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1421, Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1422, Title: Validate platform compatibility, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1501, Title: Avoid excessive inheritance, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1502, Title: Avoid excessive complexity, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1505, Title: Avoid unmaintainable code, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1506, Title: Avoid excessive class coupling, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1507, Title: Use nameof to express symbol names, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1508, Title: Avoid dead conditional code, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1509, Title: Invalid entry in code metrics rule specification file, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1510, Title: Use ArgumentNullException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1511, Title: Use ArgumentException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1512, Title: Use ArgumentOutOfRangeException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1513, Title: Use ObjectDisposedException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1700, Title: Do not name enum values 'Reserved', Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1707, Title: Identifiers should not contain underscores, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1708, Title: Identifiers should differ by more than case, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1710, Title: Identifiers should have correct suffix, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1711, Title: Identifiers should not have incorrect suffix, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1712, Title: Do not prefix enum values with type name, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1713, Title: Events should not have 'Before' or 'After' prefix, Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1715, Title: Identifiers should have correct prefix, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1716, Title: Identifiers should not match keywords, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1720, Title: Identifier contains type name, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1721, Title: Property names should not match get methods, Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1724, Title: Type names should not match namespaces, Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1725, Title: Parameter names should match base declaration, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1727, Title: Use PascalCase for named placeholders, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1802, Title: Use literals where appropriate, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1805, Title: Do not initialize unnecessarily, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1806, Title: Do not ignore method results, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1810, Title: Initialize reference type static fields inline, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1812, Title: Avoid uninstantiated internal classes, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1813, Title: Avoid unsealed attributes, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1814, Title: Prefer jagged arrays over multidimensional, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1815, Title: Override equals and operator equals on value types, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1816, Title: Dispose methods should call SuppressFinalize, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1819, Title: Properties should not return arrays, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1820, Title: Test for empty strings using string length, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1821, Title: Remove empty Finalizers, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1822, Title: Mark members as static, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1823, Title: Avoid unused private fields, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1824, Title: Mark assemblies with NeutralResourcesLanguageAttribute, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1825, Title: Avoid zero-length array allocations, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1826, Title: Do not use Enumerable methods on indexable collections, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1827, Title: Do not use Count() or LongCount() when Any() can be used, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1828, Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1829, Title: Use Length/Count property instead of Count() when available, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1830, Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1831, Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1832, Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1833, Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1834, Title: Consider using 'StringBuilder.Append(char)' when applicable, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1835, Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1836, Title: Prefer IsEmpty over Count, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1837, Title: Use 'Environment.ProcessId', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1838, Title: Avoid 'StringBuilder' parameters for P/Invokes, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1839, Title: Use 'Environment.ProcessPath', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1840, Title: Use 'Environment.CurrentManagedThreadId', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1841, Title: Prefer Dictionary.Contains methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1842, Title: Do not use 'WhenAll' with a single task, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1843, Title: Do not use 'WaitAll' with a single task, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1844, Title: Provide memory-based overrides of async methods when subclassing 'Stream', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1845, Title: Use span-based 'string.Concat', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1846, Title: Prefer 'AsSpan' over 'Substring', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1847, Title: Use char literal for a single character lookup, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1848, Title: Use the LoggerMessage delegates, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1849, Title: Call async methods when in an async method, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1850, Title: Prefer static 'HashData' method over 'ComputeHash', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1851, Title: Possible multiple enumerations of 'IEnumerable' collection, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1852, Title: Seal internal types, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1853, Title: Unnecessary call to 'Dictionary.ContainsKey(key)', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1854, Title: "Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method", Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1855, Title: Prefer 'Clear' over 'Fill', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1856, Title: Incorrect usage of ConstantExpected attribute, Category: Performance, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1857, Title: A constant is expected for the parameter, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1858, Title: Use 'StartsWith' instead of 'IndexOf', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1859, Title: Use concrete types when possible for improved performance, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1860, Title: Avoid using 'Enumerable.Any()' extension method, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1861, Title: Avoid constant arrays as arguments, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1862, Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1863, Title: Use 'CompositeFormat', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1864, Title: "Prefer the 'IDictionary.TryAdd(TKey, TValue)' method", Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1865, Title: Use char overload, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1866, Title: Use char overload, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1867, Title: Use char overload, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: CA1868, Title: Unnecessary call to 'Contains(item)', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1869, Title: Cache and reuse 'JsonSerializerOptions' instances, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1870, Title: Use a cached 'SearchValues' instance, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2000, Title: Dispose objects before losing scope, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2002, Title: Do not lock on objects with weak identity, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2007, Title: Consider calling ConfigureAwait on the awaited task, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2008, Title: Do not create tasks without passing a TaskScheduler, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2009, Title: Do not call ToImmutableCollection on an ImmutableCollection value, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2011, Title: Avoid infinite recursion, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2012, Title: Use ValueTasks correctly, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2013, Title: Do not use ReferenceEquals with value types, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2014, Title: Do not use stackalloc in loops, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2015, Title: Do not define finalizers for types derived from MemoryManager<T>, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2016, Title: Forward the 'CancellationToken' parameter to methods, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: CA2017, Title: Parameter count mismatch, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2018, Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument", Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2019, Title: Improper 'ThreadStatic' field initialization, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2020, Title: Prevent behavioral change, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2021, Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2100, Title: Review SQL queries for security vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2101, Title: Specify marshaling for P/Invoke string arguments, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2119, Title: Seal methods that satisfy private interfaces, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2153, Title: Do Not Catch Corrupted State Exceptions, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2200, Title: Rethrow to preserve stack details, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2201, Title: Do not raise reserved exception types, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2207, Title: Initialize value type static fields inline, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2208, Title: Instantiate argument exceptions correctly, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2211, Title: Non-constant fields should not be visible, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2213, Title: Disposable fields should be disposed, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2214, Title: Do not call overridable methods in constructors, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2215, Title: Dispose methods should call base class dispose, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2216, Title: Disposable types should declare finalizer, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2217, Title: Do not mark enums with FlagsAttribute, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2219, Title: Do not raise exceptions in finally clauses, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2225, Title: Operator overloads have named alternates, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2226, Title: Operators should have symmetrical overloads, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2227, Title: Collection properties should be read only, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2231, Title: Overload operator equals on overriding value type Equals, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2234, Title: Pass system uri objects instead of strings, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2235, Title: Mark all non-serializable fields, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2237, Title: Mark ISerializable types with serializable, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2241, Title: Provide correct arguments to formatting methods, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2242, Title: Test for NaN correctly, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2243, Title: Attribute string literals should parse correctly, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2244, Title: Do not duplicate indexed element initializations, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2245, Title: Do not assign a property to itself, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2246, Title: Assigning symbol and its member in the same statement, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2247, Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2248, Title: Provide correct 'enum' argument to 'Enum.HasFlag', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2249, Title: Consider using 'string.Contains' instead of 'string.IndexOf', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2250, Title: Use 'ThrowIfCancellationRequested', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2251, Title: Use 'string.Equals', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2252, Title: This API requires opting into preview features, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2253, Title: Named placeholders should not be numeric values, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2254, Title: Template should be a static expression, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2255, Title: The 'ModuleInitializer' attribute should not be used in libraries, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2256, Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2257, Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static', Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2258, Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2259, Title: "'ThreadStatic' only affects static fields", Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2260, Title: Use correct type parameter, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2261, Title: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2300, Title: Do not use insecure deserializer BinaryFormatter, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2301, Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2302, Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2305, Title: Do not use insecure deserializer LosFormatter, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2310, Title: Do not use insecure deserializer NetDataContractSerializer, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2311, Title: Do not deserialize without first setting NetDataContractSerializer.Binder, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2312, Title: Ensure NetDataContractSerializer.Binder is set before deserializing, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2315, Title: Do not use insecure deserializer ObjectStateFormatter, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2321, Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2322, Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2326, Title: Do not use TypeNameHandling values other than None, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2327, Title: Do not use insecure JsonSerializerSettings, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2328, Title: Ensure that JsonSerializerSettings are secure, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2329, Title: Do not deserialize with JsonSerializer using an insecure configuration, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2330, Title: Ensure that JsonSerializer has a secure configuration when deserializing, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2350, Title: Do not use DataTable.ReadXml() with untrusted data, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2351, Title: Do not use DataSet.ReadXml() with untrusted data, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2352, Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2353, Title: Unsafe DataSet or DataTable in serializable type, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2354, Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2355, Title: Unsafe DataSet or DataTable type found in deserializable object graph, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2356, Title: Unsafe DataSet or DataTable type in web deserializable object graph, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2361, Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2362, Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3001, Title: Review code for SQL injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3002, Title: Review code for XSS vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3003, Title: Review code for file path injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3004, Title: Review code for information disclosure vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3005, Title: Review code for LDAP injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3006, Title: Review code for process command injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3007, Title: Review code for open redirect vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3008, Title: Review code for XPath injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3009, Title: Review code for XML injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3010, Title: Review code for XAML injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3011, Title: Review code for DLL injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3012, Title: Review code for regex injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3061, Title: Do Not Add Schema By URL, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3075, Title: Insecure DTD processing in XML, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3076, Title: Insecure XSLT script processing, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3077, Title: 'Insecure Processing in API Design, XmlDocument and XmlTextReader', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3147, Title: Mark Verb Handlers With Validate Antiforgery Token, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5350, Title: Do Not Use Weak Cryptographic Algorithms, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5351, Title: Do Not Use Broken Cryptographic Algorithms, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5358, Title: Review cipher mode usage with cryptography experts, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5359, Title: Do Not Disable Certificate Validation, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5360, Title: Do Not Call Dangerous Methods In Deserialization, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5361, Title: Do Not Disable SChannel Use of Strong Crypto, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5362, Title: Potential reference cycle in deserialized object graph, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5363, Title: Do Not Disable Request Validation, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5364, Title: Do Not Use Deprecated Security Protocols, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5365, Title: Do Not Disable HTTP Header Checking, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5366, Title: Use XmlReader for 'DataSet.ReadXml()', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5367, Title: Do Not Serialize Types With Pointer Fields, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5368, Title: Set ViewStateUserKey For Classes Derived From Page, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5369, Title: Use XmlReader for 'XmlSerializer.Deserialize()', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5370, Title: Use XmlReader for XmlValidatingReader constructor, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5371, Title: Use XmlReader for 'XmlSchema.Read()', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5372, Title: Use XmlReader for XPathDocument constructor, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5373, Title: Do not use obsolete key derivation function, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5374, Title: Do Not Use XslTransform, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5375, Title: Do Not Use Account Shared Access Signature, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5376, Title: Use SharedAccessProtocol HttpsOnly, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5377, Title: Use Container Level Access Policy, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5378, Title: Do not disable ServicePointManagerSecurityProtocols, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5379, Title: Ensure Key Derivation Function algorithm is sufficiently strong, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5380, Title: Do Not Add Certificates To Root Store, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5381, Title: Ensure Certificates Are Not Added To Root Store, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5382, Title: Use Secure Cookies In ASP.NET Core, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5383, Title: Ensure Use Secure Cookies In ASP.NET Core, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5384, Title: Do Not Use Digital Signature Algorithm (DSA), Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5385, Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5386, Title: Avoid hardcoding SecurityProtocolType value, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5387, Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5388, Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5389, Title: Do Not Add Archive Item's Path To The Target File System Path, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5390, Title: Do not hard-code encryption key, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5391, Title: Use antiforgery tokens in ASP.NET Core MVC controllers, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5392, Title: Use DefaultDllImportSearchPaths attribute for P/Invokes, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5393, Title: Do not use unsafe DllImportSearchPath value, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5394, Title: Do not use insecure randomness, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5395, Title: Miss HttpVerb attribute for action methods, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5396, Title: Set HttpOnly to true for HttpCookie, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5397, Title: Do not use deprecated SslProtocols values, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5398, Title: Avoid hardcoded SslProtocols values, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5399, Title: HttpClients should enable certificate revocation list checks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5400, Title: Ensure HttpClient certificate revocation list check is not disabled, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5401, Title: Do not use CreateEncryptor with non-default IV, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5402, Title: 'Use CreateEncryptor with the default IV ', Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5403, Title: Do not hard-code certificate, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5404, Title: Do not disable token validation checks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5405, Title: Do not always skip token validation in delegates, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CS1591, Title: Missing XML comment for publicly visible type or member, Category: Compiler, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: CS8762, Title: Parameter must have a non-null value when exiting in some condition., Category: Compiler, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: true}
+- {Id: EM0001, Title: Switch on Enum Not Exhaustive, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0002, Title: Switch on Nullable Enum Not Exhaustive, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0003, Title: Switch on Closed Type Not Exhaustive, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0011, Title: Concrete Subtype of a Closed Type Must Be a Case, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0012, Title: Closed Type Case Must Be a Direct Subtype, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0013, Title: Closed Type Case Must Be a Subtype, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0014, Title: Concrete Subtype of a Closed Type Must Be a Covered, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0015, Title: Open Interface Subtype of a Closed Type Must Be a Case, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0100, Title: When Guards Not Supported, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0101, Title: Case Pattern Not Supported, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0102, Title: Open Type Not Supported, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0103, Title: Match Must Be On Case Type, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0104, Title: Duplicate Closed Attribute, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0105, Title: Duplicate Case Type, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EnableGenerateDocumentationFile, Title: Set MSBuild property 'GenerateDocumentationFile' to 'true', Category: Style, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: IDE0004, Title: Remove Unnecessary Cast, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0005, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0005_gen, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0007, Title: Use implicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0008, Title: Use explicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0009, Title: Member access should be qualified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0010, Title: Add missing cases, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0011, Title: Add braces, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0016, Title: Use 'throw' expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0017, Title: Simplify object initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0018, Title: Inline variable declaration, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0019, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0020, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0021, Title: Use expression body for constructor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0022, Title: Use expression body for method, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0023, Title: Use expression body for conversion operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0024, Title: Use expression body for operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0025, Title: Use expression body for property, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0026, Title: Use expression body for indexer, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0027, Title: Use expression body for accessor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0028, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0029, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0030, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0031, Title: Use null propagation, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0032, Title: Use auto property, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0033, Title: Use explicitly provided tuple name, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0034, Title: Simplify 'default' expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0035, Title: Unreachable code detected, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0036, Title: Order modifiers, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0037, Title: Use inferred member name, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0039, Title: Use local function, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0040, Title: Add accessibility modifiers, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0041, Title: Use 'is null' check, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0042, Title: Deconstruct variable declaration, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0043, Title: Invalid format string, Category: Compiler, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0044, Title: Add readonly modifier, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0045, Title: Convert to conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0046, Title: Convert to conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0047, Title: Remove unnecessary parentheses, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0048, Title: Add parentheses for clarity, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0051, Title: Remove unused private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0052, Title: Remove unread private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0053, Title: Use expression body for lambda expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0054, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0055, Title: Fix formatting, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0056, Title: Use index operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0057, Title: Use range operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0058, Title: Expression value is never used, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0059, Title: Unnecessary assignment of a value, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0060, Title: Remove unused parameter, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0061, Title: Use expression body for local function, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0062, Title: Make local function 'static', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0063, Title: Use simple 'using' statement, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0064, Title: Make readonly fields writable, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0065, Title: Misplaced using directive, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0066, Title: Convert switch statement to expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0070, Title: Use 'System.HashCode', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0071, Title: Simplify interpolation, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0072, Title: Add missing cases, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0073, Title: The file header does not match the required text, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0074, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0075, Title: Simplify conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0076, Title: Invalid global 'SuppressMessageAttribute', Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0077, Title: Avoid legacy format target in 'SuppressMessageAttribute', Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0078, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0080, Title: Remove unnecessary suppression operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0082, Title: "'typeof' can be converted to 'nameof'", Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0083, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0090, Title: Use 'new(...)', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0100, Title: Remove redundant equality, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0110, Title: Remove unnecessary discard, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0120, Title: Simplify LINQ expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0130, Title: Namespace does not match folder structure, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0150, Title: Prefer 'null' check over type check, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0160, Title: Convert to block scoped namespace, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0161, Title: Convert to file-scoped namespace, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0170, Title: Property pattern can be simplified, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0180, Title: Use tuple to swap values, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0200, Title: Remove unnecessary lambda expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0210, Title: Convert to top-level statements, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0211, Title: Convert to 'Program.Main' style program, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0220, Title: Add explicit cast, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0230, Title: Use UTF-8 string literal, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0240, Title: Remove redundant nullable directive, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0241, Title: Remove unnecessary nullable directive, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0250, Title: Make struct 'readonly', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0251, Title: Make member 'readonly', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0260, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0270, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0280, Title: Use 'nameof', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0290, Title: Use primary constructor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0300, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0301, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0302, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0303, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0304, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0305, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0320, Title: Make anonymous function static, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE1005, Title: Delegate invocation can be simplified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE1006, Title: Naming Styles, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE2000, Title: Avoid multiple blank lines, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2001, Title: Embedded statements must be on their own line, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2002, Title: Consecutive braces must not have blank line between them, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2003, Title: Blank line required between block and subsequent statement, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2004, Title: Blank line not allowed after constructor initializer colon, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2005, Title: Blank line not allowed after conditional expression token, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2006, Title: Blank line not allowed after arrow expression clause token, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0001, Title: StringComparison is missing, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0002, Title: IEqualityComparer<string> or IComparer<string> is missing, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0003, Title: Add parameter name to improve readability, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0004, Title: Use Task.ConfigureAwait, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0005, Title: Use Array.Empty<T>(), Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0006, Title: Use String.Equals instead of equality operator, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0007, Title: Add a comma after the last value, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0008, Title: Add StructLayoutAttribute, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0009, Title: Add regex evaluation timeout, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0010, Title: Mark attributes with AttributeUsageAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0011, Title: IFormatProvider is missing, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0012, Title: Do not raise reserved exception type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0013, Title: Types should not extend System.ApplicationException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0014, Title: Do not raise System.ApplicationException type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0015, Title: Specify the parameter name in ArgumentException, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0016, Title: Prefer using collection abstraction instead of implementation, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0017, Title: Abstract types should not have public or internal constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0018, Title: Do not declare static members on generic types (deprecated; use CA1000 instead), Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0019, Title: Use EventArgs.Empty, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0020, Title: Use direct methods instead of LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0021, Title: Use StringComparer.GetHashCode instead of string.GetHashCode, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0022, Title: Return Task.FromResult instead of returning null, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0023, Title: Add RegexOptions.ExplicitCapture, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0024, Title: Use an explicit StringComparer when possible, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0025, Title: Implement the functionality instead of throwing NotImplementedException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0026, Title: Fix TODO comment, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
+- {Id: MA0027, Title: Prefer rethrowing an exception implicitly, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0028, Title: Optimize StringBuilder usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0029, Title: Combine LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0030, Title: Remove useless OrderBy call, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0031, Title: Optimize Enumerable.Count() usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0032, Title: Use an overload with a CancellationToken argument, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0033, Title: Do not tag instance fields with ThreadStaticAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0035, Title: Do not use dangerous threading methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0036, Title: Make class static, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0037, Title: Remove empty statement, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0038, Title: 'Make method static (deprecated, use CA1822 instead)', Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0039, Title: Do not write your own certificate validation method, Category: Security, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0040, Title: Forward the CancellationToken parameter to methods that take one, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: MA0041, Title: 'Make property static (deprecated, use CA1822 instead)', Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0042, Title: Do not use blocking calls in an async method, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0043, Title: Use nameof operator in ArgumentException, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0044, Title: Remove useless ToString call, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0045, Title: Do not use blocking calls in a sync method (need to make calling method async), Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0046, Title: Use EventHandler<T> to declare events, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0047, Title: Declare types in namespaces, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0048, Title: File name must match type name, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0049, Title: Type name should not match containing namespace, Category: Design, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0050, Title: Validate arguments correctly in iterator methods, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0051, Title: Method is too long, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: MA0052, Title: Replace constant Enum.ToString with nameof, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0053, Title: Make class sealed, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0054, Title: Embed the caught exception as innerException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0055, Title: Do not use finalizer, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0056, Title: Do not call overridable members in constructor, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0057, Title: Class name should end with 'Attribute', Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0058, Title: Class name should end with 'Exception', Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0059, Title: Class name should end with 'EventArgs', Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0060, Title: The value returned by Stream.Read/Stream.ReadAsync is not used, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0061, Title: Method overrides should not change default values, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0062, Title: Non-flags enums should not be marked with "FlagsAttribute", Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0063, Title: Use Where before OrderBy, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0064, Title: Avoid locking on publicly accessible instance, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0065, Title: Default ValueType.Equals or HashCode is used for struct equality, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0066, Title: Hash table unfriendly type is used in a hash table, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0067, Title: Use Guid.Empty, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0068, Title: Invalid parameter name for nullable attribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0069, Title: Non-constant static fields should not be visible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0070, Title: Obsolete attributes should include explanations, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0071, Title: Avoid using redundant else, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0072, Title: Do not throw from a finally block, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0073, Title: Avoid comparison with bool constant, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0074, Title: Avoid implicit culture-sensitive methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0075, Title: Do not use implicit culture-sensitive ToString, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0076, Title: Do not use implicit culture-sensitive ToString in interpolated strings, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0077, Title: A class that provides Equals(T) should implement IEquatable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0078, Title: Use 'Cast' instead of 'Select' to cast, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0079, Title: Forward the CancellationToken using .WithCancellation(), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0080, Title: Use a cancellation token using .WithCancellation(), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0081, Title: Method overrides should not omit params keyword, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0082, Title: NaN should not be used in comparisons, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0083, Title: ConstructorArgument parameters should exist in constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0084, Title: Local variables should not hide other symbols, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0085, Title: Anonymous delegates should not be used to unsubscribe from Events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0086, Title: Do not throw from a finalizer, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0087, Title: 'Parameters with [DefaultParameterValue] attributes should also be marked [Optional]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0088, Title: 'Use [DefaultParameterValue] instead of [DefaultValue]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0089, Title: Optimize string method usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0090, Title: Remove empty else/finally block, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0091, Title: Sender should be 'this' for instance events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0092, Title: Sender should be 'null' for static events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0093, Title: EventArgs should not be null, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0094, Title: A class that provides CompareTo(T) should implement IComparable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0095, Title: A class that implements IEquatable<T> should override Equals(object), Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0096, Title: A class that implements IComparable<T> should also implement IEquatable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0097, Title: A class that implements IComparable<T> or IComparable should override comparison operators, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0098, Title: Use indexer instead of LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0099, Title: Use Explicit enum value instead of 0, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0100, Title: Await task before disposing of resources, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0101, Title: String contains an implicit end of line character, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: MA0102, Title: Make member readonly, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0103, Title: Use SequenceEqual instead of equality operator, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0104, Title: Do not create a type with a name from the BCL, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0105, Title: Use the lambda parameters instead of using a closure, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0106, Title: Avoid closure by using an overload with the 'factoryArgument' parameter, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0107, Title: Do not use culture-sensitive object.ToString, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0108, Title: Remove redundant argument value, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0109, Title: Consider adding an overload with a Span<T> or Memory<T>, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0110, Title: Use the Regex source generator, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0111, Title: Use string.Create instead of FormattableString, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0112, Title: Use 'Count > 0' instead of 'Any()', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0113, Title: Use DateTime.UnixEpoch, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0114, Title: Use DateTimeOffset.UnixEpoch, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0115, Title: Unknown component parameter, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0116, Title: 'Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0117, Title: 'Parameters with [EditorRequired] attributes should also be marked as [Parameter]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0118, Title: '[JSInvokable] methods must be public', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0119, Title: JSRuntime must not be used in OnInitialized or OnInitializedAsync, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0120, Title: Use InvokeVoidAsync when the returned value is not used, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0121, Title: Do not overwrite parameter value, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0122, Title: 'Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)', Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0123, Title: Sequence number must be a constant, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0124, Title: Log parameter type is not valid, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0125, Title: The list of log parameter types contains an invalid type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0126, Title: The list of log parameter types contains a duplicate, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0127, Title: Use String.Equals instead of is pattern, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0128, Title: Use 'is' operator instead of SequenceEqual, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0129, Title: Await task in using statement, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0130, Title: GetType() should not be used on System.Type instances, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0131, Title: ArgumentNullException.ThrowIfNull should not be used with non-nullable types, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0132, Title: Do not convert implicitly to DateTimeOffset, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0133, Title: Use DateTimeOffset instead of relying on the implicit conversion, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0134, Title: Observe result of async calls, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0135, Title: The log parameter has no configured type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0136, Title: Raw String contains an implicit end of line character, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: MA0137, Title: Use 'Async' suffix when a method returns an awaitable type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0138, Title: Do not use 'Async' suffix when a method does not return an awaitable type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0139, Title: Log parameter type is not valid, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0140, Title: Both if and else branch have identical code, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0141, Title: Use pattern matching instead of inequality operators for null check, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0142, Title: Use pattern matching instead of equality operators for null check, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0143, Title: Primary constructor parameters should be readonly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0144, Title: Use System.OperatingSystem to check the current OS, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0145, Title: 'Signature for [UnsafeAccessorAttribute] method is not valid', Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0146, Title: Name must be set explicitly on local functions, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0147, Title: Avoid async void method for delegate, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0148, Title: Use pattern matching instead of equality operators for discrete value, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0149, Title: Use pattern matching instead of inequality operators for discrete value, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0150, Title: Do not call the default object.ToString explicitly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0151, Title: DebuggerDisplay must contain valid members, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0152, Title: Use Unwrap instead of using await twice, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0153, Title: Do not log symbols decorated with DataClassificationAttribute directly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0154, Title: Use langword in XML comment, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0155, Title: Do not use async void methods, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0156, Title: Use 'Async' suffix when a method returns IAsyncEnumerable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0157, Title: Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0158, Title: Use System.Threading.Lock, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0159, Title: Use 'Order' instead of 'OrderBy', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0160, Title: Use ContainsKey instead of TryGetValue, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: POLYSP0003, Title: Unsupported C# language version, Category: Microsoft.CodeAnalysis.CSharp.CSharpParseOptions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1001, Title: Add braces (when expression spans over multiple lines), Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1002, Title: Remove braces, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1002FadeOut, Title: Remove braces, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1003, Title: Add braces to if-else (when expression spans over multiple lines), Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1004, Title: Remove braces from if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1004FadeOut, Title: Remove braces from if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1005, Title: Simplify nested using statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1005FadeOut, Title: Simplify nested using statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1006, Title: Merge 'else' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1006FadeOut, Title: Merge 'else' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1007, Title: Add braces, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1008, Title: "[deprecated] Use explicit type instead of 'var' (when the type is not obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1009, Title: "[deprecated] Use explicit type instead of 'var' (foreach variable)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1010, Title: "[deprecated] Use 'var' instead of explicit type (when the type is obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1012, Title: "[deprecated] Use explicit type instead of 'var' (when the type is obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1013, Title: Use predefined type, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1014, Title: Use explicitly/implicitly typed array, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1015, Title: Use nameof operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1015FadeOut, Title: Use nameof operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1016, Title: Use block body or expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1018, Title: Add/remove accessibility modifiers, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1019, Title: Order modifiers, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1020, Title: 'Simplify Nullable<T> to T?', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1021, Title: Convert lambda expression body to expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1021FadeOut, Title: Convert lambda expression body to expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1031, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1031FadeOut, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1032, Title: Remove redundant parentheses, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1032FadeOut, Title: Remove redundant parentheses, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1033, Title: Remove redundant boolean literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1034, Title: Remove redundant 'sealed' modifier, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1035, Title: '[deprecated] Remove redundant comma in initializer', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1036, Title: Remove unnecessary blank line, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1037, Title: Remove trailing white-space, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1038, Title: '[deprecated] Remove empty statement', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1039, Title: Remove argument list from attribute, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1040, Title: "[deprecated] Remove empty 'else' clause", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1041, Title: '[deprecated] Remove empty initializer', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1042, Title: Remove enum default underlying type, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1043, Title: Remove 'partial' modifier from type with a single part, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1044, Title: Remove original exception from throw statement, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1046, Title: Asynchronous method name should end with 'Async', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1047, Title: Non-asynchronous method name should not end with 'Async', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1047FadeOut, Title: Non-asynchronous method name should not end with 'Async', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1048, Title: Use lambda expression instead of anonymous method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1048FadeOut, Title: Use lambda expression instead of anonymous method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1049, Title: Simplify boolean comparison, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1049FadeOut, Title: Simplify boolean comparison, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1050, Title: Include/omit parentheses when creating new object, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1051, Title: Add/remove parentheses from condition in conditional operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1052, Title: Declare each attribute separately, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1055, Title: Unnecessary semicolon at the end of declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1056, Title: Avoid usage of using alias directive, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1058, Title: Use compound assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1058FadeOut, Title: Use compound assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1059, Title: Avoid locking on publicly accessible instance, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1060, Title: Declare each type in separate file, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1061, Title: Merge 'if' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1061FadeOut, Title: Merge 'if' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1063, Title: '[deprecated] Avoid usage of do statement to create an infinite loop', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1064, Title: '[deprecated] Avoid usage of for statement to create an infinite loop', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1065, Title: '[deprecated] Avoid usage of while statement to create an infinite loop', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1066, Title: "[deprecated] Remove empty 'finally' clause", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1066FadeOut, Title: "[deprecated] Remove empty 'finally' clause", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1068, Title: Simplify logical negation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1069, Title: Remove unnecessary case label, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1070, Title: Remove redundant default switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1071, Title: Remove redundant base constructor call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1072, Title: '[deprecated] Remove empty namespace declaration', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1073, Title: Convert 'if' to 'return' statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1073FadeOut, Title: Convert 'if' to 'return' statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1074, Title: Remove redundant constructor, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1075, Title: Avoid empty catch clause that catches System.Exception, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1077, Title: Optimize LINQ method call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1078, Title: Use "" or 'string.Empty', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1079, Title: Throwing of new NotImplementedException, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1080, Title: Use 'Count/Length' property instead of 'Any' method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1081, Title: Split variable declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1084, Title: Use coalesce expression instead of conditional expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1085, Title: Use auto-implemented property, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1085FadeOut, Title: Use auto-implemented property, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1089, Title: Use --/++ operator instead of assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1089FadeOut, Title: Use --/++ operator instead of assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1090, Title: Add/remove 'ConfigureAwait(false)' call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1091, Title: '[deprecated] Remove empty region', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1091FadeOut, Title: '[deprecated] Remove empty region', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1093, Title: File contains no code, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1094, Title: Declare using directive on top level, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1096, Title: Use 'HasFlag' method or bitwise operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1097, Title: Remove redundant 'ToString' call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1098, Title: Constant values should be placed on right side of comparisons, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1099, Title: Default label should be the last label in a switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1100, Title: '[deprecated] Format documentation summary on a single line', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1101, Title: '[deprecated] Format documentation summary on multiple lines', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1102, Title: Make class static, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1103, Title: Convert 'if' to assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1104, Title: Simplify conditional expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1105, Title: Unnecessary interpolation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1106, Title: '[deprecated] Remove empty destructor', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1107, Title: Remove redundant 'ToCharArray' call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1108, Title: Add 'static' modifier to all partial class declarations, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1110, Title: Declare type inside namespace, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1111, Title: Add braces to switch section with multiple statements, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1112, Title: Combine 'Enumerable.Where' method chain, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1112FadeOut, Title: Combine 'Enumerable.Where' method chain, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1113, Title: Use 'string.IsNullOrEmpty' method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1114, Title: Remove redundant delegate creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1114FadeOut, Title: Remove redundant delegate creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1118, Title: Mark local variable as const, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1123, Title: Add parentheses when necessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1124, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1124FadeOut, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1126, Title: Add braces to if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1128, Title: Use coalesce expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1129, Title: Remove redundant field initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1130, Title: Bitwise operation on enum without Flags attribute, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1132, Title: Remove redundant overriding member, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1133, Title: Remove redundant Dispose/Close call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1134, Title: Remove redundant statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1135, Title: Declare enum member with zero value (when enum has FlagsAttribute), Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1136, Title: Merge switch sections with equivalent content, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1138, Title: Add summary to documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1139, Title: Add summary element to documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1140, Title: Add exception to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1141, Title: Add 'param' element to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1142, Title: Add 'typeparam' element to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1143, Title: Simplify coalesce expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1145, Title: Remove redundant 'as' operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1146, Title: Use conditional access, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1151, Title: Remove redundant cast, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1154, Title: Sort enum members, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1155, Title: Use StringComparison when comparing strings, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1156, Title: Use string.Length instead of comparison with empty string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1157, Title: Composite enum value contains undefined flag, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1158, Title: Static member in generic type should use a type parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1159, Title: Use EventHandler<T>, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1160, Title: Abstract type should not have public constructors, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1161, Title: Enum should declare explicit values, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1162, Title: Avoid chain of assignments, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1163, Title: Unused parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1164, Title: Unused type parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1165, Title: Unconstrained type parameter checked for null, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1166, Title: Value type object is never equal to null, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1168, Title: Parameter name differs from base name, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1169, Title: Make field read-only, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1170, Title: Use read-only auto-implemented property, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1171, Title: Simplify lazy initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1172, Title: Use 'is' operator instead of 'as' operator, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1173, Title: Use coalesce expression instead of 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1174, Title: Remove redundant async/await, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1174FadeOut, Title: Remove redundant async/await, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1175, Title: Unused 'this' parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1176, Title: "[deprecated] Use 'var' instead of explicit type (when the type is not obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1177, Title: "[deprecated] Use 'var' instead of explicit type (in foreach)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1179, Title: Unnecessary assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1180, Title: Inline lazy initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1181, Title: Convert comment to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1182, Title: Remove redundant base interface, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1186, Title: Use Regex instance instead of static method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1187, Title: Use constant instead of field, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1188, Title: Remove redundant auto-property initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1189, Title: Add or remove region name, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1190, Title: Join string expressions, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1191, Title: Declare enum value as combination of names, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1192, Title: Unnecessary usage of verbatim string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1193, Title: Overriding member should not change 'params' modifier, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1194, Title: Implement exception constructors, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1195, Title: Use ^ operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1196, Title: Call extension method as instance method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1197, Title: Optimize StringBuilder.Append/AppendLine call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1198, Title: Avoid unnecessary boxing of value type, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1199, Title: Unnecessary null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1200, Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1201, Title: Use method chaining, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1202, Title: Avoid NullReferenceException, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1203, Title: Use AttributeUsageAttribute, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1204, Title: Use EventArgs.Empty, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1205, Title: Order named arguments according to the order of parameters, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1206, Title: Use conditional access instead of conditional expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1207, Title: Use anonymous function or method group, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1208, Title: Reduce 'if' nesting, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1209, Title: Order type parameter constraints, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1210, Title: Return completed task instead of returning null, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1211, Title: Remove unnecessary 'else', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1212, Title: Remove redundant assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1212FadeOut, Title: Remove redundant assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1213, Title: Remove unused member declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1214, Title: Unnecessary interpolated string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1214FadeOut, Title: Unnecessary interpolated string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1215, Title: Expression is always equal to true/false, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1216, Title: Unnecessary unsafe context, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1217, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1217FadeOut, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1218, Title: Simplify code branching, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1220, Title: Use pattern matching instead of combination of 'is' operator and cast operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1221, Title: Use pattern matching instead of combination of 'as' operator and null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1222, Title: Merge preprocessor directives, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1223, Title: Mark publicly visible type with DebuggerDisplay attribute, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1224, Title: Make method an extension method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1225, Title: Make class sealed, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1226, Title: Add paragraph to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1227, Title: Validate arguments correctly, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1228, Title: Unused element in a documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1229, Title: Use async/await when necessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1230, Title: Unnecessary explicit use of enumerator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1231, Title: Make parameter ref read-only, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1232, Title: Order elements in documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1233, Title: Use short-circuiting operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1234, Title: Duplicate enum value, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1235, Title: Optimize method call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1236, Title: Use exception filter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1237, Title: '[deprecated] Use bit shift operator', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1238, Title: 'Avoid nested ?: operators', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1239, Title: Use 'for' statement instead of 'while' statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1240, Title: Operator is unnecessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1241, Title: Implement non-generic counterpart, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1242, Title: Do not pass non-read-only struct by read-only reference, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1243, Title: Duplicate word in a comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1244, Title: Simplify 'default' expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1246, Title: Use element access, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1247, Title: Fix documentation comment tag, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1248, Title: Normalize null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1249, Title: Unnecessary null-forgiving operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1250, Title: Use implicit/explicit object creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1251, Title: Remove unnecessary braces from record declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1252, Title: Normalize usage of infinite loop, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1253, Title: Format documentation comment summary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1254, Title: Normalize format of enum flag value, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1255, Title: Simplify argument null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1256, Title: Invalid argument null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1257, Title: Use enum field explicitly, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1258, Title: Unnecessary enum flag, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1259, Title: Remove empty syntax, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1260, Title: Add/remove trailing comma, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1261, Title: Resource can be disposed asynchronously, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1262, Title: Unnecessary raw string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1263, Title: Invalid reference in a documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1264, Title: Use 'var' or explicit type, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1265, Title: Remove redundant catch block, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1266, Title: Use raw string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1267, Title: Use string interpolation instead of 'string.Concat', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1268, Title: Simplify numeric comparison, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RemoveUnnecessaryImportsFixable, Title: '', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: ROS0002, Title: Analyzer option is obsolete, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: ROS0003, Title: Analyzer requires config option to be specified, Category: '', DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RS1001, Title: Missing diagnostic analyzer attribute, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1002, Title: Missing kind argument when registering an analyzer action, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1003, Title: Unsupported SymbolKind argument when registering a symbol analyzer action, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1004, Title: Recommend adding language support to diagnostic analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1005, Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1006, Title: Invalid type argument for DiagnosticAnalyzer's Register method, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1007, Title: Provide localizable arguments to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisLocalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1008, Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1009, Title: Only internal implementations of this interface are allowed, Category: MicrosoftCodeAnalysisCompatibility, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1010, Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1011, Title: Use code actions that have a unique EquivalenceKey for FixAll occurrences support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1012, Title: Start action has no registered actions, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1013, Title: Start action has no registered non-end actions, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1014, Title: Do not ignore values returned by methods on immutable objects, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1015, Title: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisDocumentation, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1016, Title: Code fix providers should provide FixAll support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1017, Title: DiagnosticId for analyzers must be a non-null constant, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1018, Title: DiagnosticId for analyzers must be in specified format, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1019, Title: DiagnosticId must be unique across analyzers, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1020, Title: Category for analyzers must be from the specified values, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1021, Title: Invalid entry in analyzer category and diagnostic ID range specification file, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1022, Title: Do not use types from Workspaces assembly in an analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1023, Title: Upgrade MSBuildWorkspace, Category: Library, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1024, Title: Symbols should be compared for equality, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1025, Title: Configure generated code analysis, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1026, Title: Enable concurrent execution, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1027, Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1028, Title: Provide non-null 'customTags' value to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisDocumentation, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1029, Title: Do not use reserved diagnostic IDs, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1030, Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1031, Title: Define diagnostic title correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1032, Title: Define diagnostic message correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1033, Title: Define diagnostic description correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1034, Title: Prefer 'IsKind' for checking syntax kinds, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1035, Title: Do not use APIs banned for analyzers, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1036, Title: Specify analyzer banned API enforcement setting, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1037, Title: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2000, Title: Add analyzer diagnostic IDs to analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2001, Title: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2002, Title: Do not add removed analyzer diagnostic IDs to unshipped analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2003, Title: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2004, Title: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2005, Title: Remove duplicate entries for diagnostic ID in the same analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2006, Title: Remove duplicate entries for diagnostic ID between analyzer releases, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2007, Title: Invalid entry in analyzer release file, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2008, Title: Enable analyzer release tracking, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S100, Title: Methods and properties should be named in PascalCase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S1006, Title: Method overrides should not change parameter defaults, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S101, Title: Types should be named in PascalCase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S103, Title: Lines should not be too long, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S104, Title: Files should not have too many lines of code, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1048, Title: Finalizers should not throw exceptions, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S105, Title: Tabulation characters should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S106, Title: Standard outputs should not be used directly to log anything, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1066, Title: Mergeable "if" statements should be combined, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1067, Title: Expressions should not be too complex, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S107, Title: Methods should not have too many parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1075, Title: URIs should not be hardcoded, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S108, Title: Nested blocks of code should not be left empty, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S109, Title: Magic numbers should not be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S110, Title: Inheritance tree of classes should not be too deep, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1104, Title: Fields should not have public accessibility, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1109, Title: A close curly brace should be located at the beginning of a line, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1110, Title: Redundant pairs of parentheses should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1116, Title: Empty statements should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1117, Title: Local variables should not shadow class fields or properties, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1118, Title: Utility classes should not have public constructors, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S112, Title: General or reserved exceptions should never be thrown, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1121, Title: Assignments should not be made from within sub-expressions, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1123, Title: '"Obsolete" attributes should include explanations', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1125, Title: Boolean literals should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1128, Title: Unnecessary "using" should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S113, Title: Files should end with a newline, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1133, Title: Deprecated code should be removed, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1134, Title: Track uses of "FIXME" tags, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1135, Title: Track uses of "TODO" tags, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: S1144, Title: Unused private types or members should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1147, Title: Exit methods should not be called, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1151, Title: '"switch case" clauses should not have too many lines of code', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1155, Title: '"Any()" should be used to test for emptiness', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1163, Title: Exceptions should not be thrown in finally blocks, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1168, Title: Empty arrays and collections should be returned instead of null, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1172, Title: Unused method parameters should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1185, Title: Overriding members should do more than simply call the same member in the base class, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1186, Title: Methods should not be empty, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1192, Title: String literals should not be duplicated, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1199, Title: Nested code blocks should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1200, Title: Classes should not be coupled to too many other classes, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1206, Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S121, Title: Control structures should use curly braces, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1210, Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1215, Title: '"GC.Collect" should not be called', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S122, Title: Statements should be on separate lines, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1226, Title: "Method parameters, caught exceptions and foreach variables' initial values should not be ignored", Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1227, Title: break statements should not be used except for switch cases, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1244, Title: Floating point numbers should not be tested for equality, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S125, Title: Sections of code should not be commented out, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S126, Title: '"if ... else if" constructs should end with "else" clauses', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1264, Title: A "while" loop should be used instead of a "for" loop, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S127, Title: '"for" loop stop conditions should be invariant', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1301, Title: '"switch" statements should have at least 3 "case" clauses', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1309, Title: Track uses of in-source issue suppressions, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S131, Title: '"switch/Select" statements should contain a "default/Case Else" clauses', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1312, Title: Logger fields should be "private static readonly", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1313, Title: Using hardcoded IP addresses is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S134, Title: 'Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S138, Title: Functions should not have too many lines of code, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1449, Title: Culture should be specified for "string" operations, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1450, Title: Private fields only used as local variables in methods should become local variables, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1451, Title: Track lack of copyright and license headers, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1479, Title: '"switch" statements with many "case" clauses should have only one statement', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1481, Title: Unused local variables should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1541, Title: Methods and properties should not be too complex, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1607, Title: Tests should not be ignored, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1643, Title: Strings should not be concatenated using '+' in a loop, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1656, Title: Variables should not be self-assigned, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1659, Title: Multiple variables should not be declared on the same line, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1694, Title: An abstract class should have both abstract and concrete methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1696, Title: NullReferenceException should not be caught, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1698, Title: '"==" should not be used when "Equals" is overridden', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1699, Title: Constructors should only call non-overridable methods, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1751, Title: Loops with at most one iteration should be refactored, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1764, Title: Identical expressions should not be used on both sides of operators, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1821, Title: '"switch" statements should not be nested', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1848, Title: Objects should not be created to be dropped immediately without being used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1854, Title: Unused assignments should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1858, Title: '"ToString()" calls should not be redundant', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1862, Title: Related "if/else if" statements should not have the same condition, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1871, Title: Two branches in a conditional structure should not have exactly the same implementation, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1905, Title: Redundant casts should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1939, Title: Inheritance list should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1940, Title: Boolean checks should not be inverted, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1944, Title: Invalid casts should be avoided, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1994, Title: "\"for\" loop increment clauses should modify the loops' counters", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2053, Title: Password hashing functions should use an unpredictable salt, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2068, Title: Hard-coded credentials are security-sensitive, Category: Blocker Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2077, Title: Formatting SQL queries is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2092, Title: Creating cookies without the "secure" flag is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2094, Title: Classes should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2114, Title: Collections should not be passed as arguments to their own methods, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2115, Title: A secure password should be used when connecting to a database, Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2123, Title: Values should not be uselessly incremented, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2139, Title: Exceptions should be either logged or rethrown but not both, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2148, Title: Underscores should be used to make large numbers readable, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2156, Title: '"sealed" classes should not have "protected" members', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2166, Title: Classes named like "Exception" should extend "Exception" or a subclass, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2178, Title: Short-circuit logic should be used in boolean contexts, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2183, Title: Integral numbers should not be shifted by zero or more than their number of bits-1, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2184, Title: Results of integer division should not be assigned to floating point variables, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2187, Title: Test classes should contain at least one test case, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2190, Title: Loops and recursions should not be infinite, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2197, Title: Modulus results should not be checked for direct equality, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2198, Title: Unnecessary mathematical comparisons should not be made, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2201, Title: Methods without side effects should not have their return values ignored, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2219, Title: Runtime type checking should be simplified, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2221, Title: '"Exception" should not be caught', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2222, Title: Locks should be released on all paths, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2223, Title: Non-constant static fields should not be visible, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2225, Title: '"ToString()" method should not return null', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2234, Title: Arguments should be passed in the same order as the method parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2245, Title: Using pseudorandom number generators (PRNGs) is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2251, Title: A "for" loop update clause should move the counter in the right direction, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2252, Title: For-loop conditions should be true at least once, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2257, Title: Using non-standard cryptographic algorithms is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2259, Title: Null pointers should not be dereferenced, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2275, Title: Composite format strings should not lead to unexpected behavior at runtime, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2290, Title: Field-like events should not be virtual, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2291, Title: Overflow checking should not be disabled for "Enumerable.Sum", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2292, Title: Trivial properties should be auto-implemented, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2302, Title: '"nameof" should be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2306, Title: '"async" and "await" should not be used as identifiers', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2325, Title: Methods and properties that don't access instance data should be static, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2326, Title: Unused type parameters should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2327, Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2328, Title: '"GetHashCode" should not reference mutable fields', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2330, Title: Array covariance should not be used, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2333, Title: Redundant modifiers should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2339, Title: Public constant members should not be used, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2342, Title: Enumeration types should comply with a naming convention, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2344, Title: Enumeration type names should not have "Flags" or "Enum" suffixes, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2345, Title: Flags enumerations should explicitly initialize all their members, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2346, Title: Flags enumerations zero-value members should be named "None", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2357, Title: Fields should be private, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2360, Title: Optional parameters should not be used, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2365, Title: Properties should not make collection or array copies, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2368, Title: Public methods should not have multidimensional array parameters, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2372, Title: Exceptions should not be thrown from property getters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2376, Title: Write-only properties should not be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2386, Title: Mutable fields should not be "public static", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2387, Title: Child class fields should not shadow parent class fields, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2436, Title: Types and methods should not have too many generic parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2437, Title: Unnecessary bit operations should not be performed, Category: Blocker Code Smell, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: S2445, Title: Blocks should be synchronized on read-only fields, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2479, Title: Whitespace and control characters in string literals should be explicit, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2486, Title: Generic exceptions should not be ignored, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2551, Title: Shared resources should not be used for locking, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2583, Title: Conditionally executed code should be reachable, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2589, Title: Boolean expressions should not be gratuitous, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2612, Title: Setting loose file permissions is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2629, Title: Logging templates should be constant, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2674, Title: The length returned from a stream read should be checked, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2681, Title: Multiline blocks should be enclosed in curly braces, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2688, Title: '"NaN" should not be used in comparisons', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2692, Title: '"IndexOf" checks should not be for positive numbers', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2696, Title: Instance members should not write to "static" fields, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2699, Title: Tests should include assertions, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2701, Title: Literal boolean values should not be used in assertions, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2737, Title: '"catch" clauses should do more than rethrow', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2743, Title: Static fields should not be used in generic types, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2755, Title: XML parsers should not be vulnerable to XXE attacks, Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2757, Title: Non-existent operators like "=+" should not be used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2760, Title: Sequential tests should not check the same condition, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2761, Title: Doubled prefix operators "!!" and "~~" should not be used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2857, Title: SQL keywords should be delimited by whitespace, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2925, Title: '"Thread.Sleep" should not be used in tests', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2930, Title: '"IDisposables" should be disposed', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2931, Title: Classes with "IDisposable" members should implement "IDisposable", Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2933, Title: Fields that are only assigned in the constructor should be "readonly", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2934, Title: Property assignments should not be made for "readonly" fields not constrained to reference types, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2952, Title: Classes should "Dispose" of members from the classes' own "Dispose" methods, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2953, Title: Methods named "Dispose" should implement "IDisposable.Dispose", Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2955, Title: Generic parameters not constrained to reference types should not be compared to "null", Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2970, Title: Assertions should be complete, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2971, Title: LINQ expressions should be simplified, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2995, Title: '"Object.ReferenceEquals" should not be used for value types', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2996, Title: '"ThreadStatic" fields should not be initialized', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2997, Title: '"IDisposables" created in a "using" statement should not be returned', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3005, Title: '"ThreadStatic" should not be used on non-static fields', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3010, Title: Static fields should not be updated in constructors, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3011, Title: 'Reflection should not be used to increase accessibility of classes, methods, or fields', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3052, Title: Members should not be initialized to default values, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3059, Title: Types should not have members with visibility set higher than the type's visibility, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3060, Title: '"is" should not be used with "this"', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3063, Title: '"StringBuilder" data should be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3168, Title: '"async" methods should not return "void"', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3169, Title: Multiple "OrderBy" calls should not be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3172, Title: Delegates should not be subtracted, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3215, Title: '"interface" instances should not be cast to concrete types', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3216, Title: '"ConfigureAwait(false)" should be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3217, Title: '"Explicit" conversions of "foreach" loops should not be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3218, Title: Inner class members should not shadow outer class "static" or type members, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3220, Title: Method calls should not resolve ambiguously to overloads with "params", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3234, Title: '"GC.SuppressFinalize" should not be invoked for types without destructors', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3235, Title: Redundant parentheses should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3236, Title: Caller information arguments should not be provided explicitly, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3237, Title: '"value" contextual keyword should be used', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3240, Title: The simplest possible condition syntax should be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3241, Title: Methods should not return values that are never used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3242, Title: Method parameters should be declared with base types, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3244, Title: Anonymous delegates should not be used to unsubscribe from Events, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3246, Title: Generic type parameters should be co/contravariant when possible, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3247, Title: Duplicate casts should not be made, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3249, Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals", Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3251, Title: Implementations should be provided for "partial" methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3253, Title: Constructor and destructor declarations should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3254, Title: Default parameter values should not be passed as arguments, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3256, Title: '"string.IsNullOrEmpty" should be used', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3257, Title: Declarations and initializations should be as concise as possible, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3260, Title: Non-derived "private" classes and records should be "sealed", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3261, Title: Namespaces should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3262, Title: '"params" should be used on overrides', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3263, Title: 'Static fields should appear in the order they must be initialized ', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3264, Title: Events should be invoked, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3265, Title: Non-flags enums should not be used in bitwise operations, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3267, Title: Loops should be simplified with "LINQ" expressions, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3329, Title: Cipher Block Chaining IVs should be unpredictable, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3330, Title: Creating cookies without the "HttpOnly" flag is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3343, Title: Caller information parameters should come at the end of the parameter list, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3346, Title: Expressions used in "Debug.Assert" should not produce side effects, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3353, Title: Unchanged variables should be marked as "const", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3358, Title: Ternary operators should not be nested, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3363, Title: Date and time should not be used as a type for primary keys, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3366, Title: '"this" should not be exposed from constructors', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3376, Title: 'Attribute, EventArgs, and Exception type names should end with the type being extended', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3397, Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3398, Title: '"private" methods called only by inner classes should be moved to those classes', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3400, Title: Methods should not return constants, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3415, Title: Assertion arguments should be passed in the correct order, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3416, Title: Loggers should be named for their enclosing types, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3427, Title: Method overloads with default parameter values should not overlap, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3431, Title: '"[ExpectedException]" should not be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3433, Title: Test method signatures should be correct, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3440, Title: Variables should not be checked against the values they're about to be assigned, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3441, Title: Redundant property names should be omitted in anonymous classes, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3442, Title: '"abstract" classes should not have "public" constructors', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3443, Title: Type should not be examined on "System.Type" instances, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3444, Title: Interfaces should not simply inherit from base interfaces with colliding members, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3445, Title: Exceptions should not be explicitly rethrown, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3447, Title: '"[Optional]" should not be used on "ref" or "out" parameters', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3449, Title: Right operands of shift operators should be integers, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3450, Title: 'Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3451, Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3453, Title: Classes should not have only "private" constructors, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3456, Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3457, Title: Composite format strings should be used correctly, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3458, Title: Empty "case" clauses that fall through to the "default" should be omitted, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3459, Title: Unassigned members should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3464, Title: Type inheritance should not be recursive, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3466, Title: Optional parameters should be passed to "base" calls, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3532, Title: Empty "default" clauses should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3597, Title: '"ServiceContract" and "OperationContract" attributes should be used together', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3598, Title: One-way "OperationContract" methods should have "void" return type, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3600, Title: '"params" should not be introduced on overrides', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3603, Title: 'Methods with "Pure" attribute should return a value ', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3604, Title: Member initializer values should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3610, Title: Nullable type comparison should not be redundant, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3626, Title: Jump statements should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3655, Title: Empty nullable value should not be accessed, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3717, Title: Track use of "NotImplementedException", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3776, Title: Cognitive Complexity of methods should not be too high, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3869, Title: '"SafeHandle.DangerousGetHandle" should not be called', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3871, Title: Exception types should be "public", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3872, Title: Parameter names should not duplicate the names of their methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3874, Title: '"out" and "ref" parameters should not be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3875, Title: '"operator==" should not be overloaded on reference types', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3876, Title: Strings or integral types should be used for indexers, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3877, Title: Exceptions should not be thrown from unexpected methods, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3878, Title: Arrays should not be created for params parameters, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3880, Title: Finalizers should not be empty, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3881, Title: '"IDisposable" should be implemented correctly', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3884, Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used', Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3885, Title: '"Assembly.Load" should be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3887, Title: 'Mutable, non-private fields should not be "readonly"', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3889, Title: '"Thread.Resume" and "Thread.Suspend" should not be used', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3897, Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3898, Title: Value types should implement "IEquatable<T>", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3900, Title: Arguments of public methods should be validated against null, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S3902, Title: '"Assembly.GetExecutingAssembly" should not be called', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3903, Title: Types should be defined in named namespaces, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3904, Title: Assemblies should have version information, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3906, Title: Event Handlers should have the correct signature, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3908, Title: Generic event handlers should be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3909, Title: Collections should implement the generic interface, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3923, Title: All branches in a conditional structure should not have exactly the same implementation, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3925, Title: '"ISerializable" should be implemented correctly', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3926, Title: Deserialization methods should be provided for "OptionalField" members, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3927, Title: Serialization event handlers should be implemented correctly, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3928, Title: 'Parameter names used into ArgumentException constructors should match an existing one ', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3937, Title: Number patterns should be regular, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3949, Title: Calculations should not overflow, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3956, Title: '"Generic.List" instances should not be part of public APIs', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3962, Title: '"static readonly" constants should be "const" instead', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3963, Title: '"static" fields should be initialized inline', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3966, Title: Objects should not be disposed more than once, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3967, Title: Multidimensional arrays should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3971, Title: '"GC.SuppressFinalize" should not be called', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3972, Title: Conditionals should start on new lines, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3973, Title: A conditionally executed single line should be denoted by indentation, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3981, Title: Collection sizes and array length comparisons should make sense, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3984, Title: Exceptions should not be created without being thrown, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3990, Title: Assemblies should be marked as CLS compliant, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3992, Title: Assemblies should explicitly specify COM visibility, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3993, Title: Custom attributes should be marked with "System.AttributeUsageAttribute", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3994, Title: URI Parameters should not be strings, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3995, Title: URI return values should not be strings, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3996, Title: URI properties should not be strings, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3997, Title: String URI overloads should call "System.Uri" overloads, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3998, Title: Threads should not lock on objects with weak identity, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4000, Title: Pointers to unmanaged memory should not be visible, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4002, Title: Disposable types should declare finalizers, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4004, Title: Collection properties should be readonly, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4005, Title: '"System.Uri" arguments should be used instead of strings', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4015, Title: Inherited member visibility should not be decreased, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4016, Title: Enumeration members should not be named "Reserved", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4017, Title: Method signatures should not contain nested generic types, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4018, Title: All type parameters should be used in the parameter list to enable type inference, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4019, Title: Base class methods should not be hidden, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4022, Title: Enumerations should have "Int32" storage, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4023, Title: Interfaces should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4025, Title: Child class fields should not differ from parent class fields only by capitalization, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4026, Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4027, Title: Exceptions should provide standard constructors, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4035, Title: Classes implementing "IEquatable<T>" should be sealed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4036, Title: Searching OS commands in PATH is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4039, Title: Interface methods should be callable by derived types, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4040, Title: Strings should be normalized to uppercase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4041, Title: Type names should not match namespaces, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4047, Title: Generics should be used when appropriate, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4049, Title: Properties should be preferred, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4050, Title: Operators should be overloaded consistently, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4052, Title: Types should not extend outdated base types, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4055, Title: Literals should not be passed as localized parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4056, Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4057, Title: Locales should be set for data types, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4058, Title: Overloads with a "StringComparison" parameter should be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4059, Title: Property names should not match get methods, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4060, Title: Non-abstract attributes should be sealed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4061, Title: '"params" should be used instead of "varargs"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4069, Title: Operator overloads should have named alternatives, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4070, Title: Non-flags enums should not be marked with "FlagsAttribute", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4136, Title: Method overloads should be grouped together, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4143, Title: Collection elements should not be replaced unconditionally, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4144, Title: Methods should not have identical implementations, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4158, Title: Empty collections should not be accessed or iterated, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4159, Title: Classes should implement their "ExportAttribute" interfaces, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4200, Title: Native methods should be wrapped, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4201, Title: Null checks should not be combined with "is" operator checks, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4210, Title: Windows Forms entry points should be marked with STAThread, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4211, Title: Members should not have conflicting transparency annotations, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4212, Title: Serialization constructors should be secured, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4214, Title: '"P/Invoke" methods should not be visible', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4220, Title: Events should have proper arguments, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4225, Title: Extension methods should not extend "object", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4226, Title: Extensions should be in separate namespaces, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4260, Title: '"ConstructorArgument" parameters should exist in constructors', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4261, Title: Methods should be named according to their synchronicities, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4275, Title: Getters and setters should access the expected fields, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4277, Title: '"Shared" parts should not be created with "new"', Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4347, Title: Secure random number generators should not output predictable values, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4423, Title: Weak SSL/TLS protocols should not be used, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4426, Title: Cryptographic keys should be robust, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4428, Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4433, Title: LDAP connections should be authenticated, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4456, Title: Parameter validation in yielding methods should be wrapped, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4457, Title: Parameter validation in "async"/"await" methods should be wrapped, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4462, Title: Calls to "async" methods should not be blocking, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4487, Title: Unread "private" fields should be removed, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4502, Title: Disabling CSRF protections is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4507, Title: Delivering code in production with debug features activated is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4524, Title: '"default" clauses should be first or last', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4545, Title: '"DebuggerDisplayAttribute" strings should reference existing members', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4581, Title: '"new Guid()" should not be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4583, Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke", Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4586, Title: Non-async "Task/Task<T>" methods should not return null, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4635, Title: Start index should be used instead of calling Substring, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4663, Title: Comments should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4790, Title: Using weak hashing algorithms is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4792, Title: Configuring loggers is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4830, Title: Server certificates should be verified during SSL/TLS connections, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5034, Title: '"ValueTask" should be consumed correctly', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5042, Title: Expanding archive files without controlling resource consumption is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5122, Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5332, Title: Using clear-text protocols is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5344, Title: Passwords should not be stored in plaintext or with a fast hashing algorithm, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5443, Title: Using publicly writable directories is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5445, Title: Insecure temporary file creation methods should not be used, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5542, Title: Encryption algorithms should be used with secure mode and padding scheme, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5547, Title: Cipher algorithms should be robust, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5659, Title: JWT should be signed and verified with strong cipher algorithms, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5693, Title: Allowing requests with excessive content length is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5753, Title: Disabling ASP.NET "Request Validation" feature is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5766, Title: Deserializing objects without performing data validation is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5773, Title: Types allowed to be deserialized should be restricted, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5856, Title: Regular expressions should be syntactically valid, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6354, Title: Use a testable date/time provider, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6377, Title: XML signatures should be validated securely, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6419, Title: Azure Functions should be stateless, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6420, Title: Client instances should not be recreated on each Azure Function invocation, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6421, Title: Azure Functions should use Structured Error Handling, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6422, Title: Calls to "async" methods should not be blocking in Azure Functions, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6423, Title: Azure Functions should log all failures, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6424, Title: Interfaces for durable entities should satisfy the restrictions, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6444, Title: Not specifying a timeout for regular expressions is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6507, Title: Blocks should not be synchronized on local variables, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S6513, Title: '"ExcludeFromCodeCoverage" attributes should include a justification', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6561, Title: Avoid using "DateTime.Now" for benchmarking or timing operations, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6562, Title: Always set the "DateTimeKind" when creating new "DateTime" instances, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6563, Title: Use UTC when recording DateTime instants, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6566, Title: Use "DateTimeOffset" instead of "DateTime", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6575, Title: Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6580, Title: Use a format provider when parsing date and time, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6585, Title: Don't hardcode the format when turning dates and times to strings, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6588, Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6602, Title: '"Find" method should be used instead of the "FirstOrDefault" extension', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6603, Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6605, Title: Collection-specific "Exists" method should be used instead of the "Any" extension, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6607, Title: The collection should be filtered before sorting by using "Where" before "OrderBy", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6608, Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6609, Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6610, Title: '"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6612, Title: The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6613, Title: '"First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6617, Title: '"Contains" should be used instead of "Any" for simple equality checks', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6618, Title: '"string.Create" should be used instead of "FormattableString"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6640, Title: Using unsafe code blocks is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6664, Title: The code block contains too many logging calls, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6667, Title: Logging in a catch clause should pass the caught exception as a parameter., Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6668, Title: Logging arguments should be passed to the correct parameter, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6669, Title: Logger field or property name should comply with a naming convention, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6670, Title: '"Trace.Write" and "Trace.WriteLine" should not be used', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6672, Title: Generic logger injection should match enclosing type, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6673, Title: Log message template placeholders should be in the right order, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6674, Title: Log message template should be syntactically correct, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6675, Title: '"Trace.WriteLineIf" should not be used with "TraceSwitch" levels', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6677, Title: Message template placeholders should be unique, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6678, Title: Use PascalCase for named placeholders, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6781, Title: JWT secret keys should not be disclosed, Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6797, Title: Blazor query parameter type should be supported, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6798, Title: '[JSInvokable] attribute should only be used on public methods', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6800, Title: Component parameter type should match the route parameter type constraint, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6802, Title: Using lambda expressions in loops should be avoided in Blazor markup section, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6803, Title: Parameters with SupplyParameterFromQuery attribute should be used only in routable components, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S6930, Title: Backslash should be avoided in route templates, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6931, Title: ASP.NET controller actions should not have a route template starting with "/", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6932, Title: Use model binding instead of reading raw request data, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6934, Title: A Route attribute should be added to the controller when a route template is specified at the action level, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6960, Title: Controllers should not have mixed responsibilities, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6961, Title: API Controllers should derive from ControllerBase instead of Controller, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6962, Title: You should pool HTTP connections with HttpClientFactory, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6964, Title: 'Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6965, Title: REST API actions should be annotated with an HTTP verb attribute, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6966, Title: Awaitable method should be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6967, Title: ModelState.IsValid should be called in controller actions, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6968, Title: Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S818, Title: Literal suffixes should be upper case, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S881, Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S907, Title: '"goto" statement should not be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S927, Title: Parameter names should match base declaration and other partial definitions, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S9999-cpd, Title: Copy-paste token calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-log, Title: Log generator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-metadata, Title: File metadata generator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-metrics, Title: Metrics calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-symbolRef, Title: Symbol reference calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-token-type, Title: Token type calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-warning, Title: Analysis Warning generator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: SA0001, Title: XML comment analysis disabled, Category: StyleCop.CSharp.SpecialRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA0002, Title: Invalid settings file, Category: StyleCop.CSharp.SpecialRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1000, Title: Keywords should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1001, Title: Commas should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1002, Title: Semicolons should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1003, Title: Symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1004, Title: Documentation lines should begin with single space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1005, Title: Single line comments should begin with single space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1006, Title: Preprocessor keywords should not be preceded by space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1007, Title: Operator keyword should be followed by space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1008, Title: Opening parenthesis should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1009, Title: Closing parenthesis should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1010, Title: Opening square brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1011, Title: Closing square brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1012, Title: Opening braces should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1013, Title: Closing braces should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1014, Title: Opening generic brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1015, Title: Closing generic brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1016, Title: Opening attribute brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1017, Title: Closing attribute brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1018, Title: Nullable type symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1019, Title: Member access symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1020, Title: Increment decrement symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1021, Title: Negative signs should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1022, Title: Positive signs should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1023, Title: Dereference and access of symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1024, Title: Colons Should Be Spaced Correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1025, Title: Code should not contain multiple whitespace in a row, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1026, Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1027, Title: Use tabs correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1028, Title: Code should not contain trailing whitespace, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1100, Title: Do not prefix calls with base unless local implementation exists, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1101, Title: Prefix local calls with this, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1102, Title: Query clause should follow previous clause, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1103, Title: Query clauses should be on separate lines or all on one line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1104, Title: Query clause should begin on new line when previous clause spans multiple lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1105, Title: Query clauses spanning multiple lines should begin on own line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1106, Title: Code should not contain empty statements, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1107, Title: Code should not contain multiple statements on one line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1108, Title: Block statements should not contain embedded comments, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1109, Title: Block statements should not contain embedded regions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1110, Title: Opening parenthesis or bracket should be on declaration line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1111, Title: Closing parenthesis should be on line of last parameter, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1112, Title: Closing parenthesis should be on line of opening parenthesis, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1113, Title: Comma should be on the same line as previous parameter, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1114, Title: Parameter list should follow declaration, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1115, Title: Parameter should follow comma, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1116, Title: Split parameters should start on line after declaration, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1117, Title: Parameters should be on same line or separate lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1118, Title: Parameter should not span multiple lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1119, Title: Statement should not use unnecessary parenthesis, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1119_p, Title: Statement should not use unnecessary parenthesis, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SA1120, Title: Comments should contain text, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1121, Title: Use built-in type alias, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1122, Title: Use string.Empty for empty strings, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1123, Title: Do not place regions within elements, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1124, Title: Do not use regions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1125, Title: Use shorthand for nullable types, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1126, Title: Prefix calls correctly, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1127, Title: Generic type constraints should be on their own line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1128, Title: Put constructor initializers on their own line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1129, Title: Do not use default value type constructor, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1130, Title: Use lambda syntax, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1131, Title: Use readable conditions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1132, Title: Do not combine fields, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1133, Title: Do not combine attributes, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1134, Title: Attributes should not share line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1135, Title: Using directives should be qualified, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1136, Title: Enum values should be on separate lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1137, Title: Elements should have the same indentation, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1139, Title: Use literal suffix notation instead of casting, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1141, Title: Use tuple syntax, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1142, Title: Refer to tuple fields by name, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1200, Title: Using directives should be placed correctly, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1201, Title: Elements should appear in the correct order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1202, Title: Elements should be ordered by access, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1203, Title: Constants should appear before fields, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1204, Title: Static elements should appear before instance elements, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1205, Title: Partial elements should declare access, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1206, Title: Declaration keywords should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1207, Title: Protected should come before internal, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1208, Title: System using directives should be placed before other using directives, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1209, Title: Using alias directives should be placed after other using directives, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1210, Title: Using directives should be ordered alphabetically by namespace, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1211, Title: Using alias directives should be ordered alphabetically by alias name, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1212, Title: Property accessors should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1213, Title: Event accessors should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1214, Title: Readonly fields should appear before non-readonly fields, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1216, Title: Using static directives should be placed at the correct location, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1217, Title: Using static directives should be ordered alphabetically, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1300, Title: Element should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1301, Title: Element should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1302, Title: Interface names should begin with I, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1303, Title: Const field names should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1304, Title: Non-private readonly fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1305, Title: Field names should not use Hungarian notation, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1306, Title: Field names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1307, Title: Accessible fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1308, Title: Variable names should not be prefixed, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1309, Title: Field names should not begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
+- {Id: SA1310, Title: Field names should not contain underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1311, Title: Static readonly fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1312, Title: Variable names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1313, Title: Parameter names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1314, Title: Type parameter names should begin with T, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1316, Title: Tuple element names should use correct casing, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1400, Title: Access modifier should be declared, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1401, Title: Fields should be private, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1402, Title: File may only contain a single type, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1403, Title: File may only contain a single namespace, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1404, Title: Code analysis suppression should have justification, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1405, Title: Debug.Assert should provide message text, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1406, Title: Debug.Fail should provide message text, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1407, Title: Arithmetic expressions should declare precedence, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1408, Title: Conditional expressions should declare precedence, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1409, Title: Remove unnecessary code, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1410, Title: Remove delegate parenthesis when possible, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1411, Title: Attribute constructor should not use unnecessary parenthesis, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1412, Title: Store files as UTF-8 with byte order mark, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1413, Title: Use trailing comma in multi-line initializers, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1414, Title: Tuple types in signatures should have element names, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1500, Title: Braces for multi-line statements should not share line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1501, Title: Statement should not be on a single line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1502, Title: Element should not be on a single line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1503, Title: Braces should not be omitted, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1504, Title: All accessors should be single-line or multi-line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1505, Title: Opening braces should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1506, Title: Element documentation headers should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1507, Title: Code should not contain multiple blank lines in a row, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1508, Title: Closing braces should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1509, Title: Opening braces should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1510, Title: Chained statement blocks should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1511, Title: While-do footer should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1512, Title: Single-line comments should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1513, Title: Closing brace should be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1514, Title: Element documentation header should be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1515, Title: Single-line comment should be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1516, Title: Elements should be separated by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1517, Title: Code should not contain blank lines at start of file, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1518, Title: Use line endings correctly at end of file, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1519, Title: Braces should not be omitted from multi-line child statement, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1520, Title: Use braces consistently, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1600, Title: Elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1601, Title: Partial elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: SA1602, Title: Enumeration items should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1603, Title: Documentation should contain valid XML, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1604, Title: Element documentation should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1605, Title: Partial element documentation should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1606, Title: Element documentation should have summary text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1607, Title: Partial element documentation should have summary text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1608, Title: Element documentation should not have default summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1609, Title: Property documentation should have value, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1610, Title: Property documentation should have value text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1611, Title: Element parameters should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1612, Title: Element parameter documentation should match element parameters, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1613, Title: Element parameter documentation should declare parameter name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1614, Title: Element parameter documentation should have text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1615, Title: Element return value should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1616, Title: Element return value documentation should have text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1617, Title: Void return value should not be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1618, Title: Generic type parameters should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1619, Title: Generic type parameters should be documented partial class, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1620, Title: Generic type parameter documentation should match type parameters, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1621, Title: Generic type parameter documentation should declare parameter name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1622, Title: Generic type parameter documentation should have text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1623, Title: Property summary documentation should match accessors, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1624, Title: Property summary documentation should omit accessor with restricted access, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1625, Title: Element documentation should not be copied and pasted, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1626, Title: Single-line comments should not use documentation style slashes, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1627, Title: Documentation text should not be empty, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1628, Title: Documentation text should begin with a capital letter, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1629, Title: Documentation text should end with a period, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1630, Title: Documentation text should contain whitespace, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1631, Title: Documentation should meet character percentage, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1632, Title: Documentation text should meet minimum character length, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1633, Title: File should have header, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1634, Title: File header should show copyright, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1635, Title: File header should have copyright text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1636, Title: File header copyright text should match, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1637, Title: File header should contain file name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1638, Title: File header file name documentation should match file name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1639, Title: File header should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: SA1640, Title: File header should have valid company text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1641, Title: File header company name text should match, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1642, Title: Constructor summary documentation should begin with standard text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1643, Title: Destructor summary documentation should begin with standard text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1644, Title: Documentation headers should not contain blank lines, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1645, Title: Included documentation file does not exist, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1646, Title: Included documentation XPath does not exist, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1647, Title: Include node does not contain valid file and path, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1648, Title: inheritdoc should be used with inheriting class, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1649, Title: File name should match first type name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1650, Title: Element documentation should be spelled correctly, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1651, Title: Do not use placeholder elements, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SX1101, Title: Do not prefix local calls with 'this.', Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SX1309, Title: Field names should begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SX1309S, Title: Static field names should begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SYSLIB1045, Title: Convert to 'GeneratedRegexAttribute'., Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1054, Title: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1055, Title: Invalid 'CustomMarshallerAttribute' usage, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1056, Title: Specified marshaller type is invalid, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1057, Title: Marshaller type does not have the required shape, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1058, Title: Invalid 'NativeMarshallingAttribute' usage, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1060, Title: Specified marshaller type is invalid, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1061, Title: Marshaller type has incompatible method signatures, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1090, Title: "'GeneratedComInterfaceType' does not support the 'ComInterfaceType' value supplied to 'InterfaceTypeAttribute' on the same type.", Category: ComInterfaceGenerator, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1096, Title: Convert to 'GeneratedComInterface', Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1097, Title: Add 'GeneratedComClassAttribute' to enable passing objects of this type to COM, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1098, Title: .NET COM hosting with 'EnableComHosting' does not support interfaces with the 'GeneratedComInterfaceAttribute', Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1099, Title: COM Interop APIs on 'System.Runtime.InteropServices.Marshal' do not support source-generated COM, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD001, Title: Avoid legacy thread switching APIs, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD002, Title: Avoid problematic synchronous waits, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: VSTHRD003, Title: Avoid awaiting foreign Tasks, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD004, Title: Await SwitchToMainThreadAsync, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD010, Title: Invoke single-threaded types on Main thread, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD011, Title: Use AsyncLazy<T>, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD012, Title: Provide JoinableTaskFactory where allowed, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD100, Title: Avoid async void methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD101, Title: Avoid unsupported async delegates, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD102, Title: Implement internal logic asynchronously, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD103, Title: Call async methods when in an async method, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD104, Title: Offer async methods, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD105, Title: Avoid method overloads that assume TaskScheduler.Current, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD106, Title: Use InvokeAsync to raise async events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD107, Title: Await Task within using expression, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD108, Title: Assert thread affinity unconditionally, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD109, Title: Switch instead of assert in async methods, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD110, Title: Observe result of async calls, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD111, Title: Use ConfigureAwait(bool), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: VSTHRD112, Title: Implement System.IAsyncDisposable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD113, Title: Check for System.IAsyncDisposable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD114, Title: Avoid returning a null Task, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD200, Title: Use "Async" suffix for async methods, Category: Style, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}

--- a/tests/Moq.Analyzers.Test/SquiggleCop.Baseline.yaml
+++ b/tests/Moq.Analyzers.Test/SquiggleCop.Baseline.yaml
@@ -1,13275 +1,1658 @@
-- Id: CA1000
-  Title: Do not declare static members on generic types
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1001
-  Title: Types that own disposable fields should be disposable
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1002
-  Title: Do not expose generic lists
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1003
-  Title: Use generic event handler instances
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1005
-  Title: Avoid excessive parameters on generic types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1008
-  Title: Enums should have zero value
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1010
-  Title: Generic interface should also be implemented
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1012
-  Title: Abstract types should not have public constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1014
-  Title: Mark assemblies with CLSCompliant
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1016
-  Title: Mark assemblies with assembly version
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1017
-  Title: Mark assemblies with ComVisible
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1018
-  Title: Mark attributes with AttributeUsageAttribute
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1019
-  Title: Define accessors for attribute arguments
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1021
-  Title: Avoid out parameters
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1024
-  Title: Use properties where appropriate
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1027
-  Title: Mark enums with FlagsAttribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1028
-  Title: Enum Storage should be Int32
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1030
-  Title: Use events where appropriate
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1031
-  Title: Do not catch general exception types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1032
-  Title: Implement standard exception constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1033
-  Title: Interface methods should be callable by child types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1034
-  Title: Nested types should not be visible
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1036
-  Title: Override methods on comparable types
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1040
-  Title: Avoid empty interfaces
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1041
-  Title: Provide ObsoleteAttribute message
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1043
-  Title: Use Integral Or String Argument For Indexers
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1044
-  Title: Properties should not be write only
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1045
-  Title: Do not pass types by reference
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1046
-  Title: Do not overload equality operator on reference types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1050
-  Title: Declare types in namespaces
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1051
-  Title: Do not declare visible instance fields
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1052
-  Title: Static holder types should be Static or NotInheritable
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1054
-  Title: URI-like parameters should not be strings
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1055
-  Title: URI-like return values should not be strings
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1056
-  Title: URI-like properties should not be strings
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1058
-  Title: Types should not extend certain base types
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1060
-  Title: Move pinvokes to native methods class
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1061
-  Title: Do not hide base class methods
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1062
-  Title: Validate arguments of public methods
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1063
-  Title: Implement IDisposable Correctly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1064
-  Title: Exceptions should be public
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1065
-  Title: Do not raise exceptions in unexpected locations
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1066
-  Title: Implement IEquatable when overriding Object.Equals
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: CA1067
-  Title: Override Object.Equals(object) when implementing IEquatable<T>
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1068
-  Title: CancellationToken parameters must come last
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1069
-  Title: Enums values should not be duplicated
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1070
-  Title: Do not declare event fields as virtual
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1200
-  Title: Avoid using cref tags with a prefix
-  Category: Documentation
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1303
-  Title: Do not pass literals as localized parameters
-  Category: Globalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1304
-  Title: Specify CultureInfo
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1305
-  Title: Specify IFormatProvider
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1307
-  Title: Specify StringComparison for clarity
-  Category: Globalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1308
-  Title: Normalize strings to uppercase
-  Category: Globalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1309
-  Title: Use ordinal string comparison
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1310
-  Title: Specify StringComparison for correctness
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1311
-  Title: Specify a culture or use an invariant version
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1401
-  Title: P/Invokes should not be visible
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1416
-  Title: Validate platform compatibility
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1417
-  Title: Do not use 'OutAttribute' on string parameters for P/Invokes
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1418
-  Title: Use valid platform string
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1419
-  Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1420
-  Title: Property, type, or attribute requires runtime marshalling
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1421
-  Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1422
-  Title: Validate platform compatibility
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1501
-  Title: Avoid excessive inheritance
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1502
-  Title: Avoid excessive complexity
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1505
-  Title: Avoid unmaintainable code
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1506
-  Title: Avoid excessive class coupling
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1507
-  Title: Use nameof to express symbol names
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1508
-  Title: Avoid dead conditional code
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1509
-  Title: Invalid entry in code metrics rule specification file
-  Category: Maintainability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1510
-  Title: Use ArgumentNullException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1511
-  Title: Use ArgumentException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1512
-  Title: Use ArgumentOutOfRangeException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1513
-  Title: Use ObjectDisposedException throw helper
-  Category: Maintainability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1700
-  Title: Do not name enum values 'Reserved'
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1707
-  Title: Identifiers should not contain underscores
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1708
-  Title: Identifiers should differ by more than case
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1710
-  Title: Identifiers should have correct suffix
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1711
-  Title: Identifiers should not have incorrect suffix
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1712
-  Title: Do not prefix enum values with type name
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1713
-  Title: Events should not have 'Before' or 'After' prefix
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1715
-  Title: Identifiers should have correct prefix
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1716
-  Title: Identifiers should not match keywords
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1720
-  Title: Identifier contains type name
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1721
-  Title: Property names should not match get methods
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1724
-  Title: Type names should not match namespaces
-  Category: Naming
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1725
-  Title: Parameter names should match base declaration
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1727
-  Title: Use PascalCase for named placeholders
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1802
-  Title: Use literals where appropriate
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1805
-  Title: Do not initialize unnecessarily
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1806
-  Title: Do not ignore method results
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1810
-  Title: Initialize reference type static fields inline
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1812
-  Title: Avoid uninstantiated internal classes
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1813
-  Title: Avoid unsealed attributes
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1814
-  Title: Prefer jagged arrays over multidimensional
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1815
-  Title: Override equals and operator equals on value types
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1816
-  Title: Dispose methods should call SuppressFinalize
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1819
-  Title: Properties should not return arrays
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1820
-  Title: Test for empty strings using string length
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1821
-  Title: Remove empty Finalizers
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1822
-  Title: Mark members as static
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1823
-  Title: Avoid unused private fields
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1824
-  Title: Mark assemblies with NeutralResourcesLanguageAttribute
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1825
-  Title: Avoid zero-length array allocations
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1826
-  Title: Do not use Enumerable methods on indexable collections
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1827
-  Title: Do not use Count() or LongCount() when Any() can be used
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1828
-  Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1829
-  Title: Use Length/Count property instead of Count() when available
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1830
-  Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1831
-  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1832
-  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1833
-  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1834
-  Title: Consider using 'StringBuilder.Append(char)' when applicable
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1835
-  Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1836
-  Title: Prefer IsEmpty over Count
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1837
-  Title: Use 'Environment.ProcessId'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1838
-  Title: Avoid 'StringBuilder' parameters for P/Invokes
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1839
-  Title: Use 'Environment.ProcessPath'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1840
-  Title: Use 'Environment.CurrentManagedThreadId'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1841
-  Title: Prefer Dictionary.Contains methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1842
-  Title: Do not use 'WhenAll' with a single task
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1843
-  Title: Do not use 'WaitAll' with a single task
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1844
-  Title: Provide memory-based overrides of async methods when subclassing 'Stream'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1845
-  Title: Use span-based 'string.Concat'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1846
-  Title: Prefer 'AsSpan' over 'Substring'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1847
-  Title: Use char literal for a single character lookup
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1848
-  Title: Use the LoggerMessage delegates
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1849
-  Title: Call async methods when in an async method
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1850
-  Title: Prefer static 'HashData' method over 'ComputeHash'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1851
-  Title: Possible multiple enumerations of 'IEnumerable' collection
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA1852
-  Title: Seal internal types
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1853
-  Title: Unnecessary call to 'Dictionary.ContainsKey(key)'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1854
-  Title: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1855
-  Title: Prefer 'Clear' over 'Fill'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1856
-  Title: Incorrect usage of ConstantExpected attribute
-  Category: Performance
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1857
-  Title: A constant is expected for the parameter
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA1858
-  Title: Use 'StartsWith' instead of 'IndexOf'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1859
-  Title: Use concrete types when possible for improved performance
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1860
-  Title: Avoid using 'Enumerable.Any()' extension method
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1861
-  Title: Avoid constant arrays as arguments
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1862
-  Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1863
-  Title: Use 'CompositeFormat'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA1864
-  Title: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1865
-  Title: Use char overload
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1866
-  Title: Use char overload
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1867
-  Title: Use char overload
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: CA1868
-  Title: Unnecessary call to 'Contains(item)'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1869
-  Title: Cache and reuse 'JsonSerializerOptions' instances
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA1870
-  Title: Use a cached 'SearchValues' instance
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2000
-  Title: Dispose objects before losing scope
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2002
-  Title: Do not lock on objects with weak identity
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2007
-  Title: Consider calling ConfigureAwait on the awaited task
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2008
-  Title: Do not create tasks without passing a TaskScheduler
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2009
-  Title: Do not call ToImmutableCollection on an ImmutableCollection value
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2011
-  Title: Avoid infinite recursion
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2012
-  Title: Use ValueTasks correctly
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2013
-  Title: Do not use ReferenceEquals with value types
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2014
-  Title: Do not use stackalloc in loops
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2015
-  Title: Do not define finalizers for types derived from MemoryManager<T>
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2016
-  Title: Forward the 'CancellationToken' parameter to methods
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: CA2017
-  Title: Parameter count mismatch
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2018
-  Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument"
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2019
-  Title: Improper 'ThreadStatic' field initialization
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2020
-  Title: Prevent behavioral change
-  Category: Reliability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2021
-  Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
-  Category: Reliability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2100
-  Title: Review SQL queries for security vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2101
-  Title: Specify marshaling for P/Invoke string arguments
-  Category: Globalization
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2119
-  Title: Seal methods that satisfy private interfaces
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2153
-  Title: Do Not Catch Corrupted State Exceptions
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2200
-  Title: Rethrow to preserve stack details
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2201
-  Title: Do not raise reserved exception types
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA2207
-  Title: Initialize value type static fields inline
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2208
-  Title: Instantiate argument exceptions correctly
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2211
-  Title: Non-constant fields should not be visible
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2213
-  Title: Disposable fields should be disposed
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2214
-  Title: Do not call overridable methods in constructors
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2215
-  Title: Dispose methods should call base class dispose
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA2216
-  Title: Disposable types should declare finalizer
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2217
-  Title: Do not mark enums with FlagsAttribute
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2219
-  Title: Do not raise exceptions in finally clauses
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2225
-  Title: Operator overloads have named alternates
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2226
-  Title: Operators should have symmetrical overloads
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2227
-  Title: Collection properties should be read only
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2231
-  Title: Overload operator equals on overriding value type Equals
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2234
-  Title: Pass system uri objects instead of strings
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2235
-  Title: Mark all non-serializable fields
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2237
-  Title: Mark ISerializable types with serializable
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2241
-  Title: Provide correct arguments to formatting methods
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2242
-  Title: Test for NaN correctly
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2243
-  Title: Attribute string literals should parse correctly
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2244
-  Title: Do not duplicate indexed element initializations
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2245
-  Title: Do not assign a property to itself
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2246
-  Title: Assigning symbol and its member in the same statement
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2247
-  Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2248
-  Title: Provide correct 'enum' argument to 'Enum.HasFlag'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2249
-  Title: Consider using 'string.Contains' instead of 'string.IndexOf'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2250
-  Title: Use 'ThrowIfCancellationRequested'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2251
-  Title: Use 'string.Equals'
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA2252
-  Title: This API requires opting into preview features
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2253
-  Title: Named placeholders should not be numeric values
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2254
-  Title: Template should be a static expression
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: CA2255
-  Title: The 'ModuleInitializer' attribute should not be used in libraries
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2256
-  Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2257
-  Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2258
-  Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2259
-  Title: "'ThreadStatic' only affects static fields"
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2260
-  Title: Use correct type parameter
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2261
-  Title: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CA2300
-  Title: Do not use insecure deserializer BinaryFormatter
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2301
-  Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2302
-  Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2305
-  Title: Do not use insecure deserializer LosFormatter
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2310
-  Title: Do not use insecure deserializer NetDataContractSerializer
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2311
-  Title: Do not deserialize without first setting NetDataContractSerializer.Binder
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2312
-  Title: Ensure NetDataContractSerializer.Binder is set before deserializing
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2315
-  Title: Do not use insecure deserializer ObjectStateFormatter
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2321
-  Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2322
-  Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2326
-  Title: Do not use TypeNameHandling values other than None
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2327
-  Title: Do not use insecure JsonSerializerSettings
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2328
-  Title: Ensure that JsonSerializerSettings are secure
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2329
-  Title: Do not deserialize with JsonSerializer using an insecure configuration
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2330
-  Title: Ensure that JsonSerializer has a secure configuration when deserializing
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2350
-  Title: Do not use DataTable.ReadXml() with untrusted data
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2351
-  Title: Do not use DataSet.ReadXml() with untrusted data
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2352
-  Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2353
-  Title: Unsafe DataSet or DataTable in serializable type
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2354
-  Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2355
-  Title: Unsafe DataSet or DataTable type found in deserializable object graph
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2356
-  Title: Unsafe DataSet or DataTable type in web deserializable object graph
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2361
-  Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA2362
-  Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3001
-  Title: Review code for SQL injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3002
-  Title: Review code for XSS vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3003
-  Title: Review code for file path injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3004
-  Title: Review code for information disclosure vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3005
-  Title: Review code for LDAP injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3006
-  Title: Review code for process command injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3007
-  Title: Review code for open redirect vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3008
-  Title: Review code for XPath injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3009
-  Title: Review code for XML injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3010
-  Title: Review code for XAML injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3011
-  Title: Review code for DLL injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3012
-  Title: Review code for regex injection vulnerabilities
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA3061
-  Title: Do Not Add Schema By URL
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3075
-  Title: Insecure DTD processing in XML
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3076
-  Title: Insecure XSLT script processing
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3077
-  Title: Insecure Processing in API Design, XmlDocument and XmlTextReader
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA3147
-  Title: Mark Verb Handlers With Validate Antiforgery Token
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5350
-  Title: Do Not Use Weak Cryptographic Algorithms
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5351
-  Title: Do Not Use Broken Cryptographic Algorithms
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5358
-  Title: Review cipher mode usage with cryptography experts
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5359
-  Title: Do Not Disable Certificate Validation
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5360
-  Title: Do Not Call Dangerous Methods In Deserialization
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5361
-  Title: Do Not Disable SChannel Use of Strong Crypto
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5362
-  Title: Potential reference cycle in deserialized object graph
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5363
-  Title: Do Not Disable Request Validation
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5364
-  Title: Do Not Use Deprecated Security Protocols
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5365
-  Title: Do Not Disable HTTP Header Checking
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5366
-  Title: Use XmlReader for 'DataSet.ReadXml()'
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5367
-  Title: Do Not Serialize Types With Pointer Fields
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5368
-  Title: Set ViewStateUserKey For Classes Derived From Page
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5369
-  Title: Use XmlReader for 'XmlSerializer.Deserialize()'
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5370
-  Title: Use XmlReader for XmlValidatingReader constructor
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5371
-  Title: Use XmlReader for 'XmlSchema.Read()'
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5372
-  Title: Use XmlReader for XPathDocument constructor
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5373
-  Title: Do not use obsolete key derivation function
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5374
-  Title: Do Not Use XslTransform
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5375
-  Title: Do Not Use Account Shared Access Signature
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5376
-  Title: Use SharedAccessProtocol HttpsOnly
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5377
-  Title: Use Container Level Access Policy
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5378
-  Title: Do not disable ServicePointManagerSecurityProtocols
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5379
-  Title: Ensure Key Derivation Function algorithm is sufficiently strong
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5380
-  Title: Do Not Add Certificates To Root Store
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5381
-  Title: Ensure Certificates Are Not Added To Root Store
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5382
-  Title: Use Secure Cookies In ASP.NET Core
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5383
-  Title: Ensure Use Secure Cookies In ASP.NET Core
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5384
-  Title: Do Not Use Digital Signature Algorithm (DSA)
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5385
-  Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5386
-  Title: Avoid hardcoding SecurityProtocolType value
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5387
-  Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5388
-  Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5389
-  Title: Do Not Add Archive Item's Path To The Target File System Path
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5390
-  Title: Do not hard-code encryption key
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5391
-  Title: Use antiforgery tokens in ASP.NET Core MVC controllers
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5392
-  Title: Use DefaultDllImportSearchPaths attribute for P/Invokes
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5393
-  Title: Do not use unsafe DllImportSearchPath value
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5394
-  Title: Do not use insecure randomness
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5395
-  Title: Miss HttpVerb attribute for action methods
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5396
-  Title: Set HttpOnly to true for HttpCookie
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5397
-  Title: Do not use deprecated SslProtocols values
-  Category: Security
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: CA5398
-  Title: Avoid hardcoded SslProtocols values
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5399
-  Title: HttpClients should enable certificate revocation list checks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5400
-  Title: Ensure HttpClient certificate revocation list check is not disabled
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5401
-  Title: Do not use CreateEncryptor with non-default IV
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5402
-  Title: 'Use CreateEncryptor with the default IV '
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5403
-  Title: Do not hard-code certificate
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5404
-  Title: Do not disable token validation checks
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: CA5405
-  Title: Do not always skip token validation in delegates
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: EM0001
-  Title: Switch on Enum Not Exhaustive
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0002
-  Title: Switch on Nullable Enum Not Exhaustive
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0003
-  Title: Switch on Closed Type Not Exhaustive
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0011
-  Title: Concrete Subtype of a Closed Type Must Be a Case
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0012
-  Title: Closed Type Case Must Be a Direct Subtype
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0013
-  Title: Closed Type Case Must Be a Subtype
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0014
-  Title: Concrete Subtype of a Closed Type Must Be a Covered
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0015
-  Title: Open Interface Subtype of a Closed Type Must Be a Case
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0100
-  Title: When Guards Not Supported
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0101
-  Title: Case Pattern Not Supported
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0102
-  Title: Open Type Not Supported
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0103
-  Title: Match Must Be On Case Type
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0104
-  Title: Duplicate Closed Attribute
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EM0105
-  Title: Duplicate Case Type
-  Category: Logic
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: EnableGenerateDocumentationFile
-  Title: Set MSBuild property 'GenerateDocumentationFile' to 'true'
-  Category: Style
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: IDE0004
-  Title: Remove Unnecessary Cast
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0005
-  Title: Using directive is unnecessary.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0005_gen
-  Title: Using directive is unnecessary.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0007
-  Title: Use implicit type
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0008
-  Title: Use explicit type
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0009
-  Title: Member access should be qualified.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0010
-  Title: Add missing cases
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0011
-  Title: Add braces
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0016
-  Title: Use 'throw' expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0017
-  Title: Simplify object initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0018
-  Title: Inline variable declaration
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0019
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0020
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0021
-  Title: Use expression body for constructor
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0022
-  Title: Use expression body for method
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0023
-  Title: Use expression body for conversion operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0024
-  Title: Use expression body for operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0025
-  Title: Use expression body for property
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0026
-  Title: Use expression body for indexer
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0027
-  Title: Use expression body for accessor
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0028
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0029
-  Title: Use coalesce expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0030
-  Title: Use coalesce expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0031
-  Title: Use null propagation
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0032
-  Title: Use auto property
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0033
-  Title: Use explicitly provided tuple name
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0034
-  Title: Simplify 'default' expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0035
-  Title: Unreachable code detected
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0036
-  Title: Order modifiers
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0037
-  Title: Use inferred member name
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0039
-  Title: Use local function
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0040
-  Title: Add accessibility modifiers
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0041
-  Title: Use 'is null' check
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0042
-  Title: Deconstruct variable declaration
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0043
-  Title: Invalid format string
-  Category: Compiler
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0044
-  Title: Add readonly modifier
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0045
-  Title: Convert to conditional expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0046
-  Title: Convert to conditional expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0047
-  Title: Remove unnecessary parentheses
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0048
-  Title: Add parentheses for clarity
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0051
-  Title: Remove unused private members
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0052
-  Title: Remove unread private members
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0053
-  Title: Use expression body for lambda expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0054
-  Title: Use compound assignment
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0055
-  Title: Fix formatting
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0056
-  Title: Use index operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0057
-  Title: Use range operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0058
-  Title: Expression value is never used
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0059
-  Title: Unnecessary assignment of a value
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0060
-  Title: Remove unused parameter
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0061
-  Title: Use expression body for local function
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0062
-  Title: Make local function 'static'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0063
-  Title: Use simple 'using' statement
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0064
-  Title: Make readonly fields writable
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0065
-  Title: Misplaced using directive
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0066
-  Title: Convert switch statement to expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0070
-  Title: Use 'System.HashCode'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0071
-  Title: Simplify interpolation
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0072
-  Title: Add missing cases
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0073
-  Title: The file header does not match the required text
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0074
-  Title: Use compound assignment
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0075
-  Title: Simplify conditional expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0076
-  Title: Invalid global 'SuppressMessageAttribute'
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0077
-  Title: Avoid legacy format target in 'SuppressMessageAttribute'
-  Category: CodeQuality
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0078
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0080
-  Title: Remove unnecessary suppression operator
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0082
-  Title: "'typeof' can be converted to 'nameof'"
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0083
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0090
-  Title: Use 'new(...)'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0100
-  Title: Remove redundant equality
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0110
-  Title: Remove unnecessary discard
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0120
-  Title: Simplify LINQ expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0130
-  Title: Namespace does not match folder structure
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0150
-  Title: Prefer 'null' check over type check
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0160
-  Title: Convert to block scoped namespace
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0161
-  Title: Convert to file-scoped namespace
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0170
-  Title: Property pattern can be simplified
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0180
-  Title: Use tuple to swap values
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0200
-  Title: Remove unnecessary lambda expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0210
-  Title: Convert to top-level statements
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0211
-  Title: Convert to 'Program.Main' style program
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0220
-  Title: Add explicit cast
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0230
-  Title: Use UTF-8 string literal
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0240
-  Title: Remove redundant nullable directive
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0241
-  Title: Remove unnecessary nullable directive
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0250
-  Title: Make struct 'readonly'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0251
-  Title: Make member 'readonly'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0260
-  Title: Use pattern matching
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0270
-  Title: Use coalesce expression
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0280
-  Title: Use 'nameof'
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE0290
-  Title: Use primary constructor
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0300
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0301
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0302
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0303
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0304
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0305
-  Title: Simplify collection initialization
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE0320
-  Title: Make anonymous function static
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE1005
-  Title: Delegate invocation can be simplified.
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE1006
-  Title: Naming Styles
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: IDE2000
-  Title: Avoid multiple blank lines
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2001
-  Title: Embedded statements must be on their own line
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2002
-  Title: Consecutive braces must not have blank line between them
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2003
-  Title: Blank line required between block and subsequent statement
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2004
-  Title: Blank line not allowed after constructor initializer colon
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2005
-  Title: Blank line not allowed after conditional expression token
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: IDE2006
-  Title: Blank line not allowed after arrow expression clause token
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0001
-  Title: StringComparison is missing
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0002
-  Title: IEqualityComparer<string> or IComparer<string> is missing
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0003
-  Title: Add parameter name to improve readability
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0004
-  Title: Use Task.ConfigureAwait
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0005
-  Title: Use Array.Empty<T>()
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0006
-  Title: Use String.Equals instead of equality operator
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0007
-  Title: Add a comma after the last value
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0008
-  Title: Add StructLayoutAttribute
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0009
-  Title: Add regex evaluation timeout
-  Category: Security
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0010
-  Title: Mark attributes with AttributeUsageAttribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0011
-  Title: IFormatProvider is missing
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0012
-  Title: Do not raise reserved exception type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0013
-  Title: Types should not extend System.ApplicationException
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0014
-  Title: Do not raise System.ApplicationException type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0015
-  Title: Specify the parameter name in ArgumentException
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0016
-  Title: Prefer using collection abstraction instead of implementation
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0017
-  Title: Abstract types should not have public or internal constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0018
-  Title: Do not declare static members on generic types (deprecated; use CA1000 instead)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0019
-  Title: Use EventArgs.Empty
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0020
-  Title: Use direct methods instead of LINQ methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0021
-  Title: Use StringComparer.GetHashCode instead of string.GetHashCode
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0022
-  Title: Return Task.FromResult instead of returning null
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0023
-  Title: Add RegexOptions.ExplicitCapture
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0024
-  Title: Use an explicit StringComparer when possible
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0025
-  Title: Implement the functionality instead of throwing NotImplementedException
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0026
-  Title: Fix TODO comment
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - None
-  IsEverSuppressed: true
-- Id: MA0027
-  Title: Prefer rethrowing an exception implicitly
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0028
-  Title: Optimize StringBuilder usage
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0029
-  Title: Combine LINQ methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0030
-  Title: Remove useless OrderBy call
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0031
-  Title: Optimize Enumerable.Count() usage
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0032
-  Title: Use an overload with a CancellationToken argument
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0033
-  Title: Do not tag instance fields with ThreadStaticAttribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0035
-  Title: Do not use dangerous threading methods
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0036
-  Title: Make class static
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0037
-  Title: Remove empty statement
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0038
-  Title: Make method static (deprecated, use CA1822 instead)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0039
-  Title: Do not write your own certificate validation method
-  Category: Security
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0040
-  Title: Forward the CancellationToken parameter to methods that take one
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: MA0041
-  Title: Make property static (deprecated, use CA1822 instead)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0042
-  Title: Do not use blocking calls in an async method
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0043
-  Title: Use nameof operator in ArgumentException
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0044
-  Title: Remove useless ToString call
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0045
-  Title: Do not use blocking calls in a sync method (need to make calling method async)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0046
-  Title: Use EventHandler<T> to declare events
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0047
-  Title: Declare types in namespaces
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0048
-  Title: File name must match type name
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0049
-  Title: Type name should not match containing namespace
-  Category: Design
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0050
-  Title: Validate arguments correctly in iterator methods
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0051
-  Title: Method is too long
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: MA0052
-  Title: Replace constant Enum.ToString with nameof
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0053
-  Title: Make class sealed
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0054
-  Title: Embed the caught exception as innerException
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0055
-  Title: Do not use finalizer
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0056
-  Title: Do not call overridable members in constructor
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0057
-  Title: Class name should end with 'Attribute'
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0058
-  Title: Class name should end with 'Exception'
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0059
-  Title: Class name should end with 'EventArgs'
-  Category: Naming
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0060
-  Title: The value returned by Stream.Read/Stream.ReadAsync is not used
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0061
-  Title: Method overrides should not change default values
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0062
-  Title: Non-flags enums should not be marked with "FlagsAttribute"
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0063
-  Title: Use Where before OrderBy
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0064
-  Title: Avoid locking on publicly accessible instance
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0065
-  Title: Default ValueType.Equals or HashCode is used for struct equality
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0066
-  Title: Hash table unfriendly type is used in a hash table
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0067
-  Title: Use Guid.Empty
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0068
-  Title: Invalid parameter name for nullable attribute
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0069
-  Title: Non-constant static fields should not be visible
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0070
-  Title: Obsolete attributes should include explanations
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0071
-  Title: Avoid using redundant else
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0072
-  Title: Do not throw from a finally block
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0073
-  Title: Avoid comparison with bool constant
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0074
-  Title: Avoid implicit culture-sensitive methods
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0075
-  Title: Do not use implicit culture-sensitive ToString
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0076
-  Title: Do not use implicit culture-sensitive ToString in interpolated strings
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0077
-  Title: A class that provides Equals(T) should implement IEquatable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0078
-  Title: Use 'Cast' instead of 'Select' to cast
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0079
-  Title: Forward the CancellationToken using .WithCancellation()
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0080
-  Title: Use a cancellation token using .WithCancellation()
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0081
-  Title: Method overrides should not omit params keyword
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0082
-  Title: NaN should not be used in comparisons
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0083
-  Title: ConstructorArgument parameters should exist in constructors
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0084
-  Title: Local variables should not hide other symbols
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0085
-  Title: Anonymous delegates should not be used to unsubscribe from Events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0086
-  Title: Do not throw from a finalizer
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0087
-  Title: Parameters with [DefaultParameterValue] attributes should also be marked [Optional]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0088
-  Title: Use [DefaultParameterValue] instead of [DefaultValue]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0089
-  Title: Optimize string method usage
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0090
-  Title: Remove empty else/finally block
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0091
-  Title: Sender should be 'this' for instance events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0092
-  Title: Sender should be 'null' for static events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0093
-  Title: EventArgs should not be null
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0094
-  Title: A class that provides CompareTo(T) should implement IComparable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0095
-  Title: A class that implements IEquatable<T> should override Equals(object)
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0096
-  Title: A class that implements IComparable<T> should also implement IEquatable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0097
-  Title: A class that implements IComparable<T> or IComparable should override comparison operators
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0098
-  Title: Use indexer instead of LINQ methods
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0099
-  Title: Use Explicit enum value instead of 0
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0100
-  Title: Await task before disposing of resources
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0101
-  Title: String contains an implicit end of line character
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: MA0102
-  Title: Make member readonly
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0103
-  Title: Use SequenceEqual instead of equality operator
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0104
-  Title: Do not create a type with a name from the BCL
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0105
-  Title: Use the lambda parameters instead of using a closure
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0106
-  Title: Avoid closure by using an overload with the 'factoryArgument' parameter
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0107
-  Title: Do not use culture-sensitive object.ToString
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0108
-  Title: Remove redundant argument value
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0109
-  Title: Consider adding an overload with a Span<T> or Memory<T>
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0110
-  Title: Use the Regex source generator
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0111
-  Title: Use string.Create instead of FormattableString
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0112
-  Title: Use 'Count > 0' instead of 'Any()'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0113
-  Title: Use DateTime.UnixEpoch
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0114
-  Title: Use DateTimeOffset.UnixEpoch
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0115
-  Title: Unknown component parameter
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0116
-  Title: Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0117
-  Title: Parameters with [EditorRequired] attributes should also be marked as [Parameter]
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0118
-  Title: '[JSInvokable] methods must be public'
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0119
-  Title: JSRuntime must not be used in OnInitialized or OnInitializedAsync
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0120
-  Title: Use InvokeVoidAsync when the returned value is not used
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0121
-  Title: Do not overwrite parameter value
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0122
-  Title: Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0123
-  Title: Sequence number must be a constant
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0124
-  Title: Log parameter type is not valid
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0125
-  Title: The list of log parameter types contains an invalid type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0126
-  Title: The list of log parameter types contains a duplicate
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0127
-  Title: Use String.Equals instead of is pattern
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0128
-  Title: Use 'is' operator instead of SequenceEqual
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0129
-  Title: Await task in using statement
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0130
-  Title: GetType() should not be used on System.Type instances
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0131
-  Title: ArgumentNullException.ThrowIfNull should not be used with non-nullable types
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0132
-  Title: Do not convert implicitly to DateTimeOffset
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0133
-  Title: Use DateTimeOffset instead of relying on the implicit conversion
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0134
-  Title: Observe result of async calls
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0135
-  Title: The log parameter has no configured type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: MA0136
-  Title: Raw String contains an implicit end of line character
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: MA0137
-  Title: Use 'Async' suffix when a method returns an awaitable type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0138
-  Title: Do not use 'Async' suffix when a method does not return an awaitable type
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0139
-  Title: Log parameter type is not valid
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0140
-  Title: Both if and else branch have identical code
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0141
-  Title: Use pattern matching instead of inequality operators for null check
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0142
-  Title: Use pattern matching instead of equality operators for null check
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0143
-  Title: Primary constructor parameters should be readonly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0144
-  Title: Use System.OperatingSystem to check the current OS
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0145
-  Title: Signature for [UnsafeAccessorAttribute] method is not valid
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0146
-  Title: Name must be set explicitly on local functions
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0147
-  Title: Avoid async void method for delegate
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0148
-  Title: Use pattern matching instead of equality operators for discrete value
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0149
-  Title: Use pattern matching instead of inequality operators for discrete value
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0150
-  Title: Do not call the default object.ToString explicitly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0151
-  Title: DebuggerDisplay must contain valid members
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0152
-  Title: Use Unwrap instead of using await twice
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0153
-  Title: Do not log symbols decorated with DataClassificationAttribute directly
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0154
-  Title: Use langword in XML comment
-  Category: Design
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0155
-  Title: Do not use async void methods
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0156
-  Title: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0157
-  Title: Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T>
-  Category: Design
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: MA0158
-  Title: Use System.Threading.Lock
-  Category: Performance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: MA0159
-  Title: Use 'Order' instead of 'OrderBy'
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: MA0160
-  Title: Use ContainsKey instead of TryGetValue
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: POLYSP0003
-  Title: Unsupported C# language version
-  Category: Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1001
-  Title: Add braces (when expression spans over multiple lines)
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1002
-  Title: Remove braces
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1002FadeOut
-  Title: Remove braces
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1003
-  Title: Add braces to if-else (when expression spans over multiple lines)
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1004
-  Title: Remove braces from if-else
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1004FadeOut
-  Title: Remove braces from if-else
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1005
-  Title: Simplify nested using statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1005FadeOut
-  Title: Simplify nested using statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1006
-  Title: Merge 'else' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1006FadeOut
-  Title: Merge 'else' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1007
-  Title: Add braces
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1008
-  Title: "[deprecated] Use explicit type instead of 'var' (when the type is not obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1009
-  Title: "[deprecated] Use explicit type instead of 'var' (foreach variable)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1010
-  Title: "[deprecated] Use 'var' instead of explicit type (when the type is obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1012
-  Title: "[deprecated] Use explicit type instead of 'var' (when the type is obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1013
-  Title: Use predefined type
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1014
-  Title: Use explicitly/implicitly typed array
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1015
-  Title: Use nameof operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1015FadeOut
-  Title: Use nameof operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1016
-  Title: Use block body or expression body
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1018
-  Title: Add/remove accessibility modifiers
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1019
-  Title: Order modifiers
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1020
-  Title: Simplify Nullable<T> to T?
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1021
-  Title: Convert lambda expression body to expression body
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1021FadeOut
-  Title: Convert lambda expression body to expression body
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1031
-  Title: Remove unnecessary braces in switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1031FadeOut
-  Title: Remove unnecessary braces in switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1032
-  Title: Remove redundant parentheses
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1032FadeOut
-  Title: Remove redundant parentheses
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1033
-  Title: Remove redundant boolean literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1034
-  Title: Remove redundant 'sealed' modifier
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1035
-  Title: '[deprecated] Remove redundant comma in initializer'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1036
-  Title: Remove unnecessary blank line
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1037
-  Title: Remove trailing white-space
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1038
-  Title: '[deprecated] Remove empty statement'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1039
-  Title: Remove argument list from attribute
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1040
-  Title: "[deprecated] Remove empty 'else' clause"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1041
-  Title: '[deprecated] Remove empty initializer'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1042
-  Title: Remove enum default underlying type
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1043
-  Title: Remove 'partial' modifier from type with a single part
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1044
-  Title: Remove original exception from throw statement
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1046
-  Title: Asynchronous method name should end with 'Async'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1047
-  Title: Non-asynchronous method name should not end with 'Async'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1047FadeOut
-  Title: Non-asynchronous method name should not end with 'Async'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1048
-  Title: Use lambda expression instead of anonymous method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1048FadeOut
-  Title: Use lambda expression instead of anonymous method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1049
-  Title: Simplify boolean comparison
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1049FadeOut
-  Title: Simplify boolean comparison
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1050
-  Title: Include/omit parentheses when creating new object
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1051
-  Title: Add/remove parentheses from condition in conditional operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1052
-  Title: Declare each attribute separately
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1055
-  Title: Unnecessary semicolon at the end of declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1056
-  Title: Avoid usage of using alias directive
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1058
-  Title: Use compound assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1058FadeOut
-  Title: Use compound assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1059
-  Title: Avoid locking on publicly accessible instance
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1060
-  Title: Declare each type in separate file
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1061
-  Title: Merge 'if' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1061FadeOut
-  Title: Merge 'if' with nested 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1063
-  Title: '[deprecated] Avoid usage of do statement to create an infinite loop'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1064
-  Title: '[deprecated] Avoid usage of for statement to create an infinite loop'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1065
-  Title: '[deprecated] Avoid usage of while statement to create an infinite loop'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1066
-  Title: "[deprecated] Remove empty 'finally' clause"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1066FadeOut
-  Title: "[deprecated] Remove empty 'finally' clause"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1068
-  Title: Simplify logical negation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1069
-  Title: Remove unnecessary case label
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1070
-  Title: Remove redundant default switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1071
-  Title: Remove redundant base constructor call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1072
-  Title: '[deprecated] Remove empty namespace declaration'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1073
-  Title: Convert 'if' to 'return' statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1073FadeOut
-  Title: Convert 'if' to 'return' statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1074
-  Title: Remove redundant constructor
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1075
-  Title: Avoid empty catch clause that catches System.Exception
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1077
-  Title: Optimize LINQ method call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1078
-  Title: Use "" or 'string.Empty'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1079
-  Title: Throwing of new NotImplementedException
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1080
-  Title: Use 'Count/Length' property instead of 'Any' method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1081
-  Title: Split variable declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1084
-  Title: Use coalesce expression instead of conditional expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1085
-  Title: Use auto-implemented property
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1085FadeOut
-  Title: Use auto-implemented property
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1089
-  Title: Use --/++ operator instead of assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1089FadeOut
-  Title: Use --/++ operator instead of assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1090
-  Title: Add/remove 'ConfigureAwait(false)' call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1091
-  Title: '[deprecated] Remove empty region'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1091FadeOut
-  Title: '[deprecated] Remove empty region'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1093
-  Title: File contains no code
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1094
-  Title: Declare using directive on top level
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1096
-  Title: Use 'HasFlag' method or bitwise operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1097
-  Title: Remove redundant 'ToString' call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1098
-  Title: Constant values should be placed on right side of comparisons
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1099
-  Title: Default label should be the last label in a switch section
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1100
-  Title: '[deprecated] Format documentation summary on a single line'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1101
-  Title: '[deprecated] Format documentation summary on multiple lines'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1102
-  Title: Make class static
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1103
-  Title: Convert 'if' to assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1104
-  Title: Simplify conditional expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1105
-  Title: Unnecessary interpolation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1106
-  Title: '[deprecated] Remove empty destructor'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1107
-  Title: Remove redundant 'ToCharArray' call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1108
-  Title: Add 'static' modifier to all partial class declarations
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1110
-  Title: Declare type inside namespace
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1111
-  Title: Add braces to switch section with multiple statements
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1112
-  Title: Combine 'Enumerable.Where' method chain
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1112FadeOut
-  Title: Combine 'Enumerable.Where' method chain
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1113
-  Title: Use 'string.IsNullOrEmpty' method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1114
-  Title: Remove redundant delegate creation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1114FadeOut
-  Title: Remove redundant delegate creation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1118
-  Title: Mark local variable as const
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1123
-  Title: Add parentheses when necessary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1124
-  Title: Inline local variable
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1124FadeOut
-  Title: Inline local variable
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1126
-  Title: Add braces to if-else
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1128
-  Title: Use coalesce expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1129
-  Title: Remove redundant field initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1130
-  Title: Bitwise operation on enum without Flags attribute
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1132
-  Title: Remove redundant overriding member
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1133
-  Title: Remove redundant Dispose/Close call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1134
-  Title: Remove redundant statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1135
-  Title: Declare enum member with zero value (when enum has FlagsAttribute)
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1136
-  Title: Merge switch sections with equivalent content
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1138
-  Title: Add summary to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1139
-  Title: Add summary element to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1140
-  Title: Add exception to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1141
-  Title: Add 'param' element to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1142
-  Title: Add 'typeparam' element to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1143
-  Title: Simplify coalesce expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1145
-  Title: Remove redundant 'as' operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1146
-  Title: Use conditional access
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1151
-  Title: Remove redundant cast
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1154
-  Title: Sort enum members
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1155
-  Title: Use StringComparison when comparing strings
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1156
-  Title: Use string.Length instead of comparison with empty string
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1157
-  Title: Composite enum value contains undefined flag
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1158
-  Title: Static member in generic type should use a type parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1159
-  Title: Use EventHandler<T>
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1160
-  Title: Abstract type should not have public constructors
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1161
-  Title: Enum should declare explicit values
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1162
-  Title: Avoid chain of assignments
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1163
-  Title: Unused parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1164
-  Title: Unused type parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1165
-  Title: Unconstrained type parameter checked for null
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1166
-  Title: Value type object is never equal to null
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1168
-  Title: Parameter name differs from base name
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1169
-  Title: Make field read-only
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1170
-  Title: Use read-only auto-implemented property
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1171
-  Title: Simplify lazy initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1172
-  Title: Use 'is' operator instead of 'as' operator
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1173
-  Title: Use coalesce expression instead of 'if'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1174
-  Title: Remove redundant async/await
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1174FadeOut
-  Title: Remove redundant async/await
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1175
-  Title: Unused 'this' parameter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1176
-  Title: "[deprecated] Use 'var' instead of explicit type (when the type is not obvious)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1177
-  Title: "[deprecated] Use 'var' instead of explicit type (in foreach)"
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1179
-  Title: Unnecessary assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1180
-  Title: Inline lazy initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1181
-  Title: Convert comment to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1182
-  Title: Remove redundant base interface
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1186
-  Title: Use Regex instance instead of static method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1187
-  Title: Use constant instead of field
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1188
-  Title: Remove redundant auto-property initialization
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1189
-  Title: Add or remove region name
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1190
-  Title: Join string expressions
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1191
-  Title: Declare enum value as combination of names
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1192
-  Title: Unnecessary usage of verbatim string literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1193
-  Title: Overriding member should not change 'params' modifier
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1194
-  Title: Implement exception constructors
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1195
-  Title: Use ^ operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1196
-  Title: Call extension method as instance method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1197
-  Title: Optimize StringBuilder.Append/AppendLine call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1198
-  Title: Avoid unnecessary boxing of value type
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1199
-  Title: Unnecessary null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1200
-  Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1201
-  Title: Use method chaining
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1202
-  Title: Avoid NullReferenceException
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1203
-  Title: Use AttributeUsageAttribute
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1204
-  Title: Use EventArgs.Empty
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1205
-  Title: Order named arguments according to the order of parameters
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1206
-  Title: Use conditional access instead of conditional expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1207
-  Title: Use anonymous function or method group
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1208
-  Title: Reduce 'if' nesting
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1209
-  Title: Order type parameter constraints
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1210
-  Title: Return completed task instead of returning null
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1211
-  Title: Remove unnecessary 'else'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1212
-  Title: Remove redundant assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1212FadeOut
-  Title: Remove redundant assignment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1213
-  Title: Remove unused member declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1214
-  Title: Unnecessary interpolated string
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1214FadeOut
-  Title: Unnecessary interpolated string
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1215
-  Title: Expression is always equal to true/false
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1216
-  Title: Unnecessary unsafe context
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1217
-  Title: Convert interpolated string to concatenation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1217FadeOut
-  Title: Convert interpolated string to concatenation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1218
-  Title: Simplify code branching
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1220
-  Title: Use pattern matching instead of combination of 'is' operator and cast operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1221
-  Title: Use pattern matching instead of combination of 'as' operator and null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1222
-  Title: Merge preprocessor directives
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1223
-  Title: Mark publicly visible type with DebuggerDisplay attribute
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1224
-  Title: Make method an extension method
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1225
-  Title: Make class sealed
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1226
-  Title: Add paragraph to documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1227
-  Title: Validate arguments correctly
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1228
-  Title: Unused element in a documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1229
-  Title: Use async/await when necessary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1230
-  Title: Unnecessary explicit use of enumerator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1231
-  Title: Make parameter ref read-only
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RCS1232
-  Title: Order elements in documentation comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1233
-  Title: Use short-circuiting operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1234
-  Title: Duplicate enum value
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1235
-  Title: Optimize method call
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1236
-  Title: Use exception filter
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1237
-  Title: '[deprecated] Use bit shift operator'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1238
-  Title: 'Avoid nested ?: operators'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1239
-  Title: Use 'for' statement instead of 'while' statement
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1240
-  Title: Operator is unnecessary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1241
-  Title: Implement non-generic counterpart
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1242
-  Title: Do not pass non-read-only struct by read-only reference
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1243
-  Title: Duplicate word in a comment
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1244
-  Title: Simplify 'default' expression
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: RCS1246
-  Title: Use element access
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1247
-  Title: Fix documentation comment tag
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1248
-  Title: Normalize null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1249
-  Title: Unnecessary null-forgiving operator
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1250
-  Title: Use implicit/explicit object creation
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1251
-  Title: Remove unnecessary braces from record declaration
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1252
-  Title: Normalize usage of infinite loop
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1253
-  Title: Format documentation comment summary
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1254
-  Title: Normalize format of enum flag value
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1255
-  Title: Simplify argument null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1256
-  Title: Invalid argument null check
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1257
-  Title: Use enum field explicitly
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1258
-  Title: Unnecessary enum flag
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1259
-  Title: Remove empty syntax
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1260
-  Title: Add/remove trailing comma
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1261
-  Title: Resource can be disposed asynchronously
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1262
-  Title: Unnecessary raw string literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1263
-  Title: Invalid reference in a documentation comment
-  Category: Roslynator
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RCS1264
-  Title: Use 'var' or explicit type
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RCS1265
-  Title: Remove redundant catch block
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1266
-  Title: Use raw string literal
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1267
-  Title: Use string interpolation instead of 'string.Concat'
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RCS1268
-  Title: Simplify numeric comparison
-  Category: Roslynator
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: RemoveUnnecessaryImportsFixable
-  Title: ''
-  Category: Style
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: ROS0002
-  Title: Analyzer option is obsolete
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: ROS0003
-  Title: Analyzer requires config option to be specified
-  Category: ''
-  DefaultSeverity: Note
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: RS1001
-  Title: Missing diagnostic analyzer attribute
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1002
-  Title: Missing kind argument when registering an analyzer action
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1003
-  Title: Unsupported SymbolKind argument when registering a symbol analyzer action
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1004
-  Title: Recommend adding language support to diagnostic analyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1005
-  Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1006
-  Title: Invalid type argument for DiagnosticAnalyzer's Register method
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1007
-  Title: Provide localizable arguments to diagnostic descriptor constructor
-  Category: MicrosoftCodeAnalysisLocalization
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1008
-  Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1009
-  Title: Only internal implementations of this interface are allowed
-  Category: MicrosoftCodeAnalysisCompatibility
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1010
-  Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support
-  Category: Correctness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1011
-  Title: Use code actions that have a unique EquivalenceKey for FixAll occurrences support
-  Category: Correctness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1012
-  Title: Start action has no registered actions
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1013
-  Title: Start action has no registered non-end actions
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1014
-  Title: Do not ignore values returned by methods on immutable objects
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1015
-  Title: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor
-  Category: MicrosoftCodeAnalysisDocumentation
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1016
-  Title: Code fix providers should provide FixAll support
-  Category: Correctness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1017
-  Title: DiagnosticId for analyzers must be a non-null constant
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1018
-  Title: DiagnosticId for analyzers must be in specified format
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1019
-  Title: DiagnosticId must be unique across analyzers
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1020
-  Title: Category for analyzers must be from the specified values
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1021
-  Title: Invalid entry in analyzer category and diagnostic ID range specification file
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1022
-  Title: Do not use types from Workspaces assembly in an analyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1023
-  Title: Upgrade MSBuildWorkspace
-  Category: Library
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1024
-  Title: Symbols should be compared for equality
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1025
-  Title: Configure generated code analysis
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: true
-- Id: RS1026
-  Title: Enable concurrent execution
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: true
-- Id: RS1027
-  Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1028
-  Title: Provide non-null 'customTags' value to diagnostic descriptor constructor
-  Category: MicrosoftCodeAnalysisDocumentation
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: RS1029
-  Title: Do not use reserved diagnostic IDs
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1030
-  Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1031
-  Title: Define diagnostic title correctly
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1032
-  Title: Define diagnostic message correctly
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1033
-  Title: Define diagnostic description correctly
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1034
-  Title: Prefer 'IsKind' for checking syntax kinds
-  Category: MicrosoftCodeAnalysisPerformance
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1035
-  Title: Do not use APIs banned for analyzers
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1036
-  Title: Specify analyzer banned API enforcement setting
-  Category: MicrosoftCodeAnalysisCorrectness
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS1037
-  Title: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor
-  Category: MicrosoftCodeAnalysisDesign
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2000
-  Title: Add analyzer diagnostic IDs to analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2001
-  Title: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2002
-  Title: Do not add removed analyzer diagnostic IDs to unshipped analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2003
-  Title: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2004
-  Title: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2005
-  Title: Remove duplicate entries for diagnostic ID in the same analyzer release
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2006
-  Title: Remove duplicate entries for diagnostic ID between analyzer releases
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2007
-  Title: Invalid entry in analyzer release file
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: RS2008
-  Title: Enable analyzer release tracking
-  Category: MicrosoftCodeAnalysisReleaseTracking
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S100
-  Title: Methods and properties should be named in PascalCase
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S1006
-  Title: Method overrides should not change parameter defaults
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S101
-  Title: Types should be named in PascalCase
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S103
-  Title: Lines should not be too long
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S104
-  Title: Files should not have too many lines of code
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1048
-  Title: Finalizers should not throw exceptions
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S105
-  Title: Tabulation characters should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S106
-  Title: Standard outputs should not be used directly to log anything
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1066
-  Title: Mergeable "if" statements should be combined
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1067
-  Title: Expressions should not be too complex
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S107
-  Title: Methods should not have too many parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1075
-  Title: URIs should not be hardcoded
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S108
-  Title: Nested blocks of code should not be left empty
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S109
-  Title: Magic numbers should not be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S110
-  Title: Inheritance tree of classes should not be too deep
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1104
-  Title: Fields should not have public accessibility
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1109
-  Title: A close curly brace should be located at the beginning of a line
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1110
-  Title: Redundant pairs of parentheses should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1116
-  Title: Empty statements should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1117
-  Title: Local variables should not shadow class fields or properties
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1118
-  Title: Utility classes should not have public constructors
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S112
-  Title: General or reserved exceptions should never be thrown
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1121
-  Title: Assignments should not be made from within sub-expressions
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1123
-  Title: '"Obsolete" attributes should include explanations'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1125
-  Title: Boolean literals should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1128
-  Title: Unnecessary "using" should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S113
-  Title: Files should end with a newline
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1133
-  Title: Deprecated code should be removed
-  Category: Info Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1134
-  Title: Track uses of "FIXME" tags
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1135
-  Title: Track uses of "TODO" tags
-  Category: Info Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: false
-- Id: S1144
-  Title: Unused private types or members should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1147
-  Title: Exit methods should not be called
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1151
-  Title: '"switch case" clauses should not have too many lines of code'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1155
-  Title: '"Any()" should be used to test for emptiness'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1163
-  Title: Exceptions should not be thrown in finally blocks
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1168
-  Title: Empty arrays and collections should be returned instead of null
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1172
-  Title: Unused method parameters should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1185
-  Title: Overriding members should do more than simply call the same member in the base class
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1186
-  Title: Methods should not be empty
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1192
-  Title: String literals should not be duplicated
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1199
-  Title: Nested code blocks should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1200
-  Title: Classes should not be coupled to too many other classes
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1206
-  Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S121
-  Title: Control structures should use curly braces
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1210
-  Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1215
-  Title: '"GC.Collect" should not be called'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S122
-  Title: Statements should be on separate lines
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1226
-  Title: Method parameters, caught exceptions and foreach variables' initial values should not be ignored
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1227
-  Title: break statements should not be used except for switch cases
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1244
-  Title: Floating point numbers should not be tested for equality
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S125
-  Title: Sections of code should not be commented out
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S126
-  Title: '"if ... else if" constructs should end with "else" clauses'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1264
-  Title: A "while" loop should be used instead of a "for" loop
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S127
-  Title: '"for" loop stop conditions should be invariant'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1301
-  Title: '"switch" statements should have at least 3 "case" clauses'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1309
-  Title: Track uses of in-source issue suppressions
-  Category: Info Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S131
-  Title: '"switch/Select" statements should contain a "default/Case Else" clauses'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1312
-  Title: Logger fields should be "private static readonly"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1313
-  Title: Using hardcoded IP addresses is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S134
-  Title: Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S138
-  Title: Functions should not have too many lines of code
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1449
-  Title: Culture should be specified for "string" operations
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1450
-  Title: Private fields only used as local variables in methods should become local variables
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1451
-  Title: Track lack of copyright and license headers
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1479
-  Title: '"switch" statements with many "case" clauses should have only one statement'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1481
-  Title: Unused local variables should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1541
-  Title: Methods and properties should not be too complex
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1607
-  Title: Tests should not be ignored
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1643
-  Title: Strings should not be concatenated using '+' in a loop
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1656
-  Title: Variables should not be self-assigned
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1659
-  Title: Multiple variables should not be declared on the same line
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1694
-  Title: An abstract class should have both abstract and concrete methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1696
-  Title: NullReferenceException should not be caught
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1698
-  Title: '"==" should not be used when "Equals" is overridden'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1699
-  Title: Constructors should only call non-overridable methods
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1751
-  Title: Loops with at most one iteration should be refactored
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1764
-  Title: Identical expressions should not be used on both sides of operators
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1821
-  Title: '"switch" statements should not be nested'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1848
-  Title: Objects should not be created to be dropped immediately without being used
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1854
-  Title: Unused assignments should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1858
-  Title: '"ToString()" calls should not be redundant'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S1862
-  Title: Related "if/else if" statements should not have the same condition
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1871
-  Title: Two branches in a conditional structure should not have exactly the same implementation
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1905
-  Title: Redundant casts should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1939
-  Title: Inheritance list should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1940
-  Title: Boolean checks should not be inverted
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1944
-  Title: Invalid casts should be avoided
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S1994
-  Title: "\"for\" loop increment clauses should modify the loops' counters"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2053
-  Title: Password hashing functions should use an unpredictable salt
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2068
-  Title: Hard-coded credentials are security-sensitive
-  Category: Blocker Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2077
-  Title: Formatting SQL queries is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2092
-  Title: Creating cookies without the "secure" flag is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2094
-  Title: Classes should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2114
-  Title: Collections should not be passed as arguments to their own methods
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2115
-  Title: A secure password should be used when connecting to a database
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2123
-  Title: Values should not be uselessly incremented
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2139
-  Title: Exceptions should be either logged or rethrown but not both
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2148
-  Title: Underscores should be used to make large numbers readable
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2156
-  Title: '"sealed" classes should not have "protected" members'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2166
-  Title: Classes named like "Exception" should extend "Exception" or a subclass
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2178
-  Title: Short-circuit logic should be used in boolean contexts
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2183
-  Title: Integral numbers should not be shifted by zero or more than their number of bits-1
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2184
-  Title: Results of integer division should not be assigned to floating point variables
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2187
-  Title: Test classes should contain at least one test case
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2190
-  Title: Loops and recursions should not be infinite
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2197
-  Title: Modulus results should not be checked for direct equality
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2198
-  Title: Unnecessary mathematical comparisons should not be made
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2201
-  Title: Methods without side effects should not have their return values ignored
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2219
-  Title: Runtime type checking should be simplified
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2221
-  Title: '"Exception" should not be caught'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2222
-  Title: Locks should be released on all paths
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2223
-  Title: Non-constant static fields should not be visible
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2225
-  Title: '"ToString()" method should not return null'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2234
-  Title: Arguments should be passed in the same order as the method parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2245
-  Title: Using pseudorandom number generators (PRNGs) is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2251
-  Title: A "for" loop update clause should move the counter in the right direction
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2252
-  Title: For-loop conditions should be true at least once
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2257
-  Title: Using non-standard cryptographic algorithms is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2259
-  Title: Null pointers should not be dereferenced
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2275
-  Title: Composite format strings should not lead to unexpected behavior at runtime
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2290
-  Title: Field-like events should not be virtual
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2291
-  Title: Overflow checking should not be disabled for "Enumerable.Sum"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2292
-  Title: Trivial properties should be auto-implemented
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2302
-  Title: '"nameof" should be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2306
-  Title: '"async" and "await" should not be used as identifiers'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2325
-  Title: Methods and properties that don't access instance data should be static
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2326
-  Title: Unused type parameters should be removed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2327
-  Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2328
-  Title: '"GetHashCode" should not reference mutable fields'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2330
-  Title: Array covariance should not be used
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2333
-  Title: Redundant modifiers should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2339
-  Title: Public constant members should not be used
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2342
-  Title: Enumeration types should comply with a naming convention
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2344
-  Title: Enumeration type names should not have "Flags" or "Enum" suffixes
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2345
-  Title: Flags enumerations should explicitly initialize all their members
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2346
-  Title: Flags enumerations zero-value members should be named "None"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2357
-  Title: Fields should be private
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2360
-  Title: Optional parameters should not be used
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2365
-  Title: Properties should not make collection or array copies
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2368
-  Title: Public methods should not have multidimensional array parameters
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2372
-  Title: Exceptions should not be thrown from property getters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2376
-  Title: Write-only properties should not be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2386
-  Title: Mutable fields should not be "public static"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2387
-  Title: Child class fields should not shadow parent class fields
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2436
-  Title: Types and methods should not have too many generic parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2437
-  Title: Unnecessary bit operations should not be performed
-  Category: Blocker Code Smell
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: S2445
-  Title: Blocks should be synchronized on read-only fields
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2479
-  Title: Whitespace and control characters in string literals should be explicit
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2486
-  Title: Generic exceptions should not be ignored
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2551
-  Title: Shared resources should not be used for locking
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2583
-  Title: Conditionally executed code should be reachable
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2589
-  Title: Boolean expressions should not be gratuitous
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2612
-  Title: Setting loose file permissions is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2629
-  Title: Logging templates should be constant
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2674
-  Title: The length returned from a stream read should be checked
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2681
-  Title: Multiline blocks should be enclosed in curly braces
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2688
-  Title: '"NaN" should not be used in comparisons'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2692
-  Title: '"IndexOf" checks should not be for positive numbers'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2696
-  Title: Instance members should not write to "static" fields
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2699
-  Title: Tests should include assertions
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2701
-  Title: Literal boolean values should not be used in assertions
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2737
-  Title: '"catch" clauses should do more than rethrow'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2743
-  Title: Static fields should not be used in generic types
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2755
-  Title: XML parsers should not be vulnerable to XXE attacks
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2757
-  Title: Non-existent operators like "=+" should not be used
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2760
-  Title: Sequential tests should not check the same condition
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2761
-  Title: Doubled prefix operators "!!" and "~~" should not be used
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2857
-  Title: SQL keywords should be delimited by whitespace
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2925
-  Title: '"Thread.Sleep" should not be used in tests'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2930
-  Title: '"IDisposables" should be disposed'
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2931
-  Title: Classes with "IDisposable" members should implement "IDisposable"
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2933
-  Title: Fields that are only assigned in the constructor should be "readonly"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2934
-  Title: Property assignments should not be made for "readonly" fields not constrained to reference types
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2952
-  Title: Classes should "Dispose" of members from the classes' own "Dispose" methods
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S2953
-  Title: Methods named "Dispose" should implement "IDisposable.Dispose"
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2955
-  Title: Generic parameters not constrained to reference types should not be compared to "null"
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2970
-  Title: Assertions should be complete
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2971
-  Title: LINQ expressions should be simplified
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2995
-  Title: '"Object.ReferenceEquals" should not be used for value types'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2996
-  Title: '"ThreadStatic" fields should not be initialized'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S2997
-  Title: '"IDisposables" created in a "using" statement should not be returned'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3005
-  Title: '"ThreadStatic" should not be used on non-static fields'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3010
-  Title: Static fields should not be updated in constructors
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3011
-  Title: Reflection should not be used to increase accessibility of classes, methods, or fields
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3052
-  Title: Members should not be initialized to default values
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3059
-  Title: Types should not have members with visibility set higher than the type's visibility
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3060
-  Title: '"is" should not be used with "this"'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3063
-  Title: '"StringBuilder" data should be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3168
-  Title: '"async" methods should not return "void"'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3169
-  Title: Multiple "OrderBy" calls should not be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3172
-  Title: Delegates should not be subtracted
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3215
-  Title: '"interface" instances should not be cast to concrete types'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3216
-  Title: '"ConfigureAwait(false)" should be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3217
-  Title: '"Explicit" conversions of "foreach" loops should not be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3218
-  Title: Inner class members should not shadow outer class "static" or type members
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3220
-  Title: Method calls should not resolve ambiguously to overloads with "params"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3234
-  Title: '"GC.SuppressFinalize" should not be invoked for types without destructors'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3235
-  Title: Redundant parentheses should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3236
-  Title: Caller information arguments should not be provided explicitly
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3237
-  Title: '"value" contextual keyword should be used'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3240
-  Title: The simplest possible condition syntax should be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3241
-  Title: Methods should not return values that are never used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3242
-  Title: Method parameters should be declared with base types
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3244
-  Title: Anonymous delegates should not be used to unsubscribe from Events
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3246
-  Title: Generic type parameters should be co/contravariant when possible
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3247
-  Title: Duplicate casts should not be made
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3249
-  Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3251
-  Title: Implementations should be provided for "partial" methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3253
-  Title: Constructor and destructor declarations should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3254
-  Title: Default parameter values should not be passed as arguments
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3256
-  Title: '"string.IsNullOrEmpty" should be used'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3257
-  Title: Declarations and initializations should be as concise as possible
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3260
-  Title: Non-derived "private" classes and records should be "sealed"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3261
-  Title: Namespaces should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3262
-  Title: '"params" should be used on overrides'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3263
-  Title: 'Static fields should appear in the order they must be initialized '
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3264
-  Title: Events should be invoked
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3265
-  Title: Non-flags enums should not be used in bitwise operations
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3267
-  Title: Loops should be simplified with "LINQ" expressions
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3329
-  Title: Cipher Block Chaining IVs should be unpredictable
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3330
-  Title: Creating cookies without the "HttpOnly" flag is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3343
-  Title: Caller information parameters should come at the end of the parameter list
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3346
-  Title: Expressions used in "Debug.Assert" should not produce side effects
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3353
-  Title: Unchanged variables should be marked as "const"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3358
-  Title: Ternary operators should not be nested
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3363
-  Title: Date and time should not be used as a type for primary keys
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3366
-  Title: '"this" should not be exposed from constructors'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3376
-  Title: Attribute, EventArgs, and Exception type names should end with the type being extended
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3397
-  Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3398
-  Title: '"private" methods called only by inner classes should be moved to those classes'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3400
-  Title: Methods should not return constants
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3415
-  Title: Assertion arguments should be passed in the correct order
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3416
-  Title: Loggers should be named for their enclosing types
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3427
-  Title: Method overloads with default parameter values should not overlap
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3431
-  Title: '"[ExpectedException]" should not be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3433
-  Title: Test method signatures should be correct
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3440
-  Title: Variables should not be checked against the values they're about to be assigned
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3441
-  Title: Redundant property names should be omitted in anonymous classes
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3442
-  Title: '"abstract" classes should not have "public" constructors'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3443
-  Title: Type should not be examined on "System.Type" instances
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3444
-  Title: Interfaces should not simply inherit from base interfaces with colliding members
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3445
-  Title: Exceptions should not be explicitly rethrown
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3447
-  Title: '"[Optional]" should not be used on "ref" or "out" parameters'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3449
-  Title: Right operands of shift operators should be integers
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3450
-  Title: Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3451
-  Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3453
-  Title: Classes should not have only "private" constructors
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3456
-  Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly'
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3457
-  Title: Composite format strings should be used correctly
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3458
-  Title: Empty "case" clauses that fall through to the "default" should be omitted
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3459
-  Title: Unassigned members should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3464
-  Title: Type inheritance should not be recursive
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3466
-  Title: Optional parameters should be passed to "base" calls
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3532
-  Title: Empty "default" clauses should be removed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3597
-  Title: '"ServiceContract" and "OperationContract" attributes should be used together'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3598
-  Title: One-way "OperationContract" methods should have "void" return type
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3600
-  Title: '"params" should not be introduced on overrides'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3603
-  Title: 'Methods with "Pure" attribute should return a value '
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3604
-  Title: Member initializer values should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3610
-  Title: Nullable type comparison should not be redundant
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3626
-  Title: Jump statements should not be redundant
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3655
-  Title: Empty nullable value should not be accessed
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3717
-  Title: Track use of "NotImplementedException"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3776
-  Title: Cognitive Complexity of methods should not be too high
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3869
-  Title: '"SafeHandle.DangerousGetHandle" should not be called'
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3871
-  Title: Exception types should be "public"
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3872
-  Title: Parameter names should not duplicate the names of their methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3874
-  Title: '"out" and "ref" parameters should not be used'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3875
-  Title: '"operator==" should not be overloaded on reference types'
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3876
-  Title: Strings or integral types should be used for indexers
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3877
-  Title: Exceptions should not be thrown from unexpected methods
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3878
-  Title: Arrays should not be created for params parameters
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3880
-  Title: Finalizers should not be empty
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3881
-  Title: '"IDisposable" should be implemented correctly'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3884
-  Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used'
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3885
-  Title: '"Assembly.Load" should be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3887
-  Title: Mutable, non-private fields should not be "readonly"
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3889
-  Title: '"Thread.Resume" and "Thread.Suspend" should not be used'
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3897
-  Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3898
-  Title: Value types should implement "IEquatable<T>"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3900
-  Title: Arguments of public methods should be validated against null
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S3902
-  Title: '"Assembly.GetExecutingAssembly" should not be called'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3903
-  Title: Types should be defined in named namespaces
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3904
-  Title: Assemblies should have version information
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3906
-  Title: Event Handlers should have the correct signature
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3908
-  Title: Generic event handlers should be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3909
-  Title: Collections should implement the generic interface
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3923
-  Title: All branches in a conditional structure should not have exactly the same implementation
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3925
-  Title: '"ISerializable" should be implemented correctly'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3926
-  Title: Deserialization methods should be provided for "OptionalField" members
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3927
-  Title: Serialization event handlers should be implemented correctly
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3928
-  Title: 'Parameter names used into ArgumentException constructors should match an existing one '
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3937
-  Title: Number patterns should be regular
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3949
-  Title: Calculations should not overflow
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3956
-  Title: '"Generic.List" instances should not be part of public APIs'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3962
-  Title: '"static readonly" constants should be "const" instead'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3963
-  Title: '"static" fields should be initialized inline'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3966
-  Title: Objects should not be disposed more than once
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3967
-  Title: Multidimensional arrays should not be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3971
-  Title: '"GC.SuppressFinalize" should not be called'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3972
-  Title: Conditionals should start on new lines
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3973
-  Title: A conditionally executed single line should be denoted by indentation
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3981
-  Title: Collection sizes and array length comparisons should make sense
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3984
-  Title: Exceptions should not be created without being thrown
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S3990
-  Title: Assemblies should be marked as CLS compliant
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3992
-  Title: Assemblies should explicitly specify COM visibility
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3993
-  Title: Custom attributes should be marked with "System.AttributeUsageAttribute"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3994
-  Title: URI Parameters should not be strings
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3995
-  Title: URI return values should not be strings
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3996
-  Title: URI properties should not be strings
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3997
-  Title: String URI overloads should call "System.Uri" overloads
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S3998
-  Title: Threads should not lock on objects with weak identity
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4000
-  Title: Pointers to unmanaged memory should not be visible
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4002
-  Title: Disposable types should declare finalizers
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4004
-  Title: Collection properties should be readonly
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4005
-  Title: '"System.Uri" arguments should be used instead of strings'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4015
-  Title: Inherited member visibility should not be decreased
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4016
-  Title: Enumeration members should not be named "Reserved"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4017
-  Title: Method signatures should not contain nested generic types
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4018
-  Title: All type parameters should be used in the parameter list to enable type inference
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4019
-  Title: Base class methods should not be hidden
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4022
-  Title: Enumerations should have "Int32" storage
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4023
-  Title: Interfaces should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4025
-  Title: Child class fields should not differ from parent class fields only by capitalization
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4026
-  Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4027
-  Title: Exceptions should provide standard constructors
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4035
-  Title: Classes implementing "IEquatable<T>" should be sealed
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4036
-  Title: Searching OS commands in PATH is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4039
-  Title: Interface methods should be callable by derived types
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4040
-  Title: Strings should be normalized to uppercase
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4041
-  Title: Type names should not match namespaces
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4047
-  Title: Generics should be used when appropriate
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4049
-  Title: Properties should be preferred
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4050
-  Title: Operators should be overloaded consistently
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4052
-  Title: Types should not extend outdated base types
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4055
-  Title: Literals should not be passed as localized parameters
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4056
-  Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4057
-  Title: Locales should be set for data types
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4058
-  Title: Overloads with a "StringComparison" parameter should be used
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4059
-  Title: Property names should not match get methods
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4060
-  Title: Non-abstract attributes should be sealed
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4061
-  Title: '"params" should be used instead of "varargs"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4069
-  Title: Operator overloads should have named alternatives
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4070
-  Title: Non-flags enums should not be marked with "FlagsAttribute"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4136
-  Title: Method overloads should be grouped together
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4143
-  Title: Collection elements should not be replaced unconditionally
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4144
-  Title: Methods should not have identical implementations
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4158
-  Title: Empty collections should not be accessed or iterated
-  Category: Minor Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4159
-  Title: Classes should implement their "ExportAttribute" interfaces
-  Category: Blocker Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4200
-  Title: Native methods should be wrapped
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4201
-  Title: Null checks should not be combined with "is" operator checks
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4210
-  Title: Windows Forms entry points should be marked with STAThread
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4211
-  Title: Members should not have conflicting transparency annotations
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4212
-  Title: Serialization constructors should be secured
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4214
-  Title: '"P/Invoke" methods should not be visible'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4220
-  Title: Events should have proper arguments
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4225
-  Title: Extension methods should not extend "object"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4226
-  Title: Extensions should be in separate namespaces
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4260
-  Title: '"ConstructorArgument" parameters should exist in constructors'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4261
-  Title: Methods should be named according to their synchronicities
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4275
-  Title: Getters and setters should access the expected fields
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4277
-  Title: '"Shared" parts should not be created with "new"'
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4347
-  Title: Secure random number generators should not output predictable values
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4423
-  Title: Weak SSL/TLS protocols should not be used
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4426
-  Title: Cryptographic keys should be robust
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4428
-  Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4433
-  Title: LDAP connections should be authenticated
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4456
-  Title: Parameter validation in yielding methods should be wrapped
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4457
-  Title: Parameter validation in "async"/"await" methods should be wrapped
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S4462
-  Title: Calls to "async" methods should not be blocking
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S4487
-  Title: Unread "private" fields should be removed
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4502
-  Title: Disabling CSRF protections is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4507
-  Title: Delivering code in production with debug features activated is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4524
-  Title: '"default" clauses should be first or last'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4545
-  Title: '"DebuggerDisplayAttribute" strings should reference existing members'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4581
-  Title: '"new Guid()" should not be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4583
-  Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4586
-  Title: Non-async "Task/Task<T>" methods should not return null
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4635
-  Title: Start index should be used instead of calling Substring
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4663
-  Title: Comments should not be empty
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4790
-  Title: Using weak hashing algorithms is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4792
-  Title: Configuring loggers is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S4830
-  Title: Server certificates should be verified during SSL/TLS connections
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5034
-  Title: '"ValueTask" should be consumed correctly'
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5042
-  Title: Expanding archive files without controlling resource consumption is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5122
-  Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
-  Category: Minor Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5332
-  Title: Using clear-text protocols is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5344
-  Title: Passwords should not be stored in plaintext or with a fast hashing algorithm
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5443
-  Title: Using publicly writable directories is security-sensitive
-  Category: Critical Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5445
-  Title: Insecure temporary file creation methods should not be used
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5542
-  Title: Encryption algorithms should be used with secure mode and padding scheme
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5547
-  Title: Cipher algorithms should be robust
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5659
-  Title: JWT should be signed and verified with strong cipher algorithms
-  Category: Critical Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5693
-  Title: Allowing requests with excessive content length is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5753
-  Title: Disabling ASP.NET "Request Validation" feature is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5766
-  Title: Deserializing objects without performing data validation is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5773
-  Title: Types allowed to be deserialized should be restricted
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S5856
-  Title: Regular expressions should be syntactically valid
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6354
-  Title: Use a testable date/time provider
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6377
-  Title: XML signatures should be validated securely
-  Category: Major Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6419
-  Title: Azure Functions should be stateless
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6420
-  Title: Client instances should not be recreated on each Azure Function invocation
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6421
-  Title: Azure Functions should use Structured Error Handling
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6422
-  Title: Calls to "async" methods should not be blocking in Azure Functions
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6423
-  Title: Azure Functions should log all failures
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6424
-  Title: Interfaces for durable entities should satisfy the restrictions
-  Category: Blocker Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6444
-  Title: Not specifying a timeout for regular expressions is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6507
-  Title: Blocks should not be synchronized on local variables
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S6513
-  Title: '"ExcludeFromCodeCoverage" attributes should include a justification'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6561
-  Title: Avoid using "DateTime.Now" for benchmarking or timing operations
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6562
-  Title: Always set the "DateTimeKind" when creating new "DateTime" instances
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6563
-  Title: Use UTC when recording DateTime instants
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6566
-  Title: Use "DateTimeOffset" instead of "DateTime"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6575
-  Title: Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6580
-  Title: Use a format provider when parsing date and time
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6585
-  Title: Don't hardcode the format when turning dates and times to strings
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6588
-  Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6602
-  Title: '"Find" method should be used instead of the "FirstOrDefault" extension'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6603
-  Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6605
-  Title: Collection-specific "Exists" method should be used instead of the "Any" extension
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6607
-  Title: The collection should be filtered before sorting by using "Where" before "OrderBy"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6608
-  Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList"
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6609
-  Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6610
-  Title: '"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6612
-  Title: The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6613
-  Title: '"First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6617
-  Title: '"Contains" should be used instead of "Any" for simple equality checks'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6618
-  Title: '"string.Create" should be used instead of "FormattableString"'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6640
-  Title: Using unsafe code blocks is security-sensitive
-  Category: Major Security Hotspot
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6664
-  Title: The code block contains too many logging calls
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6667
-  Title: Logging in a catch clause should pass the caught exception as a parameter.
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6668
-  Title: Logging arguments should be passed to the correct parameter
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6669
-  Title: Logger field or property name should comply with a naming convention
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6670
-  Title: '"Trace.Write" and "Trace.WriteLine" should not be used'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6672
-  Title: Generic logger injection should match enclosing type
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6673
-  Title: Log message template placeholders should be in the right order
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6674
-  Title: Log message template should be syntactically correct
-  Category: Critical Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6675
-  Title: '"Trace.WriteLineIf" should not be used with "TraceSwitch" levels'
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6677
-  Title: Message template placeholders should be unique
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6678
-  Title: Use PascalCase for named placeholders
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6781
-  Title: JWT secret keys should not be disclosed
-  Category: Blocker Vulnerability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6797
-  Title: Blazor query parameter type should be supported
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6798
-  Title: '[JSInvokable] attribute should only be used on public methods'
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6800
-  Title: Component parameter type should match the route parameter type constraint
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6802
-  Title: Using lambda expressions in loops should be avoided in Blazor markup section
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S6803
-  Title: Parameters with SupplyParameterFromQuery attribute should be used only in routable components
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: S6930
-  Title: Backslash should be avoided in route templates
-  Category: Major Bug
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6931
-  Title: ASP.NET controller actions should not have a route template starting with "/"
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6932
-  Title: Use model binding instead of reading raw request data
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6934
-  Title: A Route attribute should be added to the controller when a route template is specified at the action level
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6960
-  Title: Controllers should not have mixed responsibilities
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6961
-  Title: API Controllers should derive from ControllerBase instead of Controller
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6962
-  Title: You should pool HTTP connections with HttpClientFactory
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6964
-  Title: Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6965
-  Title: REST API actions should be annotated with an HTTP verb attribute
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6966
-  Title: Awaitable method should be used
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6967
-  Title: ModelState.IsValid should be called in controller actions
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S6968
-  Title: Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S818
-  Title: Literal suffixes should be upper case
-  Category: Minor Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S881
-  Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: S907
-  Title: '"goto" statement should not be used'
-  Category: Major Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S927
-  Title: Parameter names should match base declaration and other partial definitions
-  Category: Critical Code Smell
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: S9999-cpd
-  Title: Copy-paste token calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-log
-  Title: Log generator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-metadata
-  Title: File metadata generator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-metrics
-  Title: Metrics calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-symbolRef
-  Title: Symbol reference calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-token-type
-  Title: Token type calculator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: S9999-warning
-  Title: Analysis Warning generator
-  Category: ''
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: false
-- Id: SA0001
-  Title: XML comment analysis disabled
-  Category: StyleCop.CSharp.SpecialRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA0002
-  Title: Invalid settings file
-  Category: StyleCop.CSharp.SpecialRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1000
-  Title: Keywords should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1001
-  Title: Commas should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1002
-  Title: Semicolons should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1003
-  Title: Symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1004
-  Title: Documentation lines should begin with single space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1005
-  Title: Single line comments should begin with single space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1006
-  Title: Preprocessor keywords should not be preceded by space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1007
-  Title: Operator keyword should be followed by space
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1008
-  Title: Opening parenthesis should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1009
-  Title: Closing parenthesis should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1010
-  Title: Opening square brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1011
-  Title: Closing square brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1012
-  Title: Opening braces should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1013
-  Title: Closing braces should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1014
-  Title: Opening generic brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1015
-  Title: Closing generic brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1016
-  Title: Opening attribute brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1017
-  Title: Closing attribute brackets should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1018
-  Title: Nullable type symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1019
-  Title: Member access symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1020
-  Title: Increment decrement symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1021
-  Title: Negative signs should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1022
-  Title: Positive signs should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1023
-  Title: Dereference and access of symbols should be spaced correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1024
-  Title: Colons Should Be Spaced Correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1025
-  Title: Code should not contain multiple whitespace in a row
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1026
-  Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1027
-  Title: Use tabs correctly
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1028
-  Title: Code should not contain trailing whitespace
-  Category: StyleCop.CSharp.SpacingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1100
-  Title: Do not prefix calls with base unless local implementation exists
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1101
-  Title: Prefix local calls with this
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1102
-  Title: Query clause should follow previous clause
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1103
-  Title: Query clauses should be on separate lines or all on one line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1104
-  Title: Query clause should begin on new line when previous clause spans multiple lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1105
-  Title: Query clauses spanning multiple lines should begin on own line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1106
-  Title: Code should not contain empty statements
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1107
-  Title: Code should not contain multiple statements on one line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1108
-  Title: Block statements should not contain embedded comments
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1109
-  Title: Block statements should not contain embedded regions
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1110
-  Title: Opening parenthesis or bracket should be on declaration line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1111
-  Title: Closing parenthesis should be on line of last parameter
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1112
-  Title: Closing parenthesis should be on line of opening parenthesis
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1113
-  Title: Comma should be on the same line as previous parameter
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1114
-  Title: Parameter list should follow declaration
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1115
-  Title: Parameter should follow comma
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1116
-  Title: Split parameters should start on line after declaration
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1117
-  Title: Parameters should be on same line or separate lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1118
-  Title: Parameter should not span multiple lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1119
-  Title: Statement should not use unnecessary parenthesis
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1119_p
-  Title: Statement should not use unnecessary parenthesis
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SA1120
-  Title: Comments should contain text
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1121
-  Title: Use built-in type alias
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1122
-  Title: Use string.Empty for empty strings
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1123
-  Title: Do not place regions within elements
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1124
-  Title: Do not use regions
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1125
-  Title: Use shorthand for nullable types
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1126
-  Title: Prefix calls correctly
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1127
-  Title: Generic type constraints should be on their own line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1128
-  Title: Put constructor initializers on their own line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1129
-  Title: Do not use default value type constructor
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1130
-  Title: Use lambda syntax
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1131
-  Title: Use readable conditions
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1132
-  Title: Do not combine fields
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1133
-  Title: Do not combine attributes
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1134
-  Title: Attributes should not share line
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1135
-  Title: Using directives should be qualified
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1136
-  Title: Enum values should be on separate lines
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1137
-  Title: Elements should have the same indentation
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1139
-  Title: Use literal suffix notation instead of casting
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1141
-  Title: Use tuple syntax
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1142
-  Title: Refer to tuple fields by name
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1200
-  Title: Using directives should be placed correctly
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1201
-  Title: Elements should appear in the correct order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1202
-  Title: Elements should be ordered by access
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1203
-  Title: Constants should appear before fields
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1204
-  Title: Static elements should appear before instance elements
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: true
-- Id: SA1205
-  Title: Partial elements should declare access
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1206
-  Title: Declaration keywords should follow order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1207
-  Title: Protected should come before internal
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1208
-  Title: System using directives should be placed before other using directives
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1209
-  Title: Using alias directives should be placed after other using directives
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1210
-  Title: Using directives should be ordered alphabetically by namespace
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1211
-  Title: Using alias directives should be ordered alphabetically by alias name
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1212
-  Title: Property accessors should follow order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1213
-  Title: Event accessors should follow order
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1214
-  Title: Readonly fields should appear before non-readonly fields
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1216
-  Title: Using static directives should be placed at the correct location
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1217
-  Title: Using static directives should be ordered alphabetically
-  Category: StyleCop.CSharp.OrderingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1300
-  Title: Element should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1301
-  Title: Element should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1302
-  Title: Interface names should begin with I
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1303
-  Title: Const field names should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1304
-  Title: Non-private readonly fields should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1305
-  Title: Field names should not use Hungarian notation
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1306
-  Title: Field names should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1307
-  Title: Accessible fields should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1308
-  Title: Variable names should not be prefixed
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1309
-  Title: Field names should not begin with underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - None
-  IsEverSuppressed: true
-- Id: SA1310
-  Title: Field names should not contain underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1311
-  Title: Static readonly fields should begin with upper-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1312
-  Title: Variable names should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1313
-  Title: Parameter names should begin with lower-case letter
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1314
-  Title: Type parameter names should begin with T
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1316
-  Title: Tuple element names should use correct casing
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1400
-  Title: Access modifier should be declared
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1401
-  Title: Fields should be private
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1402
-  Title: File may only contain a single type
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1403
-  Title: File may only contain a single namespace
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1404
-  Title: Code analysis suppression should have justification
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1405
-  Title: Debug.Assert should provide message text
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1406
-  Title: Debug.Fail should provide message text
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1407
-  Title: Arithmetic expressions should declare precedence
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1408
-  Title: Conditional expressions should declare precedence
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1409
-  Title: Remove unnecessary code
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1410
-  Title: Remove delegate parenthesis when possible
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1411
-  Title: Attribute constructor should not use unnecessary parenthesis
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1412
-  Title: Store files as UTF-8 with byte order mark
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1413
-  Title: Use trailing comma in multi-line initializers
-  Category: StyleCop.CSharp.MaintainabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1414
-  Title: Tuple types in signatures should have element names
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1500
-  Title: Braces for multi-line statements should not share line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1501
-  Title: Statement should not be on a single line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1502
-  Title: Element should not be on a single line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1503
-  Title: Braces should not be omitted
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1504
-  Title: All accessors should be single-line or multi-line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1505
-  Title: Opening braces should not be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1506
-  Title: Element documentation headers should not be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1507
-  Title: Code should not contain multiple blank lines in a row
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1508
-  Title: Closing braces should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1509
-  Title: Opening braces should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1510
-  Title: Chained statement blocks should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1511
-  Title: While-do footer should not be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1512
-  Title: Single-line comments should not be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1513
-  Title: Closing brace should be followed by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1514
-  Title: Element documentation header should be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1515
-  Title: Single-line comment should be preceded by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1516
-  Title: Elements should be separated by blank line
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1517
-  Title: Code should not contain blank lines at start of file
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1518
-  Title: Use line endings correctly at end of file
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1519
-  Title: Braces should not be omitted from multi-line child statement
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1520
-  Title: Use braces consistently
-  Category: StyleCop.CSharp.LayoutRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1600
-  Title: Elements should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1601
-  Title: Partial elements should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1602
-  Title: Enumeration items should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1603
-  Title: Documentation should contain valid XML
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1604
-  Title: Element documentation should have summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1605
-  Title: Partial element documentation should have summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1606
-  Title: Element documentation should have summary text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1607
-  Title: Partial element documentation should have summary text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1608
-  Title: Element documentation should not have default summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1609
-  Title: Property documentation should have value
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1610
-  Title: Property documentation should have value text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1611
-  Title: Element parameters should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1612
-  Title: Element parameter documentation should match element parameters
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1613
-  Title: Element parameter documentation should declare parameter name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1614
-  Title: Element parameter documentation should have text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1615
-  Title: Element return value should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1616
-  Title: Element return value documentation should have text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1617
-  Title: Void return value should not be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1618
-  Title: Generic type parameters should be documented
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1619
-  Title: Generic type parameters should be documented partial class
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1620
-  Title: Generic type parameter documentation should match type parameters
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1621
-  Title: Generic type parameter documentation should declare parameter name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1622
-  Title: Generic type parameter documentation should have text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1623
-  Title: Property summary documentation should match accessors
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1624
-  Title: Property summary documentation should omit accessor with restricted access
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1625
-  Title: Element documentation should not be copied and pasted
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1626
-  Title: Single-line comments should not use documentation style slashes
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1627
-  Title: Documentation text should not be empty
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1628
-  Title: Documentation text should begin with a capital letter
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1629
-  Title: Documentation text should end with a period
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1630
-  Title: Documentation text should contain whitespace
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1631
-  Title: Documentation should meet character percentage
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1632
-  Title: Documentation text should meet minimum character length
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1633
-  Title: File should have header
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - Note
-  IsEverSuppressed: true
-- Id: SA1634
-  Title: File header should show copyright
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1635
-  Title: File header should have copyright text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1636
-  Title: File header copyright text should match
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1637
-  Title: File header should contain file name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1638
-  Title: File header file name documentation should match file name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1639
-  Title: File header should have summary
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: false
-- Id: SA1640
-  Title: File header should have valid company text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1641
-  Title: File header company name text should match
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1642
-  Title: Constructor summary documentation should begin with standard text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1643
-  Title: Destructor summary documentation should begin with standard text
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1644
-  Title: Documentation headers should not contain blank lines
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1645
-  Title: Included documentation file does not exist
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1646
-  Title: Included documentation XPath does not exist
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1647
-  Title: Include node does not contain valid file and path
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1648
-  Title: inheritdoc should be used with inheriting class
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1649
-  Title: File name should match first type name
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SA1650
-  Title: Element documentation should be spelled correctly
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SA1651
-  Title: Do not use placeholder elements
-  Category: StyleCop.CSharp.DocumentationRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SX1101
-  Title: Do not prefix local calls with 'this.'
-  Category: StyleCop.CSharp.ReadabilityRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SX1309
-  Title: Field names should begin with underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SX1309S
-  Title: Static field names should begin with underscore
-  Category: StyleCop.CSharp.NamingRules
-  DefaultSeverity: Warning
-  IsEnabledByDefault: false
-  EffectiveSeverities:
-  - None
-  IsEverSuppressed: true
-- Id: SYSLIB1045
-  Title: Convert to 'GeneratedRegexAttribute'.
-  Category: Performance
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SYSLIB1054
-  Title: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SYSLIB1055
-  Title: Invalid 'CustomMarshallerAttribute' usage
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1056
-  Title: Specified marshaller type is invalid
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1057
-  Title: Marshaller type does not have the required shape
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1058
-  Title: Invalid 'NativeMarshallingAttribute' usage
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1060
-  Title: Specified marshaller type is invalid
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1061
-  Title: Marshaller type has incompatible method signatures
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1090
-  Title: "'GeneratedComInterfaceType' does not support the 'ComInterfaceType' value supplied to 'InterfaceTypeAttribute' on the same type."
-  Category: ComInterfaceGenerator
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1096
-  Title: Convert to 'GeneratedComInterface'
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SYSLIB1097
-  Title: Add 'GeneratedComClassAttribute' to enable passing objects of this type to COM
-  Category: Interoperability
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: SYSLIB1098
-  Title: .NET COM hosting with 'EnableComHosting' does not support interfaces with the 'GeneratedComInterfaceAttribute'
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: SYSLIB1099
-  Title: COM Interop APIs on 'System.Runtime.InteropServices.Marshal' do not support source-generated COM
-  Category: Interoperability
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD001
-  Title: Avoid legacy thread switching APIs
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD002
-  Title: Avoid problematic synchronous waits
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD003
-  Title: Avoid awaiting foreign Tasks
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD004
-  Title: Await SwitchToMainThreadAsync
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD010
-  Title: Invoke single-threaded types on Main thread
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD011
-  Title: Use AsyncLazy<T>
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD012
-  Title: Provide JoinableTaskFactory where allowed
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD100
-  Title: Avoid async void methods
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD101
-  Title: Avoid unsupported async delegates
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD102
-  Title: Implement internal logic asynchronously
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD103
-  Title: Call async methods when in an async method
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD104
-  Title: Offer async methods
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD105
-  Title: Avoid method overloads that assume TaskScheduler.Current
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD106
-  Title: Use InvokeAsync to raise async events
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD107
-  Title: Await Task within using expression
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD108
-  Title: Assert thread affinity unconditionally
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD109
-  Title: Switch instead of assert in async methods
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD110
-  Title: Observe result of async calls
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD111
-  Title: Use ConfigureAwait(bool)
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: VSTHRD112
-  Title: Implement System.IAsyncDisposable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD113
-  Title: Check for System.IAsyncDisposable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: VSTHRD114
-  Title: Avoid returning a null Task
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: VSTHRD200
-  Title: Use "Async" suffix for async methods
-  Category: Style
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  - None
-  IsEverSuppressed: true
-- Id: xUnit1000
-  Title: Test classes must be public
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1001
-  Title: Fact methods cannot have parameters
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1002
-  Title: Test methods cannot have multiple Fact or Theory attributes
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1003
-  Title: Theory methods must have test data
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1004
-  Title: Test methods should not be skipped
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit1005
-  Title: Fact methods should not have test data
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1006
-  Title: Theory methods should have parameters
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1007
-  Title: ClassData must point at a valid class
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1008
-  Title: Test data attribute should only be used on a Theory
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1009
-  Title: InlineData values must match the number of method parameters
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1010
-  Title: The value is not convertible to the method parameter type
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1011
-  Title: There is no matching method parameter
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1012
-  Title: Null should only be used for nullable parameters
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1013
-  Title: Public method should be marked as test
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1014
-  Title: MemberData should use nameof operator for member name
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1015
-  Title: MemberData must reference an existing member
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1016
-  Title: MemberData must reference a public member
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1017
-  Title: MemberData must reference a static member
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1018
-  Title: MemberData must reference a valid member kind
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1019
-  Title: MemberData must reference a member providing a valid data type
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1020
-  Title: MemberData must reference a property with a public getter
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1021
-  Title: MemberData should not have parameters if the referenced member is not a method
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1022
-  Title: Theory methods cannot have a parameter array
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1023
-  Title: Theory methods cannot have default parameter values
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1024
-  Title: Test methods cannot have overloads
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1025
-  Title: InlineData should be unique within the Theory it belongs to
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1026
-  Title: Theory methods should use all of their parameters
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1027
-  Title: Collection definition classes must be public
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1028
-  Title: Test method must have valid return type
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1029
-  Title: Local functions cannot be test functions
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1030
-  Title: Do not call ConfigureAwait(false) in test method
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1031
-  Title: Do not use blocking task operations in test method
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1032
-  Title: Test classes cannot be nested within a generic class
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1033
-  Title: Test classes decorated with 'Xunit.IClassFixture<TFixture>' or 'Xunit.ICollectionFixture<TFixture>' should add a constructor argument of type TFixture
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit1034
-  Title: Null should only be used for nullable parameters
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1035
-  Title: The value is not convertible to the method parameter type
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1036
-  Title: There is no matching method parameter
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1037
-  Title: There are fewer theory data type arguments than required by the parameters of the test method
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1038
-  Title: There are more theory data type arguments than allowed by the parameters of the test method
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1039
-  Title: The type argument to theory data is not compatible with the type of the corresponding test method parameter
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1040
-  Title: The type argument to theory data is nullable, while the type of the corresponding test method parameter is not
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1041
-  Title: Fixture arguments to test classes must have fixture sources
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1042
-  Title: The member referenced by the MemberData attribute returns untyped data rows
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit1043
-  Title: Constructors on classes derived from FactAttribute must be public when used on test methods
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1044
-  Title: Avoid using TheoryData type arguments that are not serializable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit1045
-  Title: Avoid using TheoryData type arguments that might not be serializable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit1046
-  Title: Avoid using TheoryDataRow arguments that are not serializable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit1047
-  Title: Avoid using TheoryDataRow arguments that might not be serializable
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit1048
-  Title: Avoid using 'async void' for test methods as it is deprecated in xUnit.net v3
-  Category: Usage
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1049
-  Title: Do not use 'async void' for test methods as it is no longer supported
-  Category: Usage
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit1050
-  Title: The class referenced by the ClassData attribute returns untyped data rows
-  Category: Usage
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit2000
-  Title: Constants and literals should be the expected argument
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2001
-  Title: Do not use invalid equality check
-  Category: Assertions
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: true
-- Id: xUnit2002
-  Title: Do not use null check on value type
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2003
-  Title: Do not use equality check to test for null value
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2004
-  Title: Do not use equality check to test for boolean conditions
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2005
-  Title: Do not use identity check on value type
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2006
-  Title: Do not use invalid string equality check
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2007
-  Title: Do not use typeof expression to check the type
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2008
-  Title: Do not use boolean check to match on regular expressions
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2009
-  Title: Do not use boolean check to check for substrings
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2010
-  Title: Do not use boolean check to check for string equality
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2011
-  Title: Do not use empty collection check
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2012
-  Title: Do not use boolean check to check if a value exists in a collection
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2013
-  Title: Do not use equality check to check for collection size.
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2014
-  Title: Do not use throws check to check for asynchronously thrown exception
-  Category: Assertions
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2015
-  Title: Do not use typeof expression to check the exception type
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2016
-  Title: Keep precision in the allowed range when asserting equality of doubles or decimals.
-  Category: Assertions
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2017
-  Title: Do not use Contains() to check if a value exists in a collection
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2018
-  Title: Do not compare an object's exact type to an abstract class or interface
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2020
-  Title: Do not use always-failing boolean assertions
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2021
-  Title: Async assertions should be awaited
-  Category: Assertions
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2022
-  Title: Boolean assertions should not be negated
-  Category: Assertions
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit2023
-  Title: Do not use collection methods for single-item collections
-  Category: Assertions
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit2024
-  Title: Do not use boolean asserts for simple equality tests
-  Category: Assertions
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit2025
-  Title: The boolean assertion statement can be simplified
-  Category: Assertions
-  DefaultSeverity: Note
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Note
-  IsEverSuppressed: false
-- Id: xUnit2026
-  Title: Comparison of sets must be done with IEqualityComparer
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2027
-  Title: Comparison of sets to linear containers have undefined results
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2028
-  Title: Do not use Assert.Empty or Assert.NotEmpty with problematic types
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit2029
-  Title: Do not use Empty() to check if a value does not exist in a collection
-  Category: Assertions
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit3000
-  Title: Classes which cross AppDomain boundaries must derive directly or indirectly from LongLivedMarshalByRefObject
-  Category: Extensibility
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: xUnit3001
-  Title: Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor
-  Category: Extensibility
-  DefaultSeverity: Error
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Error
-  IsEverSuppressed: false
-- Id: CS1591
-  Title: Missing XML comment for publicly visible type or member
-  Category: Compiler
-  DefaultSeverity: Warning
-  IsEnabledByDefault: true
-  EffectiveSeverities:
-  - Warning
-  IsEverSuppressed: true
+- {Id: CA1000, Title: Do not declare static members on generic types, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1001, Title: Types that own disposable fields should be disposable, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1002, Title: Do not expose generic lists, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1003, Title: Use generic event handler instances, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1005, Title: Avoid excessive parameters on generic types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1008, Title: Enums should have zero value, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1010, Title: Generic interface should also be implemented, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1012, Title: Abstract types should not have public constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1014, Title: Mark assemblies with CLSCompliant, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1016, Title: Mark assemblies with assembly version, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1017, Title: Mark assemblies with ComVisible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1018, Title: Mark attributes with AttributeUsageAttribute, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1019, Title: Define accessors for attribute arguments, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1021, Title: Avoid out parameters, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1024, Title: Use properties where appropriate, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1027, Title: Mark enums with FlagsAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1028, Title: Enum Storage should be Int32, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1030, Title: Use events where appropriate, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1031, Title: Do not catch general exception types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1032, Title: Implement standard exception constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1033, Title: Interface methods should be callable by child types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1034, Title: Nested types should not be visible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1036, Title: Override methods on comparable types, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1040, Title: Avoid empty interfaces, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1041, Title: Provide ObsoleteAttribute message, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1043, Title: Use Integral Or String Argument For Indexers, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1044, Title: Properties should not be write only, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1045, Title: Do not pass types by reference, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1046, Title: Do not overload equality operator on reference types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1050, Title: Declare types in namespaces, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1051, Title: Do not declare visible instance fields, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1052, Title: Static holder types should be Static or NotInheritable, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1054, Title: URI-like parameters should not be strings, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1055, Title: URI-like return values should not be strings, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1056, Title: URI-like properties should not be strings, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1058, Title: Types should not extend certain base types, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1060, Title: Move pinvokes to native methods class, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1061, Title: Do not hide base class methods, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1062, Title: Validate arguments of public methods, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1063, Title: Implement IDisposable Correctly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1064, Title: Exceptions should be public, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1065, Title: Do not raise exceptions in unexpected locations, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1066, Title: Implement IEquatable when overriding Object.Equals, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: CA1067, Title: Override Object.Equals(object) when implementing IEquatable<T>, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1068, Title: CancellationToken parameters must come last, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1069, Title: Enums values should not be duplicated, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1070, Title: Do not declare event fields as virtual, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1200, Title: Avoid using cref tags with a prefix, Category: Documentation, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1303, Title: Do not pass literals as localized parameters, Category: Globalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1304, Title: Specify CultureInfo, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1305, Title: Specify IFormatProvider, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1307, Title: Specify StringComparison for clarity, Category: Globalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1308, Title: Normalize strings to uppercase, Category: Globalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1309, Title: Use ordinal string comparison, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1310, Title: Specify StringComparison for correctness, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1311, Title: Specify a culture or use an invariant version, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1401, Title: P/Invokes should not be visible, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1416, Title: Validate platform compatibility, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1417, Title: Do not use 'OutAttribute' on string parameters for P/Invokes, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1418, Title: Use valid platform string, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1419, Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle', Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1420, Title: 'Property, type, or attribute requires runtime marshalling', Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1421, Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1422, Title: Validate platform compatibility, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1501, Title: Avoid excessive inheritance, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1502, Title: Avoid excessive complexity, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1505, Title: Avoid unmaintainable code, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1506, Title: Avoid excessive class coupling, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1507, Title: Use nameof to express symbol names, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1508, Title: Avoid dead conditional code, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1509, Title: Invalid entry in code metrics rule specification file, Category: Maintainability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1510, Title: Use ArgumentNullException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1511, Title: Use ArgumentException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1512, Title: Use ArgumentOutOfRangeException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1513, Title: Use ObjectDisposedException throw helper, Category: Maintainability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1700, Title: Do not name enum values 'Reserved', Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1707, Title: Identifiers should not contain underscores, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1708, Title: Identifiers should differ by more than case, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1710, Title: Identifiers should have correct suffix, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1711, Title: Identifiers should not have incorrect suffix, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1712, Title: Do not prefix enum values with type name, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1713, Title: Events should not have 'Before' or 'After' prefix, Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1715, Title: Identifiers should have correct prefix, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1716, Title: Identifiers should not match keywords, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1720, Title: Identifier contains type name, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1721, Title: Property names should not match get methods, Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1724, Title: Type names should not match namespaces, Category: Naming, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1725, Title: Parameter names should match base declaration, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1727, Title: Use PascalCase for named placeholders, Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1802, Title: Use literals where appropriate, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1805, Title: Do not initialize unnecessarily, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1806, Title: Do not ignore method results, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1810, Title: Initialize reference type static fields inline, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1812, Title: Avoid uninstantiated internal classes, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1813, Title: Avoid unsealed attributes, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1814, Title: Prefer jagged arrays over multidimensional, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1815, Title: Override equals and operator equals on value types, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1816, Title: Dispose methods should call SuppressFinalize, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1819, Title: Properties should not return arrays, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1820, Title: Test for empty strings using string length, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1821, Title: Remove empty Finalizers, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1822, Title: Mark members as static, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1823, Title: Avoid unused private fields, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1824, Title: Mark assemblies with NeutralResourcesLanguageAttribute, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1825, Title: Avoid zero-length array allocations, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1826, Title: Do not use Enumerable methods on indexable collections, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1827, Title: Do not use Count() or LongCount() when Any() can be used, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1828, Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1829, Title: Use Length/Count property instead of Count() when available, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1830, Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1831, Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1832, Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1833, Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1834, Title: Consider using 'StringBuilder.Append(char)' when applicable, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1835, Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1836, Title: Prefer IsEmpty over Count, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1837, Title: Use 'Environment.ProcessId', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1838, Title: Avoid 'StringBuilder' parameters for P/Invokes, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1839, Title: Use 'Environment.ProcessPath', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1840, Title: Use 'Environment.CurrentManagedThreadId', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1841, Title: Prefer Dictionary.Contains methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1842, Title: Do not use 'WhenAll' with a single task, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1843, Title: Do not use 'WaitAll' with a single task, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1844, Title: Provide memory-based overrides of async methods when subclassing 'Stream', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1845, Title: Use span-based 'string.Concat', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1846, Title: Prefer 'AsSpan' over 'Substring', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1847, Title: Use char literal for a single character lookup, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1848, Title: Use the LoggerMessage delegates, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1849, Title: Call async methods when in an async method, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1850, Title: Prefer static 'HashData' method over 'ComputeHash', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1851, Title: Possible multiple enumerations of 'IEnumerable' collection, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA1852, Title: Seal internal types, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1853, Title: Unnecessary call to 'Dictionary.ContainsKey(key)', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1854, Title: "Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method", Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1855, Title: Prefer 'Clear' over 'Fill', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1856, Title: Incorrect usage of ConstantExpected attribute, Category: Performance, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1857, Title: A constant is expected for the parameter, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA1858, Title: Use 'StartsWith' instead of 'IndexOf', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1859, Title: Use concrete types when possible for improved performance, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1860, Title: Avoid using 'Enumerable.Any()' extension method, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1861, Title: Avoid constant arrays as arguments, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1862, Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1863, Title: Use 'CompositeFormat', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA1864, Title: "Prefer the 'IDictionary.TryAdd(TKey, TValue)' method", Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1865, Title: Use char overload, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1866, Title: Use char overload, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1867, Title: Use char overload, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: CA1868, Title: Unnecessary call to 'Contains(item)', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1869, Title: Cache and reuse 'JsonSerializerOptions' instances, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA1870, Title: Use a cached 'SearchValues' instance, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2000, Title: Dispose objects before losing scope, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2002, Title: Do not lock on objects with weak identity, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2007, Title: Consider calling ConfigureAwait on the awaited task, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2008, Title: Do not create tasks without passing a TaskScheduler, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2009, Title: Do not call ToImmutableCollection on an ImmutableCollection value, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2011, Title: Avoid infinite recursion, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2012, Title: Use ValueTasks correctly, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2013, Title: Do not use ReferenceEquals with value types, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2014, Title: Do not use stackalloc in loops, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2015, Title: Do not define finalizers for types derived from MemoryManager<T>, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2016, Title: Forward the 'CancellationToken' parameter to methods, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: CA2017, Title: Parameter count mismatch, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2018, Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument", Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2019, Title: Improper 'ThreadStatic' field initialization, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2020, Title: Prevent behavioral change, Category: Reliability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2021, Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types, Category: Reliability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2100, Title: Review SQL queries for security vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2101, Title: Specify marshaling for P/Invoke string arguments, Category: Globalization, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2119, Title: Seal methods that satisfy private interfaces, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2153, Title: Do Not Catch Corrupted State Exceptions, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2200, Title: Rethrow to preserve stack details, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2201, Title: Do not raise reserved exception types, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2207, Title: Initialize value type static fields inline, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2208, Title: Instantiate argument exceptions correctly, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2211, Title: Non-constant fields should not be visible, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2213, Title: Disposable fields should be disposed, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2214, Title: Do not call overridable methods in constructors, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2215, Title: Dispose methods should call base class dispose, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2216, Title: Disposable types should declare finalizer, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2217, Title: Do not mark enums with FlagsAttribute, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2219, Title: Do not raise exceptions in finally clauses, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2225, Title: Operator overloads have named alternates, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2226, Title: Operators should have symmetrical overloads, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2227, Title: Collection properties should be read only, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2231, Title: Overload operator equals on overriding value type Equals, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2234, Title: Pass system uri objects instead of strings, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2235, Title: Mark all non-serializable fields, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2237, Title: Mark ISerializable types with serializable, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2241, Title: Provide correct arguments to formatting methods, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2242, Title: Test for NaN correctly, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2243, Title: Attribute string literals should parse correctly, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2244, Title: Do not duplicate indexed element initializations, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2245, Title: Do not assign a property to itself, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2246, Title: Assigning symbol and its member in the same statement, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2247, Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2248, Title: Provide correct 'enum' argument to 'Enum.HasFlag', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2249, Title: Consider using 'string.Contains' instead of 'string.IndexOf', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2250, Title: Use 'ThrowIfCancellationRequested', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2251, Title: Use 'string.Equals', Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA2252, Title: This API requires opting into preview features, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2253, Title: Named placeholders should not be numeric values, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2254, Title: Template should be a static expression, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: CA2255, Title: The 'ModuleInitializer' attribute should not be used in libraries, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2256, Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2257, Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static', Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2258, Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2259, Title: "'ThreadStatic' only affects static fields", Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2260, Title: Use correct type parameter, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2261, Title: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: CA2300, Title: Do not use insecure deserializer BinaryFormatter, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2301, Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2302, Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2305, Title: Do not use insecure deserializer LosFormatter, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2310, Title: Do not use insecure deserializer NetDataContractSerializer, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2311, Title: Do not deserialize without first setting NetDataContractSerializer.Binder, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2312, Title: Ensure NetDataContractSerializer.Binder is set before deserializing, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2315, Title: Do not use insecure deserializer ObjectStateFormatter, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2321, Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2322, Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2326, Title: Do not use TypeNameHandling values other than None, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2327, Title: Do not use insecure JsonSerializerSettings, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2328, Title: Ensure that JsonSerializerSettings are secure, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2329, Title: Do not deserialize with JsonSerializer using an insecure configuration, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2330, Title: Ensure that JsonSerializer has a secure configuration when deserializing, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2350, Title: Do not use DataTable.ReadXml() with untrusted data, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2351, Title: Do not use DataSet.ReadXml() with untrusted data, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2352, Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2353, Title: Unsafe DataSet or DataTable in serializable type, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2354, Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2355, Title: Unsafe DataSet or DataTable type found in deserializable object graph, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2356, Title: Unsafe DataSet or DataTable type in web deserializable object graph, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2361, Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA2362, Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3001, Title: Review code for SQL injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3002, Title: Review code for XSS vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3003, Title: Review code for file path injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3004, Title: Review code for information disclosure vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3005, Title: Review code for LDAP injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3006, Title: Review code for process command injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3007, Title: Review code for open redirect vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3008, Title: Review code for XPath injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3009, Title: Review code for XML injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3010, Title: Review code for XAML injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3011, Title: Review code for DLL injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3012, Title: Review code for regex injection vulnerabilities, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA3061, Title: Do Not Add Schema By URL, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3075, Title: Insecure DTD processing in XML, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3076, Title: Insecure XSLT script processing, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3077, Title: 'Insecure Processing in API Design, XmlDocument and XmlTextReader', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA3147, Title: Mark Verb Handlers With Validate Antiforgery Token, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5350, Title: Do Not Use Weak Cryptographic Algorithms, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5351, Title: Do Not Use Broken Cryptographic Algorithms, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5358, Title: Review cipher mode usage with cryptography experts, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5359, Title: Do Not Disable Certificate Validation, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5360, Title: Do Not Call Dangerous Methods In Deserialization, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5361, Title: Do Not Disable SChannel Use of Strong Crypto, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5362, Title: Potential reference cycle in deserialized object graph, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5363, Title: Do Not Disable Request Validation, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5364, Title: Do Not Use Deprecated Security Protocols, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5365, Title: Do Not Disable HTTP Header Checking, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5366, Title: Use XmlReader for 'DataSet.ReadXml()', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5367, Title: Do Not Serialize Types With Pointer Fields, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5368, Title: Set ViewStateUserKey For Classes Derived From Page, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5369, Title: Use XmlReader for 'XmlSerializer.Deserialize()', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5370, Title: Use XmlReader for XmlValidatingReader constructor, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5371, Title: Use XmlReader for 'XmlSchema.Read()', Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5372, Title: Use XmlReader for XPathDocument constructor, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5373, Title: Do not use obsolete key derivation function, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5374, Title: Do Not Use XslTransform, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5375, Title: Do Not Use Account Shared Access Signature, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5376, Title: Use SharedAccessProtocol HttpsOnly, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5377, Title: Use Container Level Access Policy, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5378, Title: Do not disable ServicePointManagerSecurityProtocols, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5379, Title: Ensure Key Derivation Function algorithm is sufficiently strong, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5380, Title: Do Not Add Certificates To Root Store, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5381, Title: Ensure Certificates Are Not Added To Root Store, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5382, Title: Use Secure Cookies In ASP.NET Core, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5383, Title: Ensure Use Secure Cookies In ASP.NET Core, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5384, Title: Do Not Use Digital Signature Algorithm (DSA), Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5385, Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5386, Title: Avoid hardcoding SecurityProtocolType value, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5387, Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5388, Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5389, Title: Do Not Add Archive Item's Path To The Target File System Path, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5390, Title: Do not hard-code encryption key, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5391, Title: Use antiforgery tokens in ASP.NET Core MVC controllers, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5392, Title: Use DefaultDllImportSearchPaths attribute for P/Invokes, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5393, Title: Do not use unsafe DllImportSearchPath value, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5394, Title: Do not use insecure randomness, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5395, Title: Miss HttpVerb attribute for action methods, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5396, Title: Set HttpOnly to true for HttpCookie, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5397, Title: Do not use deprecated SslProtocols values, Category: Security, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: CA5398, Title: Avoid hardcoded SslProtocols values, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5399, Title: HttpClients should enable certificate revocation list checks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5400, Title: Ensure HttpClient certificate revocation list check is not disabled, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5401, Title: Do not use CreateEncryptor with non-default IV, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5402, Title: 'Use CreateEncryptor with the default IV ', Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5403, Title: Do not hard-code certificate, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5404, Title: Do not disable token validation checks, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CA5405, Title: Do not always skip token validation in delegates, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: CS1591, Title: Missing XML comment for publicly visible type or member, Category: Compiler, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: true}
+- {Id: EM0001, Title: Switch on Enum Not Exhaustive, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0002, Title: Switch on Nullable Enum Not Exhaustive, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0003, Title: Switch on Closed Type Not Exhaustive, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0011, Title: Concrete Subtype of a Closed Type Must Be a Case, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0012, Title: Closed Type Case Must Be a Direct Subtype, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0013, Title: Closed Type Case Must Be a Subtype, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0014, Title: Concrete Subtype of a Closed Type Must Be a Covered, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0015, Title: Open Interface Subtype of a Closed Type Must Be a Case, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0100, Title: When Guards Not Supported, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0101, Title: Case Pattern Not Supported, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0102, Title: Open Type Not Supported, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0103, Title: Match Must Be On Case Type, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0104, Title: Duplicate Closed Attribute, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EM0105, Title: Duplicate Case Type, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: EnableGenerateDocumentationFile, Title: Set MSBuild property 'GenerateDocumentationFile' to 'true', Category: Style, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: IDE0004, Title: Remove Unnecessary Cast, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0005, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0005_gen, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0007, Title: Use implicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0008, Title: Use explicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0009, Title: Member access should be qualified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0010, Title: Add missing cases, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0011, Title: Add braces, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0016, Title: Use 'throw' expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0017, Title: Simplify object initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0018, Title: Inline variable declaration, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0019, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0020, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0021, Title: Use expression body for constructor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0022, Title: Use expression body for method, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0023, Title: Use expression body for conversion operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0024, Title: Use expression body for operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0025, Title: Use expression body for property, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0026, Title: Use expression body for indexer, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0027, Title: Use expression body for accessor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0028, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0029, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0030, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0031, Title: Use null propagation, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0032, Title: Use auto property, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0033, Title: Use explicitly provided tuple name, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0034, Title: Simplify 'default' expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0035, Title: Unreachable code detected, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0036, Title: Order modifiers, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0037, Title: Use inferred member name, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0039, Title: Use local function, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0040, Title: Add accessibility modifiers, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0041, Title: Use 'is null' check, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0042, Title: Deconstruct variable declaration, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0043, Title: Invalid format string, Category: Compiler, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0044, Title: Add readonly modifier, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0045, Title: Convert to conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0046, Title: Convert to conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0047, Title: Remove unnecessary parentheses, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0048, Title: Add parentheses for clarity, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0051, Title: Remove unused private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0052, Title: Remove unread private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0053, Title: Use expression body for lambda expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0054, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0055, Title: Fix formatting, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0056, Title: Use index operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0057, Title: Use range operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0058, Title: Expression value is never used, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0059, Title: Unnecessary assignment of a value, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0060, Title: Remove unused parameter, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0061, Title: Use expression body for local function, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0062, Title: Make local function 'static', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0063, Title: Use simple 'using' statement, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0064, Title: Make readonly fields writable, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0065, Title: Misplaced using directive, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0066, Title: Convert switch statement to expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0070, Title: Use 'System.HashCode', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0071, Title: Simplify interpolation, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0072, Title: Add missing cases, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0073, Title: The file header does not match the required text, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0074, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0075, Title: Simplify conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0076, Title: Invalid global 'SuppressMessageAttribute', Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0077, Title: Avoid legacy format target in 'SuppressMessageAttribute', Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0078, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0080, Title: Remove unnecessary suppression operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0082, Title: "'typeof' can be converted to 'nameof'", Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0083, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0090, Title: Use 'new(...)', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0100, Title: Remove redundant equality, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0110, Title: Remove unnecessary discard, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0120, Title: Simplify LINQ expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0130, Title: Namespace does not match folder structure, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0150, Title: Prefer 'null' check over type check, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0160, Title: Convert to block scoped namespace, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0161, Title: Convert to file-scoped namespace, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0170, Title: Property pattern can be simplified, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0180, Title: Use tuple to swap values, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0200, Title: Remove unnecessary lambda expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0210, Title: Convert to top-level statements, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0211, Title: Convert to 'Program.Main' style program, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0220, Title: Add explicit cast, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0230, Title: Use UTF-8 string literal, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0240, Title: Remove redundant nullable directive, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0241, Title: Remove unnecessary nullable directive, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0250, Title: Make struct 'readonly', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0251, Title: Make member 'readonly', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0260, Title: Use pattern matching, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0270, Title: Use coalesce expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0280, Title: Use 'nameof', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0290, Title: Use primary constructor, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0300, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0301, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0302, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0303, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0304, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0305, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0320, Title: Make anonymous function static, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE1005, Title: Delegate invocation can be simplified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE1006, Title: Naming Styles, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE2000, Title: Avoid multiple blank lines, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2001, Title: Embedded statements must be on their own line, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2002, Title: Consecutive braces must not have blank line between them, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2003, Title: Blank line required between block and subsequent statement, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2004, Title: Blank line not allowed after constructor initializer colon, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2005, Title: Blank line not allowed after conditional expression token, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE2006, Title: Blank line not allowed after arrow expression clause token, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0001, Title: StringComparison is missing, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0002, Title: IEqualityComparer<string> or IComparer<string> is missing, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0003, Title: Add parameter name to improve readability, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0004, Title: Use Task.ConfigureAwait, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0005, Title: Use Array.Empty<T>(), Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0006, Title: Use String.Equals instead of equality operator, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0007, Title: Add a comma after the last value, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0008, Title: Add StructLayoutAttribute, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0009, Title: Add regex evaluation timeout, Category: Security, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0010, Title: Mark attributes with AttributeUsageAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0011, Title: IFormatProvider is missing, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0012, Title: Do not raise reserved exception type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0013, Title: Types should not extend System.ApplicationException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0014, Title: Do not raise System.ApplicationException type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0015, Title: Specify the parameter name in ArgumentException, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0016, Title: Prefer using collection abstraction instead of implementation, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0017, Title: Abstract types should not have public or internal constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0018, Title: Do not declare static members on generic types (deprecated; use CA1000 instead), Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0019, Title: Use EventArgs.Empty, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0020, Title: Use direct methods instead of LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0021, Title: Use StringComparer.GetHashCode instead of string.GetHashCode, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0022, Title: Return Task.FromResult instead of returning null, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0023, Title: Add RegexOptions.ExplicitCapture, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0024, Title: Use an explicit StringComparer when possible, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0025, Title: Implement the functionality instead of throwing NotImplementedException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0026, Title: Fix TODO comment, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
+- {Id: MA0027, Title: Prefer rethrowing an exception implicitly, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0028, Title: Optimize StringBuilder usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0029, Title: Combine LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0030, Title: Remove useless OrderBy call, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0031, Title: Optimize Enumerable.Count() usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0032, Title: Use an overload with a CancellationToken argument, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0033, Title: Do not tag instance fields with ThreadStaticAttribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0035, Title: Do not use dangerous threading methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0036, Title: Make class static, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0037, Title: Remove empty statement, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0038, Title: 'Make method static (deprecated, use CA1822 instead)', Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0039, Title: Do not write your own certificate validation method, Category: Security, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0040, Title: Forward the CancellationToken parameter to methods that take one, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: MA0041, Title: 'Make property static (deprecated, use CA1822 instead)', Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0042, Title: Do not use blocking calls in an async method, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0043, Title: Use nameof operator in ArgumentException, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0044, Title: Remove useless ToString call, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0045, Title: Do not use blocking calls in a sync method (need to make calling method async), Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0046, Title: Use EventHandler<T> to declare events, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0047, Title: Declare types in namespaces, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0048, Title: File name must match type name, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0049, Title: Type name should not match containing namespace, Category: Design, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0050, Title: Validate arguments correctly in iterator methods, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0051, Title: Method is too long, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: MA0052, Title: Replace constant Enum.ToString with nameof, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0053, Title: Make class sealed, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0054, Title: Embed the caught exception as innerException, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0055, Title: Do not use finalizer, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0056, Title: Do not call overridable members in constructor, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0057, Title: Class name should end with 'Attribute', Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0058, Title: Class name should end with 'Exception', Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0059, Title: Class name should end with 'EventArgs', Category: Naming, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0060, Title: The value returned by Stream.Read/Stream.ReadAsync is not used, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0061, Title: Method overrides should not change default values, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0062, Title: Non-flags enums should not be marked with "FlagsAttribute", Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0063, Title: Use Where before OrderBy, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0064, Title: Avoid locking on publicly accessible instance, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0065, Title: Default ValueType.Equals or HashCode is used for struct equality, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0066, Title: Hash table unfriendly type is used in a hash table, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0067, Title: Use Guid.Empty, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0068, Title: Invalid parameter name for nullable attribute, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0069, Title: Non-constant static fields should not be visible, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0070, Title: Obsolete attributes should include explanations, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0071, Title: Avoid using redundant else, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0072, Title: Do not throw from a finally block, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0073, Title: Avoid comparison with bool constant, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0074, Title: Avoid implicit culture-sensitive methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0075, Title: Do not use implicit culture-sensitive ToString, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0076, Title: Do not use implicit culture-sensitive ToString in interpolated strings, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0077, Title: A class that provides Equals(T) should implement IEquatable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0078, Title: Use 'Cast' instead of 'Select' to cast, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0079, Title: Forward the CancellationToken using .WithCancellation(), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0080, Title: Use a cancellation token using .WithCancellation(), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0081, Title: Method overrides should not omit params keyword, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0082, Title: NaN should not be used in comparisons, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0083, Title: ConstructorArgument parameters should exist in constructors, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0084, Title: Local variables should not hide other symbols, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0085, Title: Anonymous delegates should not be used to unsubscribe from Events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0086, Title: Do not throw from a finalizer, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0087, Title: 'Parameters with [DefaultParameterValue] attributes should also be marked [Optional]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0088, Title: 'Use [DefaultParameterValue] instead of [DefaultValue]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0089, Title: Optimize string method usage, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0090, Title: Remove empty else/finally block, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0091, Title: Sender should be 'this' for instance events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0092, Title: Sender should be 'null' for static events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0093, Title: EventArgs should not be null, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0094, Title: A class that provides CompareTo(T) should implement IComparable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0095, Title: A class that implements IEquatable<T> should override Equals(object), Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0096, Title: A class that implements IComparable<T> should also implement IEquatable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0097, Title: A class that implements IComparable<T> or IComparable should override comparison operators, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0098, Title: Use indexer instead of LINQ methods, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0099, Title: Use Explicit enum value instead of 0, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0100, Title: Await task before disposing of resources, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0101, Title: String contains an implicit end of line character, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: MA0102, Title: Make member readonly, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0103, Title: Use SequenceEqual instead of equality operator, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0104, Title: Do not create a type with a name from the BCL, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0105, Title: Use the lambda parameters instead of using a closure, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0106, Title: Avoid closure by using an overload with the 'factoryArgument' parameter, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0107, Title: Do not use culture-sensitive object.ToString, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0108, Title: Remove redundant argument value, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0109, Title: Consider adding an overload with a Span<T> or Memory<T>, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0110, Title: Use the Regex source generator, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0111, Title: Use string.Create instead of FormattableString, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0112, Title: Use 'Count > 0' instead of 'Any()', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0113, Title: Use DateTime.UnixEpoch, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0114, Title: Use DateTimeOffset.UnixEpoch, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0115, Title: Unknown component parameter, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0116, Title: 'Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0117, Title: 'Parameters with [EditorRequired] attributes should also be marked as [Parameter]', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0118, Title: '[JSInvokable] methods must be public', Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0119, Title: JSRuntime must not be used in OnInitialized or OnInitializedAsync, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0120, Title: Use InvokeVoidAsync when the returned value is not used, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0121, Title: Do not overwrite parameter value, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0122, Title: 'Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)', Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0123, Title: Sequence number must be a constant, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0124, Title: Log parameter type is not valid, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0125, Title: The list of log parameter types contains an invalid type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0126, Title: The list of log parameter types contains a duplicate, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0127, Title: Use String.Equals instead of is pattern, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0128, Title: Use 'is' operator instead of SequenceEqual, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0129, Title: Await task in using statement, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0130, Title: GetType() should not be used on System.Type instances, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0131, Title: ArgumentNullException.ThrowIfNull should not be used with non-nullable types, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0132, Title: Do not convert implicitly to DateTimeOffset, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0133, Title: Use DateTimeOffset instead of relying on the implicit conversion, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0134, Title: Observe result of async calls, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0135, Title: The log parameter has no configured type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: MA0136, Title: Raw String contains an implicit end of line character, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: MA0137, Title: Use 'Async' suffix when a method returns an awaitable type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0138, Title: Do not use 'Async' suffix when a method does not return an awaitable type, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0139, Title: Log parameter type is not valid, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0140, Title: Both if and else branch have identical code, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0141, Title: Use pattern matching instead of inequality operators for null check, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0142, Title: Use pattern matching instead of equality operators for null check, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0143, Title: Primary constructor parameters should be readonly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0144, Title: Use System.OperatingSystem to check the current OS, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0145, Title: 'Signature for [UnsafeAccessorAttribute] method is not valid', Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0146, Title: Name must be set explicitly on local functions, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0147, Title: Avoid async void method for delegate, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0148, Title: Use pattern matching instead of equality operators for discrete value, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0149, Title: Use pattern matching instead of inequality operators for discrete value, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0150, Title: Do not call the default object.ToString explicitly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0151, Title: DebuggerDisplay must contain valid members, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0152, Title: Use Unwrap instead of using await twice, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0153, Title: Do not log symbols decorated with DataClassificationAttribute directly, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0154, Title: Use langword in XML comment, Category: Design, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0155, Title: Do not use async void methods, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0156, Title: Use 'Async' suffix when a method returns IAsyncEnumerable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0157, Title: Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T>, Category: Design, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: MA0158, Title: Use System.Threading.Lock, Category: Performance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: MA0159, Title: Use 'Order' instead of 'OrderBy', Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: MA0160, Title: Use ContainsKey instead of TryGetValue, Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: POLYSP0003, Title: Unsupported C# language version, Category: Microsoft.CodeAnalysis.CSharp.CSharpParseOptions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1001, Title: Add braces (when expression spans over multiple lines), Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1002, Title: Remove braces, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1002FadeOut, Title: Remove braces, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1003, Title: Add braces to if-else (when expression spans over multiple lines), Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1004, Title: Remove braces from if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1004FadeOut, Title: Remove braces from if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1005, Title: Simplify nested using statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1005FadeOut, Title: Simplify nested using statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1006, Title: Merge 'else' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1006FadeOut, Title: Merge 'else' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1007, Title: Add braces, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1008, Title: "[deprecated] Use explicit type instead of 'var' (when the type is not obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1009, Title: "[deprecated] Use explicit type instead of 'var' (foreach variable)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1010, Title: "[deprecated] Use 'var' instead of explicit type (when the type is obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1012, Title: "[deprecated] Use explicit type instead of 'var' (when the type is obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1013, Title: Use predefined type, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1014, Title: Use explicitly/implicitly typed array, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1015, Title: Use nameof operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1015FadeOut, Title: Use nameof operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1016, Title: Use block body or expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1018, Title: Add/remove accessibility modifiers, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1019, Title: Order modifiers, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1020, Title: 'Simplify Nullable<T> to T?', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1021, Title: Convert lambda expression body to expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1021FadeOut, Title: Convert lambda expression body to expression body, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1031, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1031FadeOut, Title: Remove unnecessary braces in switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1032, Title: Remove redundant parentheses, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1032FadeOut, Title: Remove redundant parentheses, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1033, Title: Remove redundant boolean literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1034, Title: Remove redundant 'sealed' modifier, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1035, Title: '[deprecated] Remove redundant comma in initializer', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1036, Title: Remove unnecessary blank line, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1037, Title: Remove trailing white-space, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1038, Title: '[deprecated] Remove empty statement', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1039, Title: Remove argument list from attribute, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1040, Title: "[deprecated] Remove empty 'else' clause", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1041, Title: '[deprecated] Remove empty initializer', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1042, Title: Remove enum default underlying type, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1043, Title: Remove 'partial' modifier from type with a single part, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1044, Title: Remove original exception from throw statement, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1046, Title: Asynchronous method name should end with 'Async', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1047, Title: Non-asynchronous method name should not end with 'Async', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1047FadeOut, Title: Non-asynchronous method name should not end with 'Async', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1048, Title: Use lambda expression instead of anonymous method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1048FadeOut, Title: Use lambda expression instead of anonymous method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1049, Title: Simplify boolean comparison, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1049FadeOut, Title: Simplify boolean comparison, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1050, Title: Include/omit parentheses when creating new object, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1051, Title: Add/remove parentheses from condition in conditional operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1052, Title: Declare each attribute separately, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1055, Title: Unnecessary semicolon at the end of declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1056, Title: Avoid usage of using alias directive, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1058, Title: Use compound assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1058FadeOut, Title: Use compound assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1059, Title: Avoid locking on publicly accessible instance, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1060, Title: Declare each type in separate file, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1061, Title: Merge 'if' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1061FadeOut, Title: Merge 'if' with nested 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1063, Title: '[deprecated] Avoid usage of do statement to create an infinite loop', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1064, Title: '[deprecated] Avoid usage of for statement to create an infinite loop', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1065, Title: '[deprecated] Avoid usage of while statement to create an infinite loop', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1066, Title: "[deprecated] Remove empty 'finally' clause", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1066FadeOut, Title: "[deprecated] Remove empty 'finally' clause", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1068, Title: Simplify logical negation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1069, Title: Remove unnecessary case label, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1070, Title: Remove redundant default switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1071, Title: Remove redundant base constructor call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1072, Title: '[deprecated] Remove empty namespace declaration', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1073, Title: Convert 'if' to 'return' statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1073FadeOut, Title: Convert 'if' to 'return' statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1074, Title: Remove redundant constructor, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1075, Title: Avoid empty catch clause that catches System.Exception, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1077, Title: Optimize LINQ method call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1078, Title: Use "" or 'string.Empty', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1079, Title: Throwing of new NotImplementedException, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1080, Title: Use 'Count/Length' property instead of 'Any' method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1081, Title: Split variable declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1084, Title: Use coalesce expression instead of conditional expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1085, Title: Use auto-implemented property, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1085FadeOut, Title: Use auto-implemented property, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1089, Title: Use --/++ operator instead of assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1089FadeOut, Title: Use --/++ operator instead of assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1090, Title: Add/remove 'ConfigureAwait(false)' call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1091, Title: '[deprecated] Remove empty region', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1091FadeOut, Title: '[deprecated] Remove empty region', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1093, Title: File contains no code, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1094, Title: Declare using directive on top level, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1096, Title: Use 'HasFlag' method or bitwise operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1097, Title: Remove redundant 'ToString' call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1098, Title: Constant values should be placed on right side of comparisons, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1099, Title: Default label should be the last label in a switch section, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1100, Title: '[deprecated] Format documentation summary on a single line', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1101, Title: '[deprecated] Format documentation summary on multiple lines', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1102, Title: Make class static, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1103, Title: Convert 'if' to assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1104, Title: Simplify conditional expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1105, Title: Unnecessary interpolation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1106, Title: '[deprecated] Remove empty destructor', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1107, Title: Remove redundant 'ToCharArray' call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1108, Title: Add 'static' modifier to all partial class declarations, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1110, Title: Declare type inside namespace, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1111, Title: Add braces to switch section with multiple statements, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1112, Title: Combine 'Enumerable.Where' method chain, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1112FadeOut, Title: Combine 'Enumerable.Where' method chain, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1113, Title: Use 'string.IsNullOrEmpty' method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1114, Title: Remove redundant delegate creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1114FadeOut, Title: Remove redundant delegate creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1118, Title: Mark local variable as const, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1123, Title: Add parentheses when necessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1124, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1124FadeOut, Title: Inline local variable, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1126, Title: Add braces to if-else, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1128, Title: Use coalesce expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1129, Title: Remove redundant field initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1130, Title: Bitwise operation on enum without Flags attribute, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1132, Title: Remove redundant overriding member, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1133, Title: Remove redundant Dispose/Close call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1134, Title: Remove redundant statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1135, Title: Declare enum member with zero value (when enum has FlagsAttribute), Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1136, Title: Merge switch sections with equivalent content, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1138, Title: Add summary to documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1139, Title: Add summary element to documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1140, Title: Add exception to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1141, Title: Add 'param' element to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1142, Title: Add 'typeparam' element to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1143, Title: Simplify coalesce expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1145, Title: Remove redundant 'as' operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1146, Title: Use conditional access, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1151, Title: Remove redundant cast, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1154, Title: Sort enum members, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1155, Title: Use StringComparison when comparing strings, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1156, Title: Use string.Length instead of comparison with empty string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1157, Title: Composite enum value contains undefined flag, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1158, Title: Static member in generic type should use a type parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1159, Title: Use EventHandler<T>, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1160, Title: Abstract type should not have public constructors, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1161, Title: Enum should declare explicit values, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1162, Title: Avoid chain of assignments, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1163, Title: Unused parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1164, Title: Unused type parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1165, Title: Unconstrained type parameter checked for null, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1166, Title: Value type object is never equal to null, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1168, Title: Parameter name differs from base name, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1169, Title: Make field read-only, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1170, Title: Use read-only auto-implemented property, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1171, Title: Simplify lazy initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1172, Title: Use 'is' operator instead of 'as' operator, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1173, Title: Use coalesce expression instead of 'if', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1174, Title: Remove redundant async/await, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1174FadeOut, Title: Remove redundant async/await, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1175, Title: Unused 'this' parameter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1176, Title: "[deprecated] Use 'var' instead of explicit type (when the type is not obvious)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1177, Title: "[deprecated] Use 'var' instead of explicit type (in foreach)", Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1179, Title: Unnecessary assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1180, Title: Inline lazy initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1181, Title: Convert comment to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1182, Title: Remove redundant base interface, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1186, Title: Use Regex instance instead of static method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1187, Title: Use constant instead of field, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1188, Title: Remove redundant auto-property initialization, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1189, Title: Add or remove region name, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1190, Title: Join string expressions, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1191, Title: Declare enum value as combination of names, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1192, Title: Unnecessary usage of verbatim string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1193, Title: Overriding member should not change 'params' modifier, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1194, Title: Implement exception constructors, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1195, Title: Use ^ operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1196, Title: Call extension method as instance method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1197, Title: Optimize StringBuilder.Append/AppendLine call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1198, Title: Avoid unnecessary boxing of value type, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1199, Title: Unnecessary null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1200, Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1201, Title: Use method chaining, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1202, Title: Avoid NullReferenceException, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1203, Title: Use AttributeUsageAttribute, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1204, Title: Use EventArgs.Empty, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1205, Title: Order named arguments according to the order of parameters, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1206, Title: Use conditional access instead of conditional expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1207, Title: Use anonymous function or method group, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1208, Title: Reduce 'if' nesting, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1209, Title: Order type parameter constraints, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1210, Title: Return completed task instead of returning null, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1211, Title: Remove unnecessary 'else', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1212, Title: Remove redundant assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1212FadeOut, Title: Remove redundant assignment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1213, Title: Remove unused member declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1214, Title: Unnecessary interpolated string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1214FadeOut, Title: Unnecessary interpolated string, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1215, Title: Expression is always equal to true/false, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1216, Title: Unnecessary unsafe context, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1217, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1217FadeOut, Title: Convert interpolated string to concatenation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1218, Title: Simplify code branching, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1220, Title: Use pattern matching instead of combination of 'is' operator and cast operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1221, Title: Use pattern matching instead of combination of 'as' operator and null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1222, Title: Merge preprocessor directives, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1223, Title: Mark publicly visible type with DebuggerDisplay attribute, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1224, Title: Make method an extension method, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1225, Title: Make class sealed, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1226, Title: Add paragraph to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1227, Title: Validate arguments correctly, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1228, Title: Unused element in a documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1229, Title: Use async/await when necessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1230, Title: Unnecessary explicit use of enumerator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1231, Title: Make parameter ref read-only, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RCS1232, Title: Order elements in documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1233, Title: Use short-circuiting operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1234, Title: Duplicate enum value, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1235, Title: Optimize method call, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1236, Title: Use exception filter, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1237, Title: '[deprecated] Use bit shift operator', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1238, Title: 'Avoid nested ?: operators', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1239, Title: Use 'for' statement instead of 'while' statement, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1240, Title: Operator is unnecessary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1241, Title: Implement non-generic counterpart, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1242, Title: Do not pass non-read-only struct by read-only reference, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1243, Title: Duplicate word in a comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1244, Title: Simplify 'default' expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: RCS1246, Title: Use element access, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1247, Title: Fix documentation comment tag, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1248, Title: Normalize null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1249, Title: Unnecessary null-forgiving operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1250, Title: Use implicit/explicit object creation, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1251, Title: Remove unnecessary braces from record declaration, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1252, Title: Normalize usage of infinite loop, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1253, Title: Format documentation comment summary, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1254, Title: Normalize format of enum flag value, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1255, Title: Simplify argument null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1256, Title: Invalid argument null check, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1257, Title: Use enum field explicitly, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1258, Title: Unnecessary enum flag, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1259, Title: Remove empty syntax, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1260, Title: Add/remove trailing comma, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1261, Title: Resource can be disposed asynchronously, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1262, Title: Unnecessary raw string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1263, Title: Invalid reference in a documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RCS1264, Title: Use 'var' or explicit type, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RCS1265, Title: Remove redundant catch block, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1266, Title: Use raw string literal, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1267, Title: Use string interpolation instead of 'string.Concat', Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1268, Title: Simplify numeric comparison, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RemoveUnnecessaryImportsFixable, Title: '', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: ROS0002, Title: Analyzer option is obsolete, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: ROS0003, Title: Analyzer requires config option to be specified, Category: '', DefaultSeverity: Note, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: RS1001, Title: Missing diagnostic analyzer attribute, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1002, Title: Missing kind argument when registering an analyzer action, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1003, Title: Unsupported SymbolKind argument when registering a symbol analyzer action, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1004, Title: Recommend adding language support to diagnostic analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1005, Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1006, Title: Invalid type argument for DiagnosticAnalyzer's Register method, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1007, Title: Provide localizable arguments to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisLocalization, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1008, Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1009, Title: Only internal implementations of this interface are allowed, Category: MicrosoftCodeAnalysisCompatibility, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1010, Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1011, Title: Use code actions that have a unique EquivalenceKey for FixAll occurrences support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1012, Title: Start action has no registered actions, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1013, Title: Start action has no registered non-end actions, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1014, Title: Do not ignore values returned by methods on immutable objects, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1015, Title: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisDocumentation, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1016, Title: Code fix providers should provide FixAll support, Category: Correctness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1017, Title: DiagnosticId for analyzers must be a non-null constant, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1018, Title: DiagnosticId for analyzers must be in specified format, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1019, Title: DiagnosticId must be unique across analyzers, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1020, Title: Category for analyzers must be from the specified values, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1021, Title: Invalid entry in analyzer category and diagnostic ID range specification file, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1022, Title: Do not use types from Workspaces assembly in an analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1023, Title: Upgrade MSBuildWorkspace, Category: Library, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1024, Title: Symbols should be compared for equality, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1025, Title: Configure generated code analysis, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: RS1026, Title: Enable concurrent execution, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: RS1027, Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1028, Title: Provide non-null 'customTags' value to diagnostic descriptor constructor, Category: MicrosoftCodeAnalysisDocumentation, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: RS1029, Title: Do not use reserved diagnostic IDs, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1030, Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1031, Title: Define diagnostic title correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1032, Title: Define diagnostic message correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1033, Title: Define diagnostic description correctly, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1034, Title: Prefer 'IsKind' for checking syntax kinds, Category: MicrosoftCodeAnalysisPerformance, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1035, Title: Do not use APIs banned for analyzers, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1036, Title: Specify analyzer banned API enforcement setting, Category: MicrosoftCodeAnalysisCorrectness, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS1037, Title: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor, Category: MicrosoftCodeAnalysisDesign, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2000, Title: Add analyzer diagnostic IDs to analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2001, Title: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2002, Title: Do not add removed analyzer diagnostic IDs to unshipped analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2003, Title: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2004, Title: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2005, Title: Remove duplicate entries for diagnostic ID in the same analyzer release, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2006, Title: Remove duplicate entries for diagnostic ID between analyzer releases, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2007, Title: Invalid entry in analyzer release file, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: RS2008, Title: Enable analyzer release tracking, Category: MicrosoftCodeAnalysisReleaseTracking, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S100, Title: Methods and properties should be named in PascalCase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S1006, Title: Method overrides should not change parameter defaults, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S101, Title: Types should be named in PascalCase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S103, Title: Lines should not be too long, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S104, Title: Files should not have too many lines of code, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1048, Title: Finalizers should not throw exceptions, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S105, Title: Tabulation characters should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S106, Title: Standard outputs should not be used directly to log anything, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1066, Title: Mergeable "if" statements should be combined, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1067, Title: Expressions should not be too complex, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S107, Title: Methods should not have too many parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1075, Title: URIs should not be hardcoded, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S108, Title: Nested blocks of code should not be left empty, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S109, Title: Magic numbers should not be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S110, Title: Inheritance tree of classes should not be too deep, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1104, Title: Fields should not have public accessibility, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1109, Title: A close curly brace should be located at the beginning of a line, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1110, Title: Redundant pairs of parentheses should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1116, Title: Empty statements should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1117, Title: Local variables should not shadow class fields or properties, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1118, Title: Utility classes should not have public constructors, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S112, Title: General or reserved exceptions should never be thrown, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1121, Title: Assignments should not be made from within sub-expressions, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1123, Title: '"Obsolete" attributes should include explanations', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1125, Title: Boolean literals should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1128, Title: Unnecessary "using" should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S113, Title: Files should end with a newline, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1133, Title: Deprecated code should be removed, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1134, Title: Track uses of "FIXME" tags, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1135, Title: Track uses of "TODO" tags, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: false}
+- {Id: S1144, Title: Unused private types or members should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1147, Title: Exit methods should not be called, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1151, Title: '"switch case" clauses should not have too many lines of code', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1155, Title: '"Any()" should be used to test for emptiness', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1163, Title: Exceptions should not be thrown in finally blocks, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1168, Title: Empty arrays and collections should be returned instead of null, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1172, Title: Unused method parameters should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1185, Title: Overriding members should do more than simply call the same member in the base class, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1186, Title: Methods should not be empty, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1192, Title: String literals should not be duplicated, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1199, Title: Nested code blocks should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1200, Title: Classes should not be coupled to too many other classes, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1206, Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S121, Title: Control structures should use curly braces, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1210, Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1215, Title: '"GC.Collect" should not be called', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S122, Title: Statements should be on separate lines, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1226, Title: "Method parameters, caught exceptions and foreach variables' initial values should not be ignored", Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1227, Title: break statements should not be used except for switch cases, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1244, Title: Floating point numbers should not be tested for equality, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S125, Title: Sections of code should not be commented out, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S126, Title: '"if ... else if" constructs should end with "else" clauses', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1264, Title: A "while" loop should be used instead of a "for" loop, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S127, Title: '"for" loop stop conditions should be invariant', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1301, Title: '"switch" statements should have at least 3 "case" clauses', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1309, Title: Track uses of in-source issue suppressions, Category: Info Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S131, Title: '"switch/Select" statements should contain a "default/Case Else" clauses', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1312, Title: Logger fields should be "private static readonly", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1313, Title: Using hardcoded IP addresses is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S134, Title: 'Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S138, Title: Functions should not have too many lines of code, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1449, Title: Culture should be specified for "string" operations, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1450, Title: Private fields only used as local variables in methods should become local variables, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1451, Title: Track lack of copyright and license headers, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1479, Title: '"switch" statements with many "case" clauses should have only one statement', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1481, Title: Unused local variables should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1541, Title: Methods and properties should not be too complex, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1607, Title: Tests should not be ignored, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1643, Title: Strings should not be concatenated using '+' in a loop, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1656, Title: Variables should not be self-assigned, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1659, Title: Multiple variables should not be declared on the same line, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1694, Title: An abstract class should have both abstract and concrete methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1696, Title: NullReferenceException should not be caught, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1698, Title: '"==" should not be used when "Equals" is overridden', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1699, Title: Constructors should only call non-overridable methods, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1751, Title: Loops with at most one iteration should be refactored, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1764, Title: Identical expressions should not be used on both sides of operators, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1821, Title: '"switch" statements should not be nested', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1848, Title: Objects should not be created to be dropped immediately without being used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1854, Title: Unused assignments should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1858, Title: '"ToString()" calls should not be redundant', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S1862, Title: Related "if/else if" statements should not have the same condition, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1871, Title: Two branches in a conditional structure should not have exactly the same implementation, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1905, Title: Redundant casts should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1939, Title: Inheritance list should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1940, Title: Boolean checks should not be inverted, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1944, Title: Invalid casts should be avoided, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S1994, Title: "\"for\" loop increment clauses should modify the loops' counters", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2053, Title: Password hashing functions should use an unpredictable salt, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2068, Title: Hard-coded credentials are security-sensitive, Category: Blocker Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2077, Title: Formatting SQL queries is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2092, Title: Creating cookies without the "secure" flag is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2094, Title: Classes should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2114, Title: Collections should not be passed as arguments to their own methods, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2115, Title: A secure password should be used when connecting to a database, Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2123, Title: Values should not be uselessly incremented, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2139, Title: Exceptions should be either logged or rethrown but not both, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2148, Title: Underscores should be used to make large numbers readable, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2156, Title: '"sealed" classes should not have "protected" members', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2166, Title: Classes named like "Exception" should extend "Exception" or a subclass, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2178, Title: Short-circuit logic should be used in boolean contexts, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2183, Title: Integral numbers should not be shifted by zero or more than their number of bits-1, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2184, Title: Results of integer division should not be assigned to floating point variables, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2187, Title: Test classes should contain at least one test case, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2190, Title: Loops and recursions should not be infinite, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2197, Title: Modulus results should not be checked for direct equality, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2198, Title: Unnecessary mathematical comparisons should not be made, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2201, Title: Methods without side effects should not have their return values ignored, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2219, Title: Runtime type checking should be simplified, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2221, Title: '"Exception" should not be caught', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2222, Title: Locks should be released on all paths, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2223, Title: Non-constant static fields should not be visible, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2225, Title: '"ToString()" method should not return null', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2234, Title: Arguments should be passed in the same order as the method parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2245, Title: Using pseudorandom number generators (PRNGs) is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2251, Title: A "for" loop update clause should move the counter in the right direction, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2252, Title: For-loop conditions should be true at least once, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2257, Title: Using non-standard cryptographic algorithms is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2259, Title: Null pointers should not be dereferenced, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2275, Title: Composite format strings should not lead to unexpected behavior at runtime, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2290, Title: Field-like events should not be virtual, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2291, Title: Overflow checking should not be disabled for "Enumerable.Sum", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2292, Title: Trivial properties should be auto-implemented, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2302, Title: '"nameof" should be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2306, Title: '"async" and "await" should not be used as identifiers', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2325, Title: Methods and properties that don't access instance data should be static, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2326, Title: Unused type parameters should be removed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2327, Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2328, Title: '"GetHashCode" should not reference mutable fields', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2330, Title: Array covariance should not be used, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2333, Title: Redundant modifiers should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2339, Title: Public constant members should not be used, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2342, Title: Enumeration types should comply with a naming convention, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2344, Title: Enumeration type names should not have "Flags" or "Enum" suffixes, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2345, Title: Flags enumerations should explicitly initialize all their members, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2346, Title: Flags enumerations zero-value members should be named "None", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2357, Title: Fields should be private, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2360, Title: Optional parameters should not be used, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2365, Title: Properties should not make collection or array copies, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2368, Title: Public methods should not have multidimensional array parameters, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2372, Title: Exceptions should not be thrown from property getters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2376, Title: Write-only properties should not be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2386, Title: Mutable fields should not be "public static", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2387, Title: Child class fields should not shadow parent class fields, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2436, Title: Types and methods should not have too many generic parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2437, Title: Unnecessary bit operations should not be performed, Category: Blocker Code Smell, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: S2445, Title: Blocks should be synchronized on read-only fields, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2479, Title: Whitespace and control characters in string literals should be explicit, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2486, Title: Generic exceptions should not be ignored, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2551, Title: Shared resources should not be used for locking, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2583, Title: Conditionally executed code should be reachable, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2589, Title: Boolean expressions should not be gratuitous, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2612, Title: Setting loose file permissions is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2629, Title: Logging templates should be constant, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2674, Title: The length returned from a stream read should be checked, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2681, Title: Multiline blocks should be enclosed in curly braces, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2688, Title: '"NaN" should not be used in comparisons', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2692, Title: '"IndexOf" checks should not be for positive numbers', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2696, Title: Instance members should not write to "static" fields, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2699, Title: Tests should include assertions, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2701, Title: Literal boolean values should not be used in assertions, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2737, Title: '"catch" clauses should do more than rethrow', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2743, Title: Static fields should not be used in generic types, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2755, Title: XML parsers should not be vulnerable to XXE attacks, Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2757, Title: Non-existent operators like "=+" should not be used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2760, Title: Sequential tests should not check the same condition, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2761, Title: Doubled prefix operators "!!" and "~~" should not be used, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2857, Title: SQL keywords should be delimited by whitespace, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2925, Title: '"Thread.Sleep" should not be used in tests', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2930, Title: '"IDisposables" should be disposed', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2931, Title: Classes with "IDisposable" members should implement "IDisposable", Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2933, Title: Fields that are only assigned in the constructor should be "readonly", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2934, Title: Property assignments should not be made for "readonly" fields not constrained to reference types, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2952, Title: Classes should "Dispose" of members from the classes' own "Dispose" methods, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S2953, Title: Methods named "Dispose" should implement "IDisposable.Dispose", Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2955, Title: Generic parameters not constrained to reference types should not be compared to "null", Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2970, Title: Assertions should be complete, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2971, Title: LINQ expressions should be simplified, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2995, Title: '"Object.ReferenceEquals" should not be used for value types', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2996, Title: '"ThreadStatic" fields should not be initialized', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S2997, Title: '"IDisposables" created in a "using" statement should not be returned', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3005, Title: '"ThreadStatic" should not be used on non-static fields', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3010, Title: Static fields should not be updated in constructors, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3011, Title: 'Reflection should not be used to increase accessibility of classes, methods, or fields', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3052, Title: Members should not be initialized to default values, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3059, Title: Types should not have members with visibility set higher than the type's visibility, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3060, Title: '"is" should not be used with "this"', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3063, Title: '"StringBuilder" data should be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3168, Title: '"async" methods should not return "void"', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3169, Title: Multiple "OrderBy" calls should not be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3172, Title: Delegates should not be subtracted, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3215, Title: '"interface" instances should not be cast to concrete types', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3216, Title: '"ConfigureAwait(false)" should be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3217, Title: '"Explicit" conversions of "foreach" loops should not be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3218, Title: Inner class members should not shadow outer class "static" or type members, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3220, Title: Method calls should not resolve ambiguously to overloads with "params", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3234, Title: '"GC.SuppressFinalize" should not be invoked for types without destructors', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3235, Title: Redundant parentheses should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3236, Title: Caller information arguments should not be provided explicitly, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3237, Title: '"value" contextual keyword should be used', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3240, Title: The simplest possible condition syntax should be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3241, Title: Methods should not return values that are never used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3242, Title: Method parameters should be declared with base types, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3244, Title: Anonymous delegates should not be used to unsubscribe from Events, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3246, Title: Generic type parameters should be co/contravariant when possible, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3247, Title: Duplicate casts should not be made, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3249, Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals", Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3251, Title: Implementations should be provided for "partial" methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3253, Title: Constructor and destructor declarations should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3254, Title: Default parameter values should not be passed as arguments, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3256, Title: '"string.IsNullOrEmpty" should be used', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3257, Title: Declarations and initializations should be as concise as possible, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3260, Title: Non-derived "private" classes and records should be "sealed", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3261, Title: Namespaces should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3262, Title: '"params" should be used on overrides', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3263, Title: 'Static fields should appear in the order they must be initialized ', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3264, Title: Events should be invoked, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3265, Title: Non-flags enums should not be used in bitwise operations, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3267, Title: Loops should be simplified with "LINQ" expressions, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3329, Title: Cipher Block Chaining IVs should be unpredictable, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3330, Title: Creating cookies without the "HttpOnly" flag is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3343, Title: Caller information parameters should come at the end of the parameter list, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3346, Title: Expressions used in "Debug.Assert" should not produce side effects, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3353, Title: Unchanged variables should be marked as "const", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3358, Title: Ternary operators should not be nested, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3363, Title: Date and time should not be used as a type for primary keys, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3366, Title: '"this" should not be exposed from constructors', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3376, Title: 'Attribute, EventArgs, and Exception type names should end with the type being extended', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3397, Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3398, Title: '"private" methods called only by inner classes should be moved to those classes', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3400, Title: Methods should not return constants, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3415, Title: Assertion arguments should be passed in the correct order, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3416, Title: Loggers should be named for their enclosing types, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3427, Title: Method overloads with default parameter values should not overlap, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3431, Title: '"[ExpectedException]" should not be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3433, Title: Test method signatures should be correct, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3440, Title: Variables should not be checked against the values they're about to be assigned, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3441, Title: Redundant property names should be omitted in anonymous classes, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3442, Title: '"abstract" classes should not have "public" constructors', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3443, Title: Type should not be examined on "System.Type" instances, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3444, Title: Interfaces should not simply inherit from base interfaces with colliding members, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3445, Title: Exceptions should not be explicitly rethrown, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3447, Title: '"[Optional]" should not be used on "ref" or "out" parameters', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3449, Title: Right operands of shift operators should be integers, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3450, Title: 'Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3451, Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3453, Title: Classes should not have only "private" constructors, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3456, Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3457, Title: Composite format strings should be used correctly, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3458, Title: Empty "case" clauses that fall through to the "default" should be omitted, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3459, Title: Unassigned members should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3464, Title: Type inheritance should not be recursive, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3466, Title: Optional parameters should be passed to "base" calls, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3532, Title: Empty "default" clauses should be removed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3597, Title: '"ServiceContract" and "OperationContract" attributes should be used together', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3598, Title: One-way "OperationContract" methods should have "void" return type, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3600, Title: '"params" should not be introduced on overrides', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3603, Title: 'Methods with "Pure" attribute should return a value ', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3604, Title: Member initializer values should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3610, Title: Nullable type comparison should not be redundant, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3626, Title: Jump statements should not be redundant, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3655, Title: Empty nullable value should not be accessed, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3717, Title: Track use of "NotImplementedException", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3776, Title: Cognitive Complexity of methods should not be too high, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3869, Title: '"SafeHandle.DangerousGetHandle" should not be called', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3871, Title: Exception types should be "public", Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3872, Title: Parameter names should not duplicate the names of their methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3874, Title: '"out" and "ref" parameters should not be used', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3875, Title: '"operator==" should not be overloaded on reference types', Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3876, Title: Strings or integral types should be used for indexers, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3877, Title: Exceptions should not be thrown from unexpected methods, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3878, Title: Arrays should not be created for params parameters, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3880, Title: Finalizers should not be empty, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3881, Title: '"IDisposable" should be implemented correctly', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3884, Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used', Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3885, Title: '"Assembly.Load" should be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3887, Title: 'Mutable, non-private fields should not be "readonly"', Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3889, Title: '"Thread.Resume" and "Thread.Suspend" should not be used', Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3897, Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3898, Title: Value types should implement "IEquatable<T>", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3900, Title: Arguments of public methods should be validated against null, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S3902, Title: '"Assembly.GetExecutingAssembly" should not be called', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3903, Title: Types should be defined in named namespaces, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3904, Title: Assemblies should have version information, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3906, Title: Event Handlers should have the correct signature, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3908, Title: Generic event handlers should be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3909, Title: Collections should implement the generic interface, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3923, Title: All branches in a conditional structure should not have exactly the same implementation, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3925, Title: '"ISerializable" should be implemented correctly', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3926, Title: Deserialization methods should be provided for "OptionalField" members, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3927, Title: Serialization event handlers should be implemented correctly, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3928, Title: 'Parameter names used into ArgumentException constructors should match an existing one ', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3937, Title: Number patterns should be regular, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3949, Title: Calculations should not overflow, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3956, Title: '"Generic.List" instances should not be part of public APIs', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3962, Title: '"static readonly" constants should be "const" instead', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3963, Title: '"static" fields should be initialized inline', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3966, Title: Objects should not be disposed more than once, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3967, Title: Multidimensional arrays should not be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3971, Title: '"GC.SuppressFinalize" should not be called', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3972, Title: Conditionals should start on new lines, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3973, Title: A conditionally executed single line should be denoted by indentation, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3981, Title: Collection sizes and array length comparisons should make sense, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3984, Title: Exceptions should not be created without being thrown, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S3990, Title: Assemblies should be marked as CLS compliant, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3992, Title: Assemblies should explicitly specify COM visibility, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3993, Title: Custom attributes should be marked with "System.AttributeUsageAttribute", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3994, Title: URI Parameters should not be strings, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3995, Title: URI return values should not be strings, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3996, Title: URI properties should not be strings, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3997, Title: String URI overloads should call "System.Uri" overloads, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S3998, Title: Threads should not lock on objects with weak identity, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4000, Title: Pointers to unmanaged memory should not be visible, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4002, Title: Disposable types should declare finalizers, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4004, Title: Collection properties should be readonly, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4005, Title: '"System.Uri" arguments should be used instead of strings', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4015, Title: Inherited member visibility should not be decreased, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4016, Title: Enumeration members should not be named "Reserved", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4017, Title: Method signatures should not contain nested generic types, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4018, Title: All type parameters should be used in the parameter list to enable type inference, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4019, Title: Base class methods should not be hidden, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4022, Title: Enumerations should have "Int32" storage, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4023, Title: Interfaces should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4025, Title: Child class fields should not differ from parent class fields only by capitalization, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4026, Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4027, Title: Exceptions should provide standard constructors, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4035, Title: Classes implementing "IEquatable<T>" should be sealed, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4036, Title: Searching OS commands in PATH is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4039, Title: Interface methods should be callable by derived types, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4040, Title: Strings should be normalized to uppercase, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4041, Title: Type names should not match namespaces, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4047, Title: Generics should be used when appropriate, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4049, Title: Properties should be preferred, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4050, Title: Operators should be overloaded consistently, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4052, Title: Types should not extend outdated base types, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4055, Title: Literals should not be passed as localized parameters, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4056, Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4057, Title: Locales should be set for data types, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4058, Title: Overloads with a "StringComparison" parameter should be used, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4059, Title: Property names should not match get methods, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4060, Title: Non-abstract attributes should be sealed, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4061, Title: '"params" should be used instead of "varargs"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4069, Title: Operator overloads should have named alternatives, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4070, Title: Non-flags enums should not be marked with "FlagsAttribute", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4136, Title: Method overloads should be grouped together, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4143, Title: Collection elements should not be replaced unconditionally, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4144, Title: Methods should not have identical implementations, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4158, Title: Empty collections should not be accessed or iterated, Category: Minor Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4159, Title: Classes should implement their "ExportAttribute" interfaces, Category: Blocker Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4200, Title: Native methods should be wrapped, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4201, Title: Null checks should not be combined with "is" operator checks, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4210, Title: Windows Forms entry points should be marked with STAThread, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4211, Title: Members should not have conflicting transparency annotations, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4212, Title: Serialization constructors should be secured, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4214, Title: '"P/Invoke" methods should not be visible', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4220, Title: Events should have proper arguments, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4225, Title: Extension methods should not extend "object", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4226, Title: Extensions should be in separate namespaces, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4260, Title: '"ConstructorArgument" parameters should exist in constructors', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4261, Title: Methods should be named according to their synchronicities, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4275, Title: Getters and setters should access the expected fields, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4277, Title: '"Shared" parts should not be created with "new"', Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4347, Title: Secure random number generators should not output predictable values, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4423, Title: Weak SSL/TLS protocols should not be used, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4426, Title: Cryptographic keys should be robust, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4428, Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4433, Title: LDAP connections should be authenticated, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4456, Title: Parameter validation in yielding methods should be wrapped, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4457, Title: Parameter validation in "async"/"await" methods should be wrapped, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S4462, Title: Calls to "async" methods should not be blocking, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S4487, Title: Unread "private" fields should be removed, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4502, Title: Disabling CSRF protections is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4507, Title: Delivering code in production with debug features activated is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4524, Title: '"default" clauses should be first or last', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4545, Title: '"DebuggerDisplayAttribute" strings should reference existing members', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4581, Title: '"new Guid()" should not be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4583, Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke", Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4586, Title: Non-async "Task/Task<T>" methods should not return null, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4635, Title: Start index should be used instead of calling Substring, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4663, Title: Comments should not be empty, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4790, Title: Using weak hashing algorithms is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4792, Title: Configuring loggers is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S4830, Title: Server certificates should be verified during SSL/TLS connections, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5034, Title: '"ValueTask" should be consumed correctly', Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5042, Title: Expanding archive files without controlling resource consumption is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5122, Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive, Category: Minor Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5332, Title: Using clear-text protocols is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5344, Title: Passwords should not be stored in plaintext or with a fast hashing algorithm, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5443, Title: Using publicly writable directories is security-sensitive, Category: Critical Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5445, Title: Insecure temporary file creation methods should not be used, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5542, Title: Encryption algorithms should be used with secure mode and padding scheme, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5547, Title: Cipher algorithms should be robust, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5659, Title: JWT should be signed and verified with strong cipher algorithms, Category: Critical Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5693, Title: Allowing requests with excessive content length is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5753, Title: Disabling ASP.NET "Request Validation" feature is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5766, Title: Deserializing objects without performing data validation is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5773, Title: Types allowed to be deserialized should be restricted, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S5856, Title: Regular expressions should be syntactically valid, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6354, Title: Use a testable date/time provider, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6377, Title: XML signatures should be validated securely, Category: Major Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6419, Title: Azure Functions should be stateless, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6420, Title: Client instances should not be recreated on each Azure Function invocation, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6421, Title: Azure Functions should use Structured Error Handling, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6422, Title: Calls to "async" methods should not be blocking in Azure Functions, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6423, Title: Azure Functions should log all failures, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6424, Title: Interfaces for durable entities should satisfy the restrictions, Category: Blocker Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6444, Title: Not specifying a timeout for regular expressions is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6507, Title: Blocks should not be synchronized on local variables, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S6513, Title: '"ExcludeFromCodeCoverage" attributes should include a justification', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6561, Title: Avoid using "DateTime.Now" for benchmarking or timing operations, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6562, Title: Always set the "DateTimeKind" when creating new "DateTime" instances, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6563, Title: Use UTC when recording DateTime instants, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6566, Title: Use "DateTimeOffset" instead of "DateTime", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6575, Title: Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6580, Title: Use a format provider when parsing date and time, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6585, Title: Don't hardcode the format when turning dates and times to strings, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6588, Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6602, Title: '"Find" method should be used instead of the "FirstOrDefault" extension', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6603, Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6605, Title: Collection-specific "Exists" method should be used instead of the "Any" extension, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6607, Title: The collection should be filtered before sorting by using "Where" before "OrderBy", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6608, Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList", Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6609, Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6610, Title: '"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6612, Title: The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6613, Title: '"First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6617, Title: '"Contains" should be used instead of "Any" for simple equality checks', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6618, Title: '"string.Create" should be used instead of "FormattableString"', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6640, Title: Using unsafe code blocks is security-sensitive, Category: Major Security Hotspot, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6664, Title: The code block contains too many logging calls, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6667, Title: Logging in a catch clause should pass the caught exception as a parameter., Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6668, Title: Logging arguments should be passed to the correct parameter, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6669, Title: Logger field or property name should comply with a naming convention, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6670, Title: '"Trace.Write" and "Trace.WriteLine" should not be used', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6672, Title: Generic logger injection should match enclosing type, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6673, Title: Log message template placeholders should be in the right order, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6674, Title: Log message template should be syntactically correct, Category: Critical Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6675, Title: '"Trace.WriteLineIf" should not be used with "TraceSwitch" levels', Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6677, Title: Message template placeholders should be unique, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6678, Title: Use PascalCase for named placeholders, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6781, Title: JWT secret keys should not be disclosed, Category: Blocker Vulnerability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6797, Title: Blazor query parameter type should be supported, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6798, Title: '[JSInvokable] attribute should only be used on public methods', Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6800, Title: Component parameter type should match the route parameter type constraint, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6802, Title: Using lambda expressions in loops should be avoided in Blazor markup section, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S6803, Title: Parameters with SupplyParameterFromQuery attribute should be used only in routable components, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: S6930, Title: Backslash should be avoided in route templates, Category: Major Bug, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6931, Title: ASP.NET controller actions should not have a route template starting with "/", Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6932, Title: Use model binding instead of reading raw request data, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6934, Title: A Route attribute should be added to the controller when a route template is specified at the action level, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6960, Title: Controllers should not have mixed responsibilities, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6961, Title: API Controllers should derive from ControllerBase instead of Controller, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6962, Title: You should pool HTTP connections with HttpClientFactory, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6964, Title: 'Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6965, Title: REST API actions should be annotated with an HTTP verb attribute, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6966, Title: Awaitable method should be used, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6967, Title: ModelState.IsValid should be called in controller actions, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S6968, Title: Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S818, Title: Literal suffixes should be upper case, Category: Minor Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S881, Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression, Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: S907, Title: '"goto" statement should not be used', Category: Major Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S927, Title: Parameter names should match base declaration and other partial definitions, Category: Critical Code Smell, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: S9999-cpd, Title: Copy-paste token calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-log, Title: Log generator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-metadata, Title: File metadata generator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-metrics, Title: Metrics calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-symbolRef, Title: Symbol reference calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-token-type, Title: Token type calculator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: S9999-warning, Title: Analysis Warning generator, Category: '', DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Warning], IsEverSuppressed: false}
+- {Id: SA0001, Title: XML comment analysis disabled, Category: StyleCop.CSharp.SpecialRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA0002, Title: Invalid settings file, Category: StyleCop.CSharp.SpecialRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1000, Title: Keywords should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1001, Title: Commas should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1002, Title: Semicolons should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1003, Title: Symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1004, Title: Documentation lines should begin with single space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1005, Title: Single line comments should begin with single space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1006, Title: Preprocessor keywords should not be preceded by space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1007, Title: Operator keyword should be followed by space, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1008, Title: Opening parenthesis should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1009, Title: Closing parenthesis should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1010, Title: Opening square brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1011, Title: Closing square brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1012, Title: Opening braces should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1013, Title: Closing braces should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1014, Title: Opening generic brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1015, Title: Closing generic brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1016, Title: Opening attribute brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1017, Title: Closing attribute brackets should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1018, Title: Nullable type symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1019, Title: Member access symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1020, Title: Increment decrement symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1021, Title: Negative signs should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1022, Title: Positive signs should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1023, Title: Dereference and access of symbols should be spaced correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1024, Title: Colons Should Be Spaced Correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1025, Title: Code should not contain multiple whitespace in a row, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1026, Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1027, Title: Use tabs correctly, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1028, Title: Code should not contain trailing whitespace, Category: StyleCop.CSharp.SpacingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1100, Title: Do not prefix calls with base unless local implementation exists, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1101, Title: Prefix local calls with this, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1102, Title: Query clause should follow previous clause, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1103, Title: Query clauses should be on separate lines or all on one line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1104, Title: Query clause should begin on new line when previous clause spans multiple lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1105, Title: Query clauses spanning multiple lines should begin on own line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1106, Title: Code should not contain empty statements, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1107, Title: Code should not contain multiple statements on one line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1108, Title: Block statements should not contain embedded comments, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1109, Title: Block statements should not contain embedded regions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1110, Title: Opening parenthesis or bracket should be on declaration line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1111, Title: Closing parenthesis should be on line of last parameter, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1112, Title: Closing parenthesis should be on line of opening parenthesis, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1113, Title: Comma should be on the same line as previous parameter, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1114, Title: Parameter list should follow declaration, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1115, Title: Parameter should follow comma, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1116, Title: Split parameters should start on line after declaration, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1117, Title: Parameters should be on same line or separate lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1118, Title: Parameter should not span multiple lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1119, Title: Statement should not use unnecessary parenthesis, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1119_p, Title: Statement should not use unnecessary parenthesis, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SA1120, Title: Comments should contain text, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1121, Title: Use built-in type alias, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1122, Title: Use string.Empty for empty strings, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1123, Title: Do not place regions within elements, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1124, Title: Do not use regions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1125, Title: Use shorthand for nullable types, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1126, Title: Prefix calls correctly, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1127, Title: Generic type constraints should be on their own line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1128, Title: Put constructor initializers on their own line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1129, Title: Do not use default value type constructor, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1130, Title: Use lambda syntax, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1131, Title: Use readable conditions, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1132, Title: Do not combine fields, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1133, Title: Do not combine attributes, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1134, Title: Attributes should not share line, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1135, Title: Using directives should be qualified, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1136, Title: Enum values should be on separate lines, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1137, Title: Elements should have the same indentation, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1139, Title: Use literal suffix notation instead of casting, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1141, Title: Use tuple syntax, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1142, Title: Refer to tuple fields by name, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1200, Title: Using directives should be placed correctly, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1201, Title: Elements should appear in the correct order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1202, Title: Elements should be ordered by access, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1203, Title: Constants should appear before fields, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1204, Title: Static elements should appear before instance elements, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: true}
+- {Id: SA1205, Title: Partial elements should declare access, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1206, Title: Declaration keywords should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1207, Title: Protected should come before internal, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1208, Title: System using directives should be placed before other using directives, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1209, Title: Using alias directives should be placed after other using directives, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1210, Title: Using directives should be ordered alphabetically by namespace, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1211, Title: Using alias directives should be ordered alphabetically by alias name, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1212, Title: Property accessors should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1213, Title: Event accessors should follow order, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1214, Title: Readonly fields should appear before non-readonly fields, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1216, Title: Using static directives should be placed at the correct location, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1217, Title: Using static directives should be ordered alphabetically, Category: StyleCop.CSharp.OrderingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1300, Title: Element should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1301, Title: Element should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1302, Title: Interface names should begin with I, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1303, Title: Const field names should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1304, Title: Non-private readonly fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1305, Title: Field names should not use Hungarian notation, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1306, Title: Field names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1307, Title: Accessible fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1308, Title: Variable names should not be prefixed, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1309, Title: Field names should not begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
+- {Id: SA1310, Title: Field names should not contain underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1311, Title: Static readonly fields should begin with upper-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1312, Title: Variable names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1313, Title: Parameter names should begin with lower-case letter, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1314, Title: Type parameter names should begin with T, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1316, Title: Tuple element names should use correct casing, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1400, Title: Access modifier should be declared, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1401, Title: Fields should be private, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1402, Title: File may only contain a single type, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1403, Title: File may only contain a single namespace, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1404, Title: Code analysis suppression should have justification, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1405, Title: Debug.Assert should provide message text, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1406, Title: Debug.Fail should provide message text, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1407, Title: Arithmetic expressions should declare precedence, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1408, Title: Conditional expressions should declare precedence, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1409, Title: Remove unnecessary code, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1410, Title: Remove delegate parenthesis when possible, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1411, Title: Attribute constructor should not use unnecessary parenthesis, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1412, Title: Store files as UTF-8 with byte order mark, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1413, Title: Use trailing comma in multi-line initializers, Category: StyleCop.CSharp.MaintainabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1414, Title: Tuple types in signatures should have element names, Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1500, Title: Braces for multi-line statements should not share line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1501, Title: Statement should not be on a single line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1502, Title: Element should not be on a single line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1503, Title: Braces should not be omitted, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1504, Title: All accessors should be single-line or multi-line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1505, Title: Opening braces should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1506, Title: Element documentation headers should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1507, Title: Code should not contain multiple blank lines in a row, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1508, Title: Closing braces should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1509, Title: Opening braces should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1510, Title: Chained statement blocks should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1511, Title: While-do footer should not be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1512, Title: Single-line comments should not be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1513, Title: Closing brace should be followed by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1514, Title: Element documentation header should be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1515, Title: Single-line comment should be preceded by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1516, Title: Elements should be separated by blank line, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1517, Title: Code should not contain blank lines at start of file, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1518, Title: Use line endings correctly at end of file, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1519, Title: Braces should not be omitted from multi-line child statement, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1520, Title: Use braces consistently, Category: StyleCop.CSharp.LayoutRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1600, Title: Elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1601, Title: Partial elements should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1602, Title: Enumeration items should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1603, Title: Documentation should contain valid XML, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1604, Title: Element documentation should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1605, Title: Partial element documentation should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1606, Title: Element documentation should have summary text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1607, Title: Partial element documentation should have summary text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1608, Title: Element documentation should not have default summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1609, Title: Property documentation should have value, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1610, Title: Property documentation should have value text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1611, Title: Element parameters should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1612, Title: Element parameter documentation should match element parameters, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1613, Title: Element parameter documentation should declare parameter name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1614, Title: Element parameter documentation should have text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1615, Title: Element return value should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1616, Title: Element return value documentation should have text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1617, Title: Void return value should not be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1618, Title: Generic type parameters should be documented, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1619, Title: Generic type parameters should be documented partial class, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1620, Title: Generic type parameter documentation should match type parameters, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1621, Title: Generic type parameter documentation should declare parameter name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1622, Title: Generic type parameter documentation should have text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1623, Title: Property summary documentation should match accessors, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1624, Title: Property summary documentation should omit accessor with restricted access, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1625, Title: Element documentation should not be copied and pasted, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1626, Title: Single-line comments should not use documentation style slashes, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1627, Title: Documentation text should not be empty, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1628, Title: Documentation text should begin with a capital letter, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1629, Title: Documentation text should end with a period, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1630, Title: Documentation text should contain whitespace, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1631, Title: Documentation should meet character percentage, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1632, Title: Documentation text should meet minimum character length, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1633, Title: File should have header, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, Note], IsEverSuppressed: true}
+- {Id: SA1634, Title: File header should show copyright, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1635, Title: File header should have copyright text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1636, Title: File header copyright text should match, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1637, Title: File header should contain file name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1638, Title: File header file name documentation should match file name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1639, Title: File header should have summary, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: false}
+- {Id: SA1640, Title: File header should have valid company text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1641, Title: File header company name text should match, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1642, Title: Constructor summary documentation should begin with standard text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1643, Title: Destructor summary documentation should begin with standard text, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1644, Title: Documentation headers should not contain blank lines, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1645, Title: Included documentation file does not exist, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1646, Title: Included documentation XPath does not exist, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1647, Title: Include node does not contain valid file and path, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1648, Title: inheritdoc should be used with inheriting class, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1649, Title: File name should match first type name, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SA1650, Title: Element documentation should be spelled correctly, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SA1651, Title: Do not use placeholder elements, Category: StyleCop.CSharp.DocumentationRules, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SX1101, Title: Do not prefix local calls with 'this.', Category: StyleCop.CSharp.ReadabilityRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SX1309, Title: Field names should begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SX1309S, Title: Static field names should begin with underscore, Category: StyleCop.CSharp.NamingRules, DefaultSeverity: Warning, IsEnabledByDefault: false, EffectiveSeverities: [None], IsEverSuppressed: true}
+- {Id: SYSLIB1045, Title: Convert to 'GeneratedRegexAttribute'., Category: Performance, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1054, Title: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1055, Title: Invalid 'CustomMarshallerAttribute' usage, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1056, Title: Specified marshaller type is invalid, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1057, Title: Marshaller type does not have the required shape, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1058, Title: Invalid 'NativeMarshallingAttribute' usage, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1060, Title: Specified marshaller type is invalid, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1061, Title: Marshaller type has incompatible method signatures, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1090, Title: "'GeneratedComInterfaceType' does not support the 'ComInterfaceType' value supplied to 'InterfaceTypeAttribute' on the same type.", Category: ComInterfaceGenerator, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1096, Title: Convert to 'GeneratedComInterface', Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1097, Title: Add 'GeneratedComClassAttribute' to enable passing objects of this type to COM, Category: Interoperability, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: SYSLIB1098, Title: .NET COM hosting with 'EnableComHosting' does not support interfaces with the 'GeneratedComInterfaceAttribute', Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: SYSLIB1099, Title: COM Interop APIs on 'System.Runtime.InteropServices.Marshal' do not support source-generated COM, Category: Interoperability, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD001, Title: Avoid legacy thread switching APIs, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD002, Title: Avoid problematic synchronous waits, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD003, Title: Avoid awaiting foreign Tasks, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD004, Title: Await SwitchToMainThreadAsync, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD010, Title: Invoke single-threaded types on Main thread, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD011, Title: Use AsyncLazy<T>, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD012, Title: Provide JoinableTaskFactory where allowed, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD100, Title: Avoid async void methods, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD101, Title: Avoid unsupported async delegates, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD102, Title: Implement internal logic asynchronously, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD103, Title: Call async methods when in an async method, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD104, Title: Offer async methods, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD105, Title: Avoid method overloads that assume TaskScheduler.Current, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD106, Title: Use InvokeAsync to raise async events, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD107, Title: Await Task within using expression, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD108, Title: Assert thread affinity unconditionally, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD109, Title: Switch instead of assert in async methods, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD110, Title: Observe result of async calls, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD111, Title: Use ConfigureAwait(bool), Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: VSTHRD112, Title: Implement System.IAsyncDisposable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD113, Title: Check for System.IAsyncDisposable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: VSTHRD114, Title: Avoid returning a null Task, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: VSTHRD200, Title: Use "Async" suffix for async methods, Category: Style, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error, None], IsEverSuppressed: true}
+- {Id: xUnit1000, Title: Test classes must be public, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1001, Title: Fact methods cannot have parameters, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1002, Title: Test methods cannot have multiple Fact or Theory attributes, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1003, Title: Theory methods must have test data, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1004, Title: Test methods should not be skipped, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit1005, Title: Fact methods should not have test data, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1006, Title: Theory methods should have parameters, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1007, Title: ClassData must point at a valid class, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1008, Title: Test data attribute should only be used on a Theory, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1009, Title: InlineData values must match the number of method parameters, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1010, Title: The value is not convertible to the method parameter type, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1011, Title: There is no matching method parameter, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1012, Title: Null should only be used for nullable parameters, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1013, Title: Public method should be marked as test, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1014, Title: MemberData should use nameof operator for member name, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1015, Title: MemberData must reference an existing member, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1016, Title: MemberData must reference a public member, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1017, Title: MemberData must reference a static member, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1018, Title: MemberData must reference a valid member kind, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1019, Title: MemberData must reference a member providing a valid data type, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1020, Title: MemberData must reference a property with a public getter, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1021, Title: MemberData should not have parameters if the referenced member is not a method, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1022, Title: Theory methods cannot have a parameter array, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1023, Title: Theory methods cannot have default parameter values, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1024, Title: Test methods cannot have overloads, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1025, Title: InlineData should be unique within the Theory it belongs to, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1026, Title: Theory methods should use all of their parameters, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1027, Title: Collection definition classes must be public, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1028, Title: Test method must have valid return type, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1029, Title: Local functions cannot be test functions, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1030, Title: Do not call ConfigureAwait(false) in test method, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1031, Title: Do not use blocking task operations in test method, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1032, Title: Test classes cannot be nested within a generic class, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1033, Title: Test classes decorated with 'Xunit.IClassFixture<TFixture>' or 'Xunit.ICollectionFixture<TFixture>' should add a constructor argument of type TFixture, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit1034, Title: Null should only be used for nullable parameters, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1035, Title: The value is not convertible to the method parameter type, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1036, Title: There is no matching method parameter, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1037, Title: There are fewer theory data type arguments than required by the parameters of the test method, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1038, Title: There are more theory data type arguments than allowed by the parameters of the test method, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1039, Title: The type argument to theory data is not compatible with the type of the corresponding test method parameter, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1040, Title: 'The type argument to theory data is nullable, while the type of the corresponding test method parameter is not', Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1041, Title: Fixture arguments to test classes must have fixture sources, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1042, Title: The member referenced by the MemberData attribute returns untyped data rows, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit1043, Title: Constructors on classes derived from FactAttribute must be public when used on test methods, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1044, Title: Avoid using TheoryData type arguments that are not serializable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit1045, Title: Avoid using TheoryData type arguments that might not be serializable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit1046, Title: Avoid using TheoryDataRow arguments that are not serializable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit1047, Title: Avoid using TheoryDataRow arguments that might not be serializable, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit1048, Title: Avoid using 'async void' for test methods as it is deprecated in xUnit.net v3, Category: Usage, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1049, Title: Do not use 'async void' for test methods as it is no longer supported, Category: Usage, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit1050, Title: The class referenced by the ClassData attribute returns untyped data rows, Category: Usage, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit2000, Title: Constants and literals should be the expected argument, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2001, Title: Do not use invalid equality check, Category: Assertions, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: xUnit2002, Title: Do not use null check on value type, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2003, Title: Do not use equality check to test for null value, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2004, Title: Do not use equality check to test for boolean conditions, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2005, Title: Do not use identity check on value type, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2006, Title: Do not use invalid string equality check, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2007, Title: Do not use typeof expression to check the type, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2008, Title: Do not use boolean check to match on regular expressions, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2009, Title: Do not use boolean check to check for substrings, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2010, Title: Do not use boolean check to check for string equality, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2011, Title: Do not use empty collection check, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2012, Title: Do not use boolean check to check if a value exists in a collection, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2013, Title: Do not use equality check to check for collection size., Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2014, Title: Do not use throws check to check for asynchronously thrown exception, Category: Assertions, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2015, Title: Do not use typeof expression to check the exception type, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2016, Title: Keep precision in the allowed range when asserting equality of doubles or decimals., Category: Assertions, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2017, Title: Do not use Contains() to check if a value exists in a collection, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2018, Title: Do not compare an object's exact type to an abstract class or interface, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2020, Title: Do not use always-failing boolean assertions, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2021, Title: Async assertions should be awaited, Category: Assertions, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2022, Title: Boolean assertions should not be negated, Category: Assertions, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit2023, Title: Do not use collection methods for single-item collections, Category: Assertions, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit2024, Title: Do not use boolean asserts for simple equality tests, Category: Assertions, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit2025, Title: The boolean assertion statement can be simplified, Category: Assertions, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: xUnit2026, Title: Comparison of sets must be done with IEqualityComparer, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2027, Title: Comparison of sets to linear containers have undefined results, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2028, Title: Do not use Assert.Empty or Assert.NotEmpty with problematic types, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit2029, Title: Do not use Empty() to check if a value does not exist in a collection, Category: Assertions, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit3000, Title: Classes which cross AppDomain boundaries must derive directly or indirectly from LongLivedMarshalByRefObject, Category: Extensibility, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
+- {Id: xUnit3001, Title: Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor, Category: Extensibility, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}

--- a/tests/Moq.Analyzers.Test/SquiggleCop.Baseline.yaml
+++ b/tests/Moq.Analyzers.Test/SquiggleCop.Baseline.yaml
@@ -356,7 +356,7 @@
 - {Id: IDE0048, Title: Add parentheses for clarity, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0051, Title: Remove unused private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0052, Title: Remove unread private members, Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0053, Title: Use expression body for lambda expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0053, Title: Use expression body for lambdas, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0054, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0055, Title: Fix formatting, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0056, Title: Use index operator, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -373,7 +373,7 @@
 - {Id: IDE0070, Title: Use 'System.HashCode', Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0071, Title: Simplify interpolation, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0072, Title: Add missing cases, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
-- {Id: IDE0073, Title: The file header does not match the required text, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
+- {Id: IDE0073, Title: Require file header, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0074, Title: Use compound assignment, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0075, Title: Simplify conditional expression, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0076, Title: Invalid global 'SuppressMessageAttribute', Category: CodeQuality, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
@@ -411,7 +411,6 @@
 - {Id: IDE0303, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0304, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0305, Title: Simplify collection initialization, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
-- {Id: IDE0320, Title: Make anonymous function static, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE1005, Title: Delegate invocation can be simplified., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE1006, Title: Naming Styles, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE2000, Title: Avoid multiple blank lines, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}

--- a/tests/Moq.Analyzers.Test/SquiggleCop.Baseline.yaml
+++ b/tests/Moq.Analyzers.Test/SquiggleCop.Baseline.yaml
@@ -1,0 +1,13275 @@
+- Id: CA1000
+  Title: Do not declare static members on generic types
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1001
+  Title: Types that own disposable fields should be disposable
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1002
+  Title: Do not expose generic lists
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1003
+  Title: Use generic event handler instances
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1005
+  Title: Avoid excessive parameters on generic types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1008
+  Title: Enums should have zero value
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1010
+  Title: Generic interface should also be implemented
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1012
+  Title: Abstract types should not have public constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1014
+  Title: Mark assemblies with CLSCompliant
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1016
+  Title: Mark assemblies with assembly version
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1017
+  Title: Mark assemblies with ComVisible
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1018
+  Title: Mark attributes with AttributeUsageAttribute
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1019
+  Title: Define accessors for attribute arguments
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1021
+  Title: Avoid out parameters
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1024
+  Title: Use properties where appropriate
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1027
+  Title: Mark enums with FlagsAttribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1028
+  Title: Enum Storage should be Int32
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1030
+  Title: Use events where appropriate
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1031
+  Title: Do not catch general exception types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1032
+  Title: Implement standard exception constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1033
+  Title: Interface methods should be callable by child types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1034
+  Title: Nested types should not be visible
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1036
+  Title: Override methods on comparable types
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1040
+  Title: Avoid empty interfaces
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1041
+  Title: Provide ObsoleteAttribute message
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1043
+  Title: Use Integral Or String Argument For Indexers
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1044
+  Title: Properties should not be write only
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1045
+  Title: Do not pass types by reference
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1046
+  Title: Do not overload equality operator on reference types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1050
+  Title: Declare types in namespaces
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1051
+  Title: Do not declare visible instance fields
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1052
+  Title: Static holder types should be Static or NotInheritable
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1054
+  Title: URI-like parameters should not be strings
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1055
+  Title: URI-like return values should not be strings
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1056
+  Title: URI-like properties should not be strings
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1058
+  Title: Types should not extend certain base types
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1060
+  Title: Move pinvokes to native methods class
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1061
+  Title: Do not hide base class methods
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1062
+  Title: Validate arguments of public methods
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1063
+  Title: Implement IDisposable Correctly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1064
+  Title: Exceptions should be public
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1065
+  Title: Do not raise exceptions in unexpected locations
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1066
+  Title: Implement IEquatable when overriding Object.Equals
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: CA1067
+  Title: Override Object.Equals(object) when implementing IEquatable<T>
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1068
+  Title: CancellationToken parameters must come last
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1069
+  Title: Enums values should not be duplicated
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1070
+  Title: Do not declare event fields as virtual
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1200
+  Title: Avoid using cref tags with a prefix
+  Category: Documentation
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1303
+  Title: Do not pass literals as localized parameters
+  Category: Globalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1304
+  Title: Specify CultureInfo
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1305
+  Title: Specify IFormatProvider
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1307
+  Title: Specify StringComparison for clarity
+  Category: Globalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1308
+  Title: Normalize strings to uppercase
+  Category: Globalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1309
+  Title: Use ordinal string comparison
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1310
+  Title: Specify StringComparison for correctness
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1311
+  Title: Specify a culture or use an invariant version
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1401
+  Title: P/Invokes should not be visible
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1416
+  Title: Validate platform compatibility
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1417
+  Title: Do not use 'OutAttribute' on string parameters for P/Invokes
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1418
+  Title: Use valid platform string
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1419
+  Title: Provide a parameterless constructor that is as visible as the containing type for concrete types derived from 'System.Runtime.InteropServices.SafeHandle'
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1420
+  Title: Property, type, or attribute requires runtime marshalling
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1421
+  Title: This method uses runtime marshalling even when the 'DisableRuntimeMarshallingAttribute' is applied
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1422
+  Title: Validate platform compatibility
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1501
+  Title: Avoid excessive inheritance
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1502
+  Title: Avoid excessive complexity
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1505
+  Title: Avoid unmaintainable code
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1506
+  Title: Avoid excessive class coupling
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1507
+  Title: Use nameof to express symbol names
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1508
+  Title: Avoid dead conditional code
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1509
+  Title: Invalid entry in code metrics rule specification file
+  Category: Maintainability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1510
+  Title: Use ArgumentNullException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1511
+  Title: Use ArgumentException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1512
+  Title: Use ArgumentOutOfRangeException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1513
+  Title: Use ObjectDisposedException throw helper
+  Category: Maintainability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1700
+  Title: Do not name enum values 'Reserved'
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1707
+  Title: Identifiers should not contain underscores
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1708
+  Title: Identifiers should differ by more than case
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1710
+  Title: Identifiers should have correct suffix
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1711
+  Title: Identifiers should not have incorrect suffix
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1712
+  Title: Do not prefix enum values with type name
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1713
+  Title: Events should not have 'Before' or 'After' prefix
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1715
+  Title: Identifiers should have correct prefix
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1716
+  Title: Identifiers should not match keywords
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1720
+  Title: Identifier contains type name
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1721
+  Title: Property names should not match get methods
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1724
+  Title: Type names should not match namespaces
+  Category: Naming
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1725
+  Title: Parameter names should match base declaration
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1727
+  Title: Use PascalCase for named placeholders
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1802
+  Title: Use literals where appropriate
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1805
+  Title: Do not initialize unnecessarily
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1806
+  Title: Do not ignore method results
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1810
+  Title: Initialize reference type static fields inline
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1812
+  Title: Avoid uninstantiated internal classes
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1813
+  Title: Avoid unsealed attributes
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1814
+  Title: Prefer jagged arrays over multidimensional
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1815
+  Title: Override equals and operator equals on value types
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1816
+  Title: Dispose methods should call SuppressFinalize
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1819
+  Title: Properties should not return arrays
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1820
+  Title: Test for empty strings using string length
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1821
+  Title: Remove empty Finalizers
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1822
+  Title: Mark members as static
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1823
+  Title: Avoid unused private fields
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1824
+  Title: Mark assemblies with NeutralResourcesLanguageAttribute
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1825
+  Title: Avoid zero-length array allocations
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1826
+  Title: Do not use Enumerable methods on indexable collections
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1827
+  Title: Do not use Count() or LongCount() when Any() can be used
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1828
+  Title: Do not use CountAsync() or LongCountAsync() when AnyAsync() can be used
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1829
+  Title: Use Length/Count property instead of Count() when available
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1830
+  Title: Prefer strongly-typed Append and Insert method overloads on StringBuilder
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1831
+  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1832
+  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1833
+  Title: Use AsSpan or AsMemory instead of Range-based indexers when appropriate
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1834
+  Title: Consider using 'StringBuilder.Append(char)' when applicable
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1835
+  Title: Prefer the 'Memory'-based overloads for 'ReadAsync' and 'WriteAsync'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1836
+  Title: Prefer IsEmpty over Count
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1837
+  Title: Use 'Environment.ProcessId'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1838
+  Title: Avoid 'StringBuilder' parameters for P/Invokes
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1839
+  Title: Use 'Environment.ProcessPath'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1840
+  Title: Use 'Environment.CurrentManagedThreadId'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1841
+  Title: Prefer Dictionary.Contains methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1842
+  Title: Do not use 'WhenAll' with a single task
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1843
+  Title: Do not use 'WaitAll' with a single task
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1844
+  Title: Provide memory-based overrides of async methods when subclassing 'Stream'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1845
+  Title: Use span-based 'string.Concat'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1846
+  Title: Prefer 'AsSpan' over 'Substring'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1847
+  Title: Use char literal for a single character lookup
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1848
+  Title: Use the LoggerMessage delegates
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1849
+  Title: Call async methods when in an async method
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1850
+  Title: Prefer static 'HashData' method over 'ComputeHash'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1851
+  Title: Possible multiple enumerations of 'IEnumerable' collection
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA1852
+  Title: Seal internal types
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1853
+  Title: Unnecessary call to 'Dictionary.ContainsKey(key)'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1854
+  Title: Prefer the 'IDictionary.TryGetValue(TKey, out TValue)' method
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1855
+  Title: Prefer 'Clear' over 'Fill'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1856
+  Title: Incorrect usage of ConstantExpected attribute
+  Category: Performance
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1857
+  Title: A constant is expected for the parameter
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA1858
+  Title: Use 'StartsWith' instead of 'IndexOf'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1859
+  Title: Use concrete types when possible for improved performance
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1860
+  Title: Avoid using 'Enumerable.Any()' extension method
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1861
+  Title: Avoid constant arrays as arguments
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1862
+  Title: Use the 'StringComparison' method overloads to perform case-insensitive string comparisons
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1863
+  Title: Use 'CompositeFormat'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA1864
+  Title: Prefer the 'IDictionary.TryAdd(TKey, TValue)' method
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1865
+  Title: Use char overload
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1866
+  Title: Use char overload
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1867
+  Title: Use char overload
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: CA1868
+  Title: Unnecessary call to 'Contains(item)'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1869
+  Title: Cache and reuse 'JsonSerializerOptions' instances
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA1870
+  Title: Use a cached 'SearchValues' instance
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2000
+  Title: Dispose objects before losing scope
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2002
+  Title: Do not lock on objects with weak identity
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2007
+  Title: Consider calling ConfigureAwait on the awaited task
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2008
+  Title: Do not create tasks without passing a TaskScheduler
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2009
+  Title: Do not call ToImmutableCollection on an ImmutableCollection value
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2011
+  Title: Avoid infinite recursion
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2012
+  Title: Use ValueTasks correctly
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2013
+  Title: Do not use ReferenceEquals with value types
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2014
+  Title: Do not use stackalloc in loops
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2015
+  Title: Do not define finalizers for types derived from MemoryManager<T>
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2016
+  Title: Forward the 'CancellationToken' parameter to methods
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: CA2017
+  Title: Parameter count mismatch
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2018
+  Title: "'Buffer.BlockCopy' expects the number of bytes to be copied for the 'count' argument"
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2019
+  Title: Improper 'ThreadStatic' field initialization
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2020
+  Title: Prevent behavioral change
+  Category: Reliability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2021
+  Title: Do not call Enumerable.Cast<T> or Enumerable.OfType<T> with incompatible types
+  Category: Reliability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2100
+  Title: Review SQL queries for security vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2101
+  Title: Specify marshaling for P/Invoke string arguments
+  Category: Globalization
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2119
+  Title: Seal methods that satisfy private interfaces
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2153
+  Title: Do Not Catch Corrupted State Exceptions
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2200
+  Title: Rethrow to preserve stack details
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2201
+  Title: Do not raise reserved exception types
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA2207
+  Title: Initialize value type static fields inline
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2208
+  Title: Instantiate argument exceptions correctly
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2211
+  Title: Non-constant fields should not be visible
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2213
+  Title: Disposable fields should be disposed
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2214
+  Title: Do not call overridable methods in constructors
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2215
+  Title: Dispose methods should call base class dispose
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA2216
+  Title: Disposable types should declare finalizer
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2217
+  Title: Do not mark enums with FlagsAttribute
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2219
+  Title: Do not raise exceptions in finally clauses
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2225
+  Title: Operator overloads have named alternates
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2226
+  Title: Operators should have symmetrical overloads
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2227
+  Title: Collection properties should be read only
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2231
+  Title: Overload operator equals on overriding value type Equals
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2234
+  Title: Pass system uri objects instead of strings
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2235
+  Title: Mark all non-serializable fields
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2237
+  Title: Mark ISerializable types with serializable
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2241
+  Title: Provide correct arguments to formatting methods
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2242
+  Title: Test for NaN correctly
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2243
+  Title: Attribute string literals should parse correctly
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2244
+  Title: Do not duplicate indexed element initializations
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2245
+  Title: Do not assign a property to itself
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2246
+  Title: Assigning symbol and its member in the same statement
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2247
+  Title: Argument passed to TaskCompletionSource constructor should be TaskCreationOptions enum instead of TaskContinuationOptions enum
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2248
+  Title: Provide correct 'enum' argument to 'Enum.HasFlag'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2249
+  Title: Consider using 'string.Contains' instead of 'string.IndexOf'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2250
+  Title: Use 'ThrowIfCancellationRequested'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2251
+  Title: Use 'string.Equals'
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA2252
+  Title: This API requires opting into preview features
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2253
+  Title: Named placeholders should not be numeric values
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2254
+  Title: Template should be a static expression
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: CA2255
+  Title: The 'ModuleInitializer' attribute should not be used in libraries
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2256
+  Title: All members declared in parent interfaces must have an implementation in a DynamicInterfaceCastableImplementation-attributed interface
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2257
+  Title: Members defined on an interface with the 'DynamicInterfaceCastableImplementationAttribute' should be 'static'
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2258
+  Title: Providing a 'DynamicInterfaceCastableImplementation' interface in Visual Basic is unsupported
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2259
+  Title: "'ThreadStatic' only affects static fields"
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2260
+  Title: Use correct type parameter
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2261
+  Title: Do not use ConfigureAwaitOptions.SuppressThrowing with Task<TResult>
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CA2300
+  Title: Do not use insecure deserializer BinaryFormatter
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2301
+  Title: Do not call BinaryFormatter.Deserialize without first setting BinaryFormatter.Binder
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2302
+  Title: Ensure BinaryFormatter.Binder is set before calling BinaryFormatter.Deserialize
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2305
+  Title: Do not use insecure deserializer LosFormatter
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2310
+  Title: Do not use insecure deserializer NetDataContractSerializer
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2311
+  Title: Do not deserialize without first setting NetDataContractSerializer.Binder
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2312
+  Title: Ensure NetDataContractSerializer.Binder is set before deserializing
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2315
+  Title: Do not use insecure deserializer ObjectStateFormatter
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2321
+  Title: Do not deserialize with JavaScriptSerializer using a SimpleTypeResolver
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2322
+  Title: Ensure JavaScriptSerializer is not initialized with SimpleTypeResolver before deserializing
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2326
+  Title: Do not use TypeNameHandling values other than None
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2327
+  Title: Do not use insecure JsonSerializerSettings
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2328
+  Title: Ensure that JsonSerializerSettings are secure
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2329
+  Title: Do not deserialize with JsonSerializer using an insecure configuration
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2330
+  Title: Ensure that JsonSerializer has a secure configuration when deserializing
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2350
+  Title: Do not use DataTable.ReadXml() with untrusted data
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2351
+  Title: Do not use DataSet.ReadXml() with untrusted data
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2352
+  Title: Unsafe DataSet or DataTable in serializable type can be vulnerable to remote code execution attacks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2353
+  Title: Unsafe DataSet or DataTable in serializable type
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2354
+  Title: Unsafe DataSet or DataTable in deserialized object graph can be vulnerable to remote code execution attacks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2355
+  Title: Unsafe DataSet or DataTable type found in deserializable object graph
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2356
+  Title: Unsafe DataSet or DataTable type in web deserializable object graph
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2361
+  Title: Ensure auto-generated class containing DataSet.ReadXml() is not used with untrusted data
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA2362
+  Title: Unsafe DataSet or DataTable in auto-generated serializable type can be vulnerable to remote code execution attacks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3001
+  Title: Review code for SQL injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3002
+  Title: Review code for XSS vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3003
+  Title: Review code for file path injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3004
+  Title: Review code for information disclosure vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3005
+  Title: Review code for LDAP injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3006
+  Title: Review code for process command injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3007
+  Title: Review code for open redirect vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3008
+  Title: Review code for XPath injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3009
+  Title: Review code for XML injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3010
+  Title: Review code for XAML injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3011
+  Title: Review code for DLL injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3012
+  Title: Review code for regex injection vulnerabilities
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA3061
+  Title: Do Not Add Schema By URL
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3075
+  Title: Insecure DTD processing in XML
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3076
+  Title: Insecure XSLT script processing
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3077
+  Title: Insecure Processing in API Design, XmlDocument and XmlTextReader
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA3147
+  Title: Mark Verb Handlers With Validate Antiforgery Token
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5350
+  Title: Do Not Use Weak Cryptographic Algorithms
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5351
+  Title: Do Not Use Broken Cryptographic Algorithms
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5358
+  Title: Review cipher mode usage with cryptography experts
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5359
+  Title: Do Not Disable Certificate Validation
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5360
+  Title: Do Not Call Dangerous Methods In Deserialization
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5361
+  Title: Do Not Disable SChannel Use of Strong Crypto
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5362
+  Title: Potential reference cycle in deserialized object graph
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5363
+  Title: Do Not Disable Request Validation
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5364
+  Title: Do Not Use Deprecated Security Protocols
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5365
+  Title: Do Not Disable HTTP Header Checking
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5366
+  Title: Use XmlReader for 'DataSet.ReadXml()'
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5367
+  Title: Do Not Serialize Types With Pointer Fields
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5368
+  Title: Set ViewStateUserKey For Classes Derived From Page
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5369
+  Title: Use XmlReader for 'XmlSerializer.Deserialize()'
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5370
+  Title: Use XmlReader for XmlValidatingReader constructor
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5371
+  Title: Use XmlReader for 'XmlSchema.Read()'
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5372
+  Title: Use XmlReader for XPathDocument constructor
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5373
+  Title: Do not use obsolete key derivation function
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5374
+  Title: Do Not Use XslTransform
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5375
+  Title: Do Not Use Account Shared Access Signature
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5376
+  Title: Use SharedAccessProtocol HttpsOnly
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5377
+  Title: Use Container Level Access Policy
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5378
+  Title: Do not disable ServicePointManagerSecurityProtocols
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5379
+  Title: Ensure Key Derivation Function algorithm is sufficiently strong
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5380
+  Title: Do Not Add Certificates To Root Store
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5381
+  Title: Ensure Certificates Are Not Added To Root Store
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5382
+  Title: Use Secure Cookies In ASP.NET Core
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5383
+  Title: Ensure Use Secure Cookies In ASP.NET Core
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5384
+  Title: Do Not Use Digital Signature Algorithm (DSA)
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5385
+  Title: Use Rivest-Shamir-Adleman (RSA) Algorithm With Sufficient Key Size
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5386
+  Title: Avoid hardcoding SecurityProtocolType value
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5387
+  Title: Do Not Use Weak Key Derivation Function With Insufficient Iteration Count
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5388
+  Title: Ensure Sufficient Iteration Count When Using Weak Key Derivation Function
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5389
+  Title: Do Not Add Archive Item's Path To The Target File System Path
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5390
+  Title: Do not hard-code encryption key
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5391
+  Title: Use antiforgery tokens in ASP.NET Core MVC controllers
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5392
+  Title: Use DefaultDllImportSearchPaths attribute for P/Invokes
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5393
+  Title: Do not use unsafe DllImportSearchPath value
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5394
+  Title: Do not use insecure randomness
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5395
+  Title: Miss HttpVerb attribute for action methods
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5396
+  Title: Set HttpOnly to true for HttpCookie
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5397
+  Title: Do not use deprecated SslProtocols values
+  Category: Security
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: CA5398
+  Title: Avoid hardcoded SslProtocols values
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5399
+  Title: HttpClients should enable certificate revocation list checks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5400
+  Title: Ensure HttpClient certificate revocation list check is not disabled
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5401
+  Title: Do not use CreateEncryptor with non-default IV
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5402
+  Title: 'Use CreateEncryptor with the default IV '
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5403
+  Title: Do not hard-code certificate
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5404
+  Title: Do not disable token validation checks
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: CA5405
+  Title: Do not always skip token validation in delegates
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: EM0001
+  Title: Switch on Enum Not Exhaustive
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0002
+  Title: Switch on Nullable Enum Not Exhaustive
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0003
+  Title: Switch on Closed Type Not Exhaustive
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0011
+  Title: Concrete Subtype of a Closed Type Must Be a Case
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0012
+  Title: Closed Type Case Must Be a Direct Subtype
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0013
+  Title: Closed Type Case Must Be a Subtype
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0014
+  Title: Concrete Subtype of a Closed Type Must Be a Covered
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0015
+  Title: Open Interface Subtype of a Closed Type Must Be a Case
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0100
+  Title: When Guards Not Supported
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0101
+  Title: Case Pattern Not Supported
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0102
+  Title: Open Type Not Supported
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0103
+  Title: Match Must Be On Case Type
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0104
+  Title: Duplicate Closed Attribute
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EM0105
+  Title: Duplicate Case Type
+  Category: Logic
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: EnableGenerateDocumentationFile
+  Title: Set MSBuild property 'GenerateDocumentationFile' to 'true'
+  Category: Style
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: IDE0004
+  Title: Remove Unnecessary Cast
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0005
+  Title: Using directive is unnecessary.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0005_gen
+  Title: Using directive is unnecessary.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0007
+  Title: Use implicit type
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0008
+  Title: Use explicit type
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0009
+  Title: Member access should be qualified.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0010
+  Title: Add missing cases
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0011
+  Title: Add braces
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0016
+  Title: Use 'throw' expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0017
+  Title: Simplify object initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0018
+  Title: Inline variable declaration
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0019
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0020
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0021
+  Title: Use expression body for constructor
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0022
+  Title: Use expression body for method
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0023
+  Title: Use expression body for conversion operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0024
+  Title: Use expression body for operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0025
+  Title: Use expression body for property
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0026
+  Title: Use expression body for indexer
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0027
+  Title: Use expression body for accessor
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0028
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0029
+  Title: Use coalesce expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0030
+  Title: Use coalesce expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0031
+  Title: Use null propagation
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0032
+  Title: Use auto property
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0033
+  Title: Use explicitly provided tuple name
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0034
+  Title: Simplify 'default' expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0035
+  Title: Unreachable code detected
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0036
+  Title: Order modifiers
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0037
+  Title: Use inferred member name
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0039
+  Title: Use local function
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0040
+  Title: Add accessibility modifiers
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0041
+  Title: Use 'is null' check
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0042
+  Title: Deconstruct variable declaration
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0043
+  Title: Invalid format string
+  Category: Compiler
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0044
+  Title: Add readonly modifier
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0045
+  Title: Convert to conditional expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0046
+  Title: Convert to conditional expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0047
+  Title: Remove unnecessary parentheses
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0048
+  Title: Add parentheses for clarity
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0051
+  Title: Remove unused private members
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0052
+  Title: Remove unread private members
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0053
+  Title: Use expression body for lambda expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0054
+  Title: Use compound assignment
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0055
+  Title: Fix formatting
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0056
+  Title: Use index operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0057
+  Title: Use range operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0058
+  Title: Expression value is never used
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0059
+  Title: Unnecessary assignment of a value
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0060
+  Title: Remove unused parameter
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0061
+  Title: Use expression body for local function
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0062
+  Title: Make local function 'static'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0063
+  Title: Use simple 'using' statement
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0064
+  Title: Make readonly fields writable
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0065
+  Title: Misplaced using directive
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0066
+  Title: Convert switch statement to expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0070
+  Title: Use 'System.HashCode'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0071
+  Title: Simplify interpolation
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0072
+  Title: Add missing cases
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0073
+  Title: The file header does not match the required text
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0074
+  Title: Use compound assignment
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0075
+  Title: Simplify conditional expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0076
+  Title: Invalid global 'SuppressMessageAttribute'
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0077
+  Title: Avoid legacy format target in 'SuppressMessageAttribute'
+  Category: CodeQuality
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0078
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0080
+  Title: Remove unnecessary suppression operator
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0082
+  Title: "'typeof' can be converted to 'nameof'"
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0083
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0090
+  Title: Use 'new(...)'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0100
+  Title: Remove redundant equality
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0110
+  Title: Remove unnecessary discard
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0120
+  Title: Simplify LINQ expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0130
+  Title: Namespace does not match folder structure
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0150
+  Title: Prefer 'null' check over type check
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0160
+  Title: Convert to block scoped namespace
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0161
+  Title: Convert to file-scoped namespace
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0170
+  Title: Property pattern can be simplified
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0180
+  Title: Use tuple to swap values
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0200
+  Title: Remove unnecessary lambda expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0210
+  Title: Convert to top-level statements
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0211
+  Title: Convert to 'Program.Main' style program
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0220
+  Title: Add explicit cast
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0230
+  Title: Use UTF-8 string literal
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0240
+  Title: Remove redundant nullable directive
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0241
+  Title: Remove unnecessary nullable directive
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0250
+  Title: Make struct 'readonly'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0251
+  Title: Make member 'readonly'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0260
+  Title: Use pattern matching
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0270
+  Title: Use coalesce expression
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0280
+  Title: Use 'nameof'
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE0290
+  Title: Use primary constructor
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0300
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0301
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0302
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0303
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0304
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0305
+  Title: Simplify collection initialization
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE0320
+  Title: Make anonymous function static
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE1005
+  Title: Delegate invocation can be simplified.
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE1006
+  Title: Naming Styles
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: IDE2000
+  Title: Avoid multiple blank lines
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2001
+  Title: Embedded statements must be on their own line
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2002
+  Title: Consecutive braces must not have blank line between them
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2003
+  Title: Blank line required between block and subsequent statement
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2004
+  Title: Blank line not allowed after constructor initializer colon
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2005
+  Title: Blank line not allowed after conditional expression token
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: IDE2006
+  Title: Blank line not allowed after arrow expression clause token
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0001
+  Title: StringComparison is missing
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0002
+  Title: IEqualityComparer<string> or IComparer<string> is missing
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0003
+  Title: Add parameter name to improve readability
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0004
+  Title: Use Task.ConfigureAwait
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0005
+  Title: Use Array.Empty<T>()
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0006
+  Title: Use String.Equals instead of equality operator
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0007
+  Title: Add a comma after the last value
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0008
+  Title: Add StructLayoutAttribute
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0009
+  Title: Add regex evaluation timeout
+  Category: Security
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0010
+  Title: Mark attributes with AttributeUsageAttribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0011
+  Title: IFormatProvider is missing
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0012
+  Title: Do not raise reserved exception type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0013
+  Title: Types should not extend System.ApplicationException
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0014
+  Title: Do not raise System.ApplicationException type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0015
+  Title: Specify the parameter name in ArgumentException
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0016
+  Title: Prefer using collection abstraction instead of implementation
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0017
+  Title: Abstract types should not have public or internal constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0018
+  Title: Do not declare static members on generic types (deprecated; use CA1000 instead)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0019
+  Title: Use EventArgs.Empty
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0020
+  Title: Use direct methods instead of LINQ methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0021
+  Title: Use StringComparer.GetHashCode instead of string.GetHashCode
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0022
+  Title: Return Task.FromResult instead of returning null
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0023
+  Title: Add RegexOptions.ExplicitCapture
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0024
+  Title: Use an explicit StringComparer when possible
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0025
+  Title: Implement the functionality instead of throwing NotImplementedException
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0026
+  Title: Fix TODO comment
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - None
+  IsEverSuppressed: true
+- Id: MA0027
+  Title: Prefer rethrowing an exception implicitly
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0028
+  Title: Optimize StringBuilder usage
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0029
+  Title: Combine LINQ methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0030
+  Title: Remove useless OrderBy call
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0031
+  Title: Optimize Enumerable.Count() usage
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0032
+  Title: Use an overload with a CancellationToken argument
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0033
+  Title: Do not tag instance fields with ThreadStaticAttribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0035
+  Title: Do not use dangerous threading methods
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0036
+  Title: Make class static
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0037
+  Title: Remove empty statement
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0038
+  Title: Make method static (deprecated, use CA1822 instead)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0039
+  Title: Do not write your own certificate validation method
+  Category: Security
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0040
+  Title: Forward the CancellationToken parameter to methods that take one
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: MA0041
+  Title: Make property static (deprecated, use CA1822 instead)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0042
+  Title: Do not use blocking calls in an async method
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0043
+  Title: Use nameof operator in ArgumentException
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0044
+  Title: Remove useless ToString call
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0045
+  Title: Do not use blocking calls in a sync method (need to make calling method async)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0046
+  Title: Use EventHandler<T> to declare events
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0047
+  Title: Declare types in namespaces
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0048
+  Title: File name must match type name
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0049
+  Title: Type name should not match containing namespace
+  Category: Design
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0050
+  Title: Validate arguments correctly in iterator methods
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0051
+  Title: Method is too long
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: MA0052
+  Title: Replace constant Enum.ToString with nameof
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0053
+  Title: Make class sealed
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0054
+  Title: Embed the caught exception as innerException
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0055
+  Title: Do not use finalizer
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0056
+  Title: Do not call overridable members in constructor
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0057
+  Title: Class name should end with 'Attribute'
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0058
+  Title: Class name should end with 'Exception'
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0059
+  Title: Class name should end with 'EventArgs'
+  Category: Naming
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0060
+  Title: The value returned by Stream.Read/Stream.ReadAsync is not used
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0061
+  Title: Method overrides should not change default values
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0062
+  Title: Non-flags enums should not be marked with "FlagsAttribute"
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0063
+  Title: Use Where before OrderBy
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0064
+  Title: Avoid locking on publicly accessible instance
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0065
+  Title: Default ValueType.Equals or HashCode is used for struct equality
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0066
+  Title: Hash table unfriendly type is used in a hash table
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0067
+  Title: Use Guid.Empty
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0068
+  Title: Invalid parameter name for nullable attribute
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0069
+  Title: Non-constant static fields should not be visible
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0070
+  Title: Obsolete attributes should include explanations
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0071
+  Title: Avoid using redundant else
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0072
+  Title: Do not throw from a finally block
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0073
+  Title: Avoid comparison with bool constant
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0074
+  Title: Avoid implicit culture-sensitive methods
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0075
+  Title: Do not use implicit culture-sensitive ToString
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0076
+  Title: Do not use implicit culture-sensitive ToString in interpolated strings
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0077
+  Title: A class that provides Equals(T) should implement IEquatable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0078
+  Title: Use 'Cast' instead of 'Select' to cast
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0079
+  Title: Forward the CancellationToken using .WithCancellation()
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0080
+  Title: Use a cancellation token using .WithCancellation()
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0081
+  Title: Method overrides should not omit params keyword
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0082
+  Title: NaN should not be used in comparisons
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0083
+  Title: ConstructorArgument parameters should exist in constructors
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0084
+  Title: Local variables should not hide other symbols
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0085
+  Title: Anonymous delegates should not be used to unsubscribe from Events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0086
+  Title: Do not throw from a finalizer
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0087
+  Title: Parameters with [DefaultParameterValue] attributes should also be marked [Optional]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0088
+  Title: Use [DefaultParameterValue] instead of [DefaultValue]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0089
+  Title: Optimize string method usage
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0090
+  Title: Remove empty else/finally block
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0091
+  Title: Sender should be 'this' for instance events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0092
+  Title: Sender should be 'null' for static events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0093
+  Title: EventArgs should not be null
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0094
+  Title: A class that provides CompareTo(T) should implement IComparable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0095
+  Title: A class that implements IEquatable<T> should override Equals(object)
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0096
+  Title: A class that implements IComparable<T> should also implement IEquatable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0097
+  Title: A class that implements IComparable<T> or IComparable should override comparison operators
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0098
+  Title: Use indexer instead of LINQ methods
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0099
+  Title: Use Explicit enum value instead of 0
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0100
+  Title: Await task before disposing of resources
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0101
+  Title: String contains an implicit end of line character
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: MA0102
+  Title: Make member readonly
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0103
+  Title: Use SequenceEqual instead of equality operator
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0104
+  Title: Do not create a type with a name from the BCL
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0105
+  Title: Use the lambda parameters instead of using a closure
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0106
+  Title: Avoid closure by using an overload with the 'factoryArgument' parameter
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0107
+  Title: Do not use culture-sensitive object.ToString
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0108
+  Title: Remove redundant argument value
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0109
+  Title: Consider adding an overload with a Span<T> or Memory<T>
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0110
+  Title: Use the Regex source generator
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0111
+  Title: Use string.Create instead of FormattableString
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0112
+  Title: Use 'Count > 0' instead of 'Any()'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0113
+  Title: Use DateTime.UnixEpoch
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0114
+  Title: Use DateTimeOffset.UnixEpoch
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0115
+  Title: Unknown component parameter
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0116
+  Title: Parameters with [SupplyParameterFromQuery] attributes should also be marked as [Parameter]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0117
+  Title: Parameters with [EditorRequired] attributes should also be marked as [Parameter]
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0118
+  Title: '[JSInvokable] methods must be public'
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0119
+  Title: JSRuntime must not be used in OnInitialized or OnInitializedAsync
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0120
+  Title: Use InvokeVoidAsync when the returned value is not used
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0121
+  Title: Do not overwrite parameter value
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0122
+  Title: Parameters with [SupplyParameterFromQuery] attributes are only valid in routable components (@page)
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0123
+  Title: Sequence number must be a constant
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0124
+  Title: Log parameter type is not valid
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0125
+  Title: The list of log parameter types contains an invalid type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0126
+  Title: The list of log parameter types contains a duplicate
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0127
+  Title: Use String.Equals instead of is pattern
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0128
+  Title: Use 'is' operator instead of SequenceEqual
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0129
+  Title: Await task in using statement
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0130
+  Title: GetType() should not be used on System.Type instances
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0131
+  Title: ArgumentNullException.ThrowIfNull should not be used with non-nullable types
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0132
+  Title: Do not convert implicitly to DateTimeOffset
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0133
+  Title: Use DateTimeOffset instead of relying on the implicit conversion
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0134
+  Title: Observe result of async calls
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0135
+  Title: The log parameter has no configured type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: MA0136
+  Title: Raw String contains an implicit end of line character
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: MA0137
+  Title: Use 'Async' suffix when a method returns an awaitable type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0138
+  Title: Do not use 'Async' suffix when a method does not return an awaitable type
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0139
+  Title: Log parameter type is not valid
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0140
+  Title: Both if and else branch have identical code
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0141
+  Title: Use pattern matching instead of inequality operators for null check
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0142
+  Title: Use pattern matching instead of equality operators for null check
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0143
+  Title: Primary constructor parameters should be readonly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0144
+  Title: Use System.OperatingSystem to check the current OS
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0145
+  Title: Signature for [UnsafeAccessorAttribute] method is not valid
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0146
+  Title: Name must be set explicitly on local functions
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0147
+  Title: Avoid async void method for delegate
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0148
+  Title: Use pattern matching instead of equality operators for discrete value
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0149
+  Title: Use pattern matching instead of inequality operators for discrete value
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0150
+  Title: Do not call the default object.ToString explicitly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0151
+  Title: DebuggerDisplay must contain valid members
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0152
+  Title: Use Unwrap instead of using await twice
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0153
+  Title: Do not log symbols decorated with DataClassificationAttribute directly
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0154
+  Title: Use langword in XML comment
+  Category: Design
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0155
+  Title: Do not use async void methods
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0156
+  Title: Use 'Async' suffix when a method returns IAsyncEnumerable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0157
+  Title: Do not use 'Async' suffix when a method does not return IAsyncEnumerable<T>
+  Category: Design
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: MA0158
+  Title: Use System.Threading.Lock
+  Category: Performance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: MA0159
+  Title: Use 'Order' instead of 'OrderBy'
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: MA0160
+  Title: Use ContainsKey instead of TryGetValue
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: POLYSP0003
+  Title: Unsupported C# language version
+  Category: Microsoft.CodeAnalysis.CSharp.CSharpParseOptions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1001
+  Title: Add braces (when expression spans over multiple lines)
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1002
+  Title: Remove braces
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1002FadeOut
+  Title: Remove braces
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1003
+  Title: Add braces to if-else (when expression spans over multiple lines)
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1004
+  Title: Remove braces from if-else
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1004FadeOut
+  Title: Remove braces from if-else
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1005
+  Title: Simplify nested using statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1005FadeOut
+  Title: Simplify nested using statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1006
+  Title: Merge 'else' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1006FadeOut
+  Title: Merge 'else' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1007
+  Title: Add braces
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1008
+  Title: "[deprecated] Use explicit type instead of 'var' (when the type is not obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1009
+  Title: "[deprecated] Use explicit type instead of 'var' (foreach variable)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1010
+  Title: "[deprecated] Use 'var' instead of explicit type (when the type is obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1012
+  Title: "[deprecated] Use explicit type instead of 'var' (when the type is obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1013
+  Title: Use predefined type
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1014
+  Title: Use explicitly/implicitly typed array
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1015
+  Title: Use nameof operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1015FadeOut
+  Title: Use nameof operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1016
+  Title: Use block body or expression body
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1018
+  Title: Add/remove accessibility modifiers
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1019
+  Title: Order modifiers
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1020
+  Title: Simplify Nullable<T> to T?
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1021
+  Title: Convert lambda expression body to expression body
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1021FadeOut
+  Title: Convert lambda expression body to expression body
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1031
+  Title: Remove unnecessary braces in switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1031FadeOut
+  Title: Remove unnecessary braces in switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1032
+  Title: Remove redundant parentheses
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1032FadeOut
+  Title: Remove redundant parentheses
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1033
+  Title: Remove redundant boolean literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1034
+  Title: Remove redundant 'sealed' modifier
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1035
+  Title: '[deprecated] Remove redundant comma in initializer'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1036
+  Title: Remove unnecessary blank line
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1037
+  Title: Remove trailing white-space
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1038
+  Title: '[deprecated] Remove empty statement'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1039
+  Title: Remove argument list from attribute
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1040
+  Title: "[deprecated] Remove empty 'else' clause"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1041
+  Title: '[deprecated] Remove empty initializer'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1042
+  Title: Remove enum default underlying type
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1043
+  Title: Remove 'partial' modifier from type with a single part
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1044
+  Title: Remove original exception from throw statement
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1046
+  Title: Asynchronous method name should end with 'Async'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1047
+  Title: Non-asynchronous method name should not end with 'Async'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1047FadeOut
+  Title: Non-asynchronous method name should not end with 'Async'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1048
+  Title: Use lambda expression instead of anonymous method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1048FadeOut
+  Title: Use lambda expression instead of anonymous method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1049
+  Title: Simplify boolean comparison
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1049FadeOut
+  Title: Simplify boolean comparison
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1050
+  Title: Include/omit parentheses when creating new object
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1051
+  Title: Add/remove parentheses from condition in conditional operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1052
+  Title: Declare each attribute separately
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1055
+  Title: Unnecessary semicolon at the end of declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1056
+  Title: Avoid usage of using alias directive
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1058
+  Title: Use compound assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1058FadeOut
+  Title: Use compound assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1059
+  Title: Avoid locking on publicly accessible instance
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1060
+  Title: Declare each type in separate file
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1061
+  Title: Merge 'if' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1061FadeOut
+  Title: Merge 'if' with nested 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1063
+  Title: '[deprecated] Avoid usage of do statement to create an infinite loop'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1064
+  Title: '[deprecated] Avoid usage of for statement to create an infinite loop'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1065
+  Title: '[deprecated] Avoid usage of while statement to create an infinite loop'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1066
+  Title: "[deprecated] Remove empty 'finally' clause"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1066FadeOut
+  Title: "[deprecated] Remove empty 'finally' clause"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1068
+  Title: Simplify logical negation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1069
+  Title: Remove unnecessary case label
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1070
+  Title: Remove redundant default switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1071
+  Title: Remove redundant base constructor call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1072
+  Title: '[deprecated] Remove empty namespace declaration'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1073
+  Title: Convert 'if' to 'return' statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1073FadeOut
+  Title: Convert 'if' to 'return' statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1074
+  Title: Remove redundant constructor
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1075
+  Title: Avoid empty catch clause that catches System.Exception
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1077
+  Title: Optimize LINQ method call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1078
+  Title: Use "" or 'string.Empty'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1079
+  Title: Throwing of new NotImplementedException
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1080
+  Title: Use 'Count/Length' property instead of 'Any' method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1081
+  Title: Split variable declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1084
+  Title: Use coalesce expression instead of conditional expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1085
+  Title: Use auto-implemented property
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1085FadeOut
+  Title: Use auto-implemented property
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1089
+  Title: Use --/++ operator instead of assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1089FadeOut
+  Title: Use --/++ operator instead of assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1090
+  Title: Add/remove 'ConfigureAwait(false)' call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1091
+  Title: '[deprecated] Remove empty region'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1091FadeOut
+  Title: '[deprecated] Remove empty region'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1093
+  Title: File contains no code
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1094
+  Title: Declare using directive on top level
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1096
+  Title: Use 'HasFlag' method or bitwise operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1097
+  Title: Remove redundant 'ToString' call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1098
+  Title: Constant values should be placed on right side of comparisons
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1099
+  Title: Default label should be the last label in a switch section
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1100
+  Title: '[deprecated] Format documentation summary on a single line'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1101
+  Title: '[deprecated] Format documentation summary on multiple lines'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1102
+  Title: Make class static
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1103
+  Title: Convert 'if' to assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1104
+  Title: Simplify conditional expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1105
+  Title: Unnecessary interpolation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1106
+  Title: '[deprecated] Remove empty destructor'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1107
+  Title: Remove redundant 'ToCharArray' call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1108
+  Title: Add 'static' modifier to all partial class declarations
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1110
+  Title: Declare type inside namespace
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1111
+  Title: Add braces to switch section with multiple statements
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1112
+  Title: Combine 'Enumerable.Where' method chain
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1112FadeOut
+  Title: Combine 'Enumerable.Where' method chain
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1113
+  Title: Use 'string.IsNullOrEmpty' method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1114
+  Title: Remove redundant delegate creation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1114FadeOut
+  Title: Remove redundant delegate creation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1118
+  Title: Mark local variable as const
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1123
+  Title: Add parentheses when necessary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1124
+  Title: Inline local variable
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1124FadeOut
+  Title: Inline local variable
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1126
+  Title: Add braces to if-else
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1128
+  Title: Use coalesce expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1129
+  Title: Remove redundant field initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1130
+  Title: Bitwise operation on enum without Flags attribute
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1132
+  Title: Remove redundant overriding member
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1133
+  Title: Remove redundant Dispose/Close call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1134
+  Title: Remove redundant statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1135
+  Title: Declare enum member with zero value (when enum has FlagsAttribute)
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1136
+  Title: Merge switch sections with equivalent content
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1138
+  Title: Add summary to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1139
+  Title: Add summary element to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1140
+  Title: Add exception to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1141
+  Title: Add 'param' element to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1142
+  Title: Add 'typeparam' element to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1143
+  Title: Simplify coalesce expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1145
+  Title: Remove redundant 'as' operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1146
+  Title: Use conditional access
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1151
+  Title: Remove redundant cast
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1154
+  Title: Sort enum members
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1155
+  Title: Use StringComparison when comparing strings
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1156
+  Title: Use string.Length instead of comparison with empty string
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1157
+  Title: Composite enum value contains undefined flag
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1158
+  Title: Static member in generic type should use a type parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1159
+  Title: Use EventHandler<T>
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1160
+  Title: Abstract type should not have public constructors
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1161
+  Title: Enum should declare explicit values
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1162
+  Title: Avoid chain of assignments
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1163
+  Title: Unused parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1164
+  Title: Unused type parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1165
+  Title: Unconstrained type parameter checked for null
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1166
+  Title: Value type object is never equal to null
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1168
+  Title: Parameter name differs from base name
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1169
+  Title: Make field read-only
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1170
+  Title: Use read-only auto-implemented property
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1171
+  Title: Simplify lazy initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1172
+  Title: Use 'is' operator instead of 'as' operator
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1173
+  Title: Use coalesce expression instead of 'if'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1174
+  Title: Remove redundant async/await
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1174FadeOut
+  Title: Remove redundant async/await
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1175
+  Title: Unused 'this' parameter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1176
+  Title: "[deprecated] Use 'var' instead of explicit type (when the type is not obvious)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1177
+  Title: "[deprecated] Use 'var' instead of explicit type (in foreach)"
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1179
+  Title: Unnecessary assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1180
+  Title: Inline lazy initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1181
+  Title: Convert comment to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1182
+  Title: Remove redundant base interface
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1186
+  Title: Use Regex instance instead of static method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1187
+  Title: Use constant instead of field
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1188
+  Title: Remove redundant auto-property initialization
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1189
+  Title: Add or remove region name
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1190
+  Title: Join string expressions
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1191
+  Title: Declare enum value as combination of names
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1192
+  Title: Unnecessary usage of verbatim string literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1193
+  Title: Overriding member should not change 'params' modifier
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1194
+  Title: Implement exception constructors
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1195
+  Title: Use ^ operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1196
+  Title: Call extension method as instance method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1197
+  Title: Optimize StringBuilder.Append/AppendLine call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1198
+  Title: Avoid unnecessary boxing of value type
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1199
+  Title: Unnecessary null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1200
+  Title: Call 'Enumerable.ThenBy' instead of 'Enumerable.OrderBy'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1201
+  Title: Use method chaining
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1202
+  Title: Avoid NullReferenceException
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1203
+  Title: Use AttributeUsageAttribute
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1204
+  Title: Use EventArgs.Empty
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1205
+  Title: Order named arguments according to the order of parameters
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1206
+  Title: Use conditional access instead of conditional expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1207
+  Title: Use anonymous function or method group
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1208
+  Title: Reduce 'if' nesting
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1209
+  Title: Order type parameter constraints
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1210
+  Title: Return completed task instead of returning null
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1211
+  Title: Remove unnecessary 'else'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1212
+  Title: Remove redundant assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1212FadeOut
+  Title: Remove redundant assignment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1213
+  Title: Remove unused member declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1214
+  Title: Unnecessary interpolated string
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1214FadeOut
+  Title: Unnecessary interpolated string
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1215
+  Title: Expression is always equal to true/false
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1216
+  Title: Unnecessary unsafe context
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1217
+  Title: Convert interpolated string to concatenation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1217FadeOut
+  Title: Convert interpolated string to concatenation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1218
+  Title: Simplify code branching
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1220
+  Title: Use pattern matching instead of combination of 'is' operator and cast operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1221
+  Title: Use pattern matching instead of combination of 'as' operator and null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1222
+  Title: Merge preprocessor directives
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1223
+  Title: Mark publicly visible type with DebuggerDisplay attribute
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1224
+  Title: Make method an extension method
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1225
+  Title: Make class sealed
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1226
+  Title: Add paragraph to documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1227
+  Title: Validate arguments correctly
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1228
+  Title: Unused element in a documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1229
+  Title: Use async/await when necessary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1230
+  Title: Unnecessary explicit use of enumerator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1231
+  Title: Make parameter ref read-only
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RCS1232
+  Title: Order elements in documentation comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1233
+  Title: Use short-circuiting operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1234
+  Title: Duplicate enum value
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1235
+  Title: Optimize method call
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1236
+  Title: Use exception filter
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1237
+  Title: '[deprecated] Use bit shift operator'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1238
+  Title: 'Avoid nested ?: operators'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1239
+  Title: Use 'for' statement instead of 'while' statement
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1240
+  Title: Operator is unnecessary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1241
+  Title: Implement non-generic counterpart
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1242
+  Title: Do not pass non-read-only struct by read-only reference
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1243
+  Title: Duplicate word in a comment
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1244
+  Title: Simplify 'default' expression
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: RCS1246
+  Title: Use element access
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1247
+  Title: Fix documentation comment tag
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1248
+  Title: Normalize null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1249
+  Title: Unnecessary null-forgiving operator
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1250
+  Title: Use implicit/explicit object creation
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1251
+  Title: Remove unnecessary braces from record declaration
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1252
+  Title: Normalize usage of infinite loop
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1253
+  Title: Format documentation comment summary
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1254
+  Title: Normalize format of enum flag value
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1255
+  Title: Simplify argument null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1256
+  Title: Invalid argument null check
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1257
+  Title: Use enum field explicitly
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1258
+  Title: Unnecessary enum flag
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1259
+  Title: Remove empty syntax
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1260
+  Title: Add/remove trailing comma
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1261
+  Title: Resource can be disposed asynchronously
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1262
+  Title: Unnecessary raw string literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1263
+  Title: Invalid reference in a documentation comment
+  Category: Roslynator
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RCS1264
+  Title: Use 'var' or explicit type
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RCS1265
+  Title: Remove redundant catch block
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1266
+  Title: Use raw string literal
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1267
+  Title: Use string interpolation instead of 'string.Concat'
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RCS1268
+  Title: Simplify numeric comparison
+  Category: Roslynator
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: RemoveUnnecessaryImportsFixable
+  Title: ''
+  Category: Style
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: ROS0002
+  Title: Analyzer option is obsolete
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: ROS0003
+  Title: Analyzer requires config option to be specified
+  Category: ''
+  DefaultSeverity: Note
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: RS1001
+  Title: Missing diagnostic analyzer attribute
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1002
+  Title: Missing kind argument when registering an analyzer action
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1003
+  Title: Unsupported SymbolKind argument when registering a symbol analyzer action
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1004
+  Title: Recommend adding language support to diagnostic analyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1005
+  Title: ReportDiagnostic invoked with an unsupported DiagnosticDescriptor
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1006
+  Title: Invalid type argument for DiagnosticAnalyzer's Register method
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1007
+  Title: Provide localizable arguments to diagnostic descriptor constructor
+  Category: MicrosoftCodeAnalysisLocalization
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1008
+  Title: Avoid storing per-compilation data into the fields of a diagnostic analyzer
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1009
+  Title: Only internal implementations of this interface are allowed
+  Category: MicrosoftCodeAnalysisCompatibility
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1010
+  Title: Create code actions should have a unique EquivalenceKey for FixAll occurrences support
+  Category: Correctness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1011
+  Title: Use code actions that have a unique EquivalenceKey for FixAll occurrences support
+  Category: Correctness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1012
+  Title: Start action has no registered actions
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1013
+  Title: Start action has no registered non-end actions
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1014
+  Title: Do not ignore values returned by methods on immutable objects
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1015
+  Title: Provide non-null 'helpLinkUri' value to diagnostic descriptor constructor
+  Category: MicrosoftCodeAnalysisDocumentation
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1016
+  Title: Code fix providers should provide FixAll support
+  Category: Correctness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1017
+  Title: DiagnosticId for analyzers must be a non-null constant
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1018
+  Title: DiagnosticId for analyzers must be in specified format
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1019
+  Title: DiagnosticId must be unique across analyzers
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1020
+  Title: Category for analyzers must be from the specified values
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1021
+  Title: Invalid entry in analyzer category and diagnostic ID range specification file
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1022
+  Title: Do not use types from Workspaces assembly in an analyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1023
+  Title: Upgrade MSBuildWorkspace
+  Category: Library
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1024
+  Title: Symbols should be compared for equality
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1025
+  Title: Configure generated code analysis
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: true
+- Id: RS1026
+  Title: Enable concurrent execution
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: true
+- Id: RS1027
+  Title: Types marked with DiagnosticAnalyzerAttribute(s) should inherit from DiagnosticAnalyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1028
+  Title: Provide non-null 'customTags' value to diagnostic descriptor constructor
+  Category: MicrosoftCodeAnalysisDocumentation
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: RS1029
+  Title: Do not use reserved diagnostic IDs
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1030
+  Title: Do not invoke Compilation.GetSemanticModel() method within a diagnostic analyzer
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1031
+  Title: Define diagnostic title correctly
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1032
+  Title: Define diagnostic message correctly
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1033
+  Title: Define diagnostic description correctly
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1034
+  Title: Prefer 'IsKind' for checking syntax kinds
+  Category: MicrosoftCodeAnalysisPerformance
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1035
+  Title: Do not use APIs banned for analyzers
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1036
+  Title: Specify analyzer banned API enforcement setting
+  Category: MicrosoftCodeAnalysisCorrectness
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS1037
+  Title: Add "CompilationEnd" custom tag to compilation end diagnostic descriptor
+  Category: MicrosoftCodeAnalysisDesign
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2000
+  Title: Add analyzer diagnostic IDs to analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2001
+  Title: Ensure up-to-date entry for analyzer diagnostic IDs are added to analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2002
+  Title: Do not add removed analyzer diagnostic IDs to unshipped analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2003
+  Title: Shipped diagnostic IDs that are no longer reported should have an entry in the 'Removed Rules' table in unshipped file
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2004
+  Title: Diagnostic IDs marked as removed in analyzer release file should not be reported by analyzers
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2005
+  Title: Remove duplicate entries for diagnostic ID in the same analyzer release
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2006
+  Title: Remove duplicate entries for diagnostic ID between analyzer releases
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2007
+  Title: Invalid entry in analyzer release file
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: RS2008
+  Title: Enable analyzer release tracking
+  Category: MicrosoftCodeAnalysisReleaseTracking
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S100
+  Title: Methods and properties should be named in PascalCase
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S1006
+  Title: Method overrides should not change parameter defaults
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S101
+  Title: Types should be named in PascalCase
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S103
+  Title: Lines should not be too long
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S104
+  Title: Files should not have too many lines of code
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1048
+  Title: Finalizers should not throw exceptions
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S105
+  Title: Tabulation characters should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S106
+  Title: Standard outputs should not be used directly to log anything
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1066
+  Title: Mergeable "if" statements should be combined
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1067
+  Title: Expressions should not be too complex
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S107
+  Title: Methods should not have too many parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1075
+  Title: URIs should not be hardcoded
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S108
+  Title: Nested blocks of code should not be left empty
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S109
+  Title: Magic numbers should not be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S110
+  Title: Inheritance tree of classes should not be too deep
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1104
+  Title: Fields should not have public accessibility
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1109
+  Title: A close curly brace should be located at the beginning of a line
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1110
+  Title: Redundant pairs of parentheses should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1116
+  Title: Empty statements should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1117
+  Title: Local variables should not shadow class fields or properties
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1118
+  Title: Utility classes should not have public constructors
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S112
+  Title: General or reserved exceptions should never be thrown
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1121
+  Title: Assignments should not be made from within sub-expressions
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1123
+  Title: '"Obsolete" attributes should include explanations'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1125
+  Title: Boolean literals should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1128
+  Title: Unnecessary "using" should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S113
+  Title: Files should end with a newline
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1133
+  Title: Deprecated code should be removed
+  Category: Info Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1134
+  Title: Track uses of "FIXME" tags
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1135
+  Title: Track uses of "TODO" tags
+  Category: Info Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: false
+- Id: S1144
+  Title: Unused private types or members should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1147
+  Title: Exit methods should not be called
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1151
+  Title: '"switch case" clauses should not have too many lines of code'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1155
+  Title: '"Any()" should be used to test for emptiness'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1163
+  Title: Exceptions should not be thrown in finally blocks
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1168
+  Title: Empty arrays and collections should be returned instead of null
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1172
+  Title: Unused method parameters should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1185
+  Title: Overriding members should do more than simply call the same member in the base class
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1186
+  Title: Methods should not be empty
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1192
+  Title: String literals should not be duplicated
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1199
+  Title: Nested code blocks should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1200
+  Title: Classes should not be coupled to too many other classes
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1206
+  Title: '"Equals(Object)" and "GetHashCode()" should be overridden in pairs'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S121
+  Title: Control structures should use curly braces
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1210
+  Title: '"Equals" and the comparison operators should be overridden when implementing "IComparable"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1215
+  Title: '"GC.Collect" should not be called'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S122
+  Title: Statements should be on separate lines
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1226
+  Title: Method parameters, caught exceptions and foreach variables' initial values should not be ignored
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1227
+  Title: break statements should not be used except for switch cases
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1244
+  Title: Floating point numbers should not be tested for equality
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S125
+  Title: Sections of code should not be commented out
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S126
+  Title: '"if ... else if" constructs should end with "else" clauses'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1264
+  Title: A "while" loop should be used instead of a "for" loop
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S127
+  Title: '"for" loop stop conditions should be invariant'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1301
+  Title: '"switch" statements should have at least 3 "case" clauses'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1309
+  Title: Track uses of in-source issue suppressions
+  Category: Info Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S131
+  Title: '"switch/Select" statements should contain a "default/Case Else" clauses'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1312
+  Title: Logger fields should be "private static readonly"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1313
+  Title: Using hardcoded IP addresses is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S134
+  Title: Control flow statements "if", "switch", "for", "foreach", "while", "do"  and "try" should not be nested too deeply
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S138
+  Title: Functions should not have too many lines of code
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1449
+  Title: Culture should be specified for "string" operations
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1450
+  Title: Private fields only used as local variables in methods should become local variables
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1451
+  Title: Track lack of copyright and license headers
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1479
+  Title: '"switch" statements with many "case" clauses should have only one statement'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1481
+  Title: Unused local variables should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1541
+  Title: Methods and properties should not be too complex
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1607
+  Title: Tests should not be ignored
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1643
+  Title: Strings should not be concatenated using '+' in a loop
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1656
+  Title: Variables should not be self-assigned
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1659
+  Title: Multiple variables should not be declared on the same line
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1694
+  Title: An abstract class should have both abstract and concrete methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1696
+  Title: NullReferenceException should not be caught
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1698
+  Title: '"==" should not be used when "Equals" is overridden'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1699
+  Title: Constructors should only call non-overridable methods
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1751
+  Title: Loops with at most one iteration should be refactored
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1764
+  Title: Identical expressions should not be used on both sides of operators
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1821
+  Title: '"switch" statements should not be nested'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1848
+  Title: Objects should not be created to be dropped immediately without being used
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1854
+  Title: Unused assignments should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1858
+  Title: '"ToString()" calls should not be redundant'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S1862
+  Title: Related "if/else if" statements should not have the same condition
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1871
+  Title: Two branches in a conditional structure should not have exactly the same implementation
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1905
+  Title: Redundant casts should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1939
+  Title: Inheritance list should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1940
+  Title: Boolean checks should not be inverted
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1944
+  Title: Invalid casts should be avoided
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S1994
+  Title: "\"for\" loop increment clauses should modify the loops' counters"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2053
+  Title: Password hashing functions should use an unpredictable salt
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2068
+  Title: Hard-coded credentials are security-sensitive
+  Category: Blocker Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2077
+  Title: Formatting SQL queries is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2092
+  Title: Creating cookies without the "secure" flag is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2094
+  Title: Classes should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2114
+  Title: Collections should not be passed as arguments to their own methods
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2115
+  Title: A secure password should be used when connecting to a database
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2123
+  Title: Values should not be uselessly incremented
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2139
+  Title: Exceptions should be either logged or rethrown but not both
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2148
+  Title: Underscores should be used to make large numbers readable
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2156
+  Title: '"sealed" classes should not have "protected" members'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2166
+  Title: Classes named like "Exception" should extend "Exception" or a subclass
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2178
+  Title: Short-circuit logic should be used in boolean contexts
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2183
+  Title: Integral numbers should not be shifted by zero or more than their number of bits-1
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2184
+  Title: Results of integer division should not be assigned to floating point variables
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2187
+  Title: Test classes should contain at least one test case
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2190
+  Title: Loops and recursions should not be infinite
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2197
+  Title: Modulus results should not be checked for direct equality
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2198
+  Title: Unnecessary mathematical comparisons should not be made
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2201
+  Title: Methods without side effects should not have their return values ignored
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2219
+  Title: Runtime type checking should be simplified
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2221
+  Title: '"Exception" should not be caught'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2222
+  Title: Locks should be released on all paths
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2223
+  Title: Non-constant static fields should not be visible
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2225
+  Title: '"ToString()" method should not return null'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2234
+  Title: Arguments should be passed in the same order as the method parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2245
+  Title: Using pseudorandom number generators (PRNGs) is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2251
+  Title: A "for" loop update clause should move the counter in the right direction
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2252
+  Title: For-loop conditions should be true at least once
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2257
+  Title: Using non-standard cryptographic algorithms is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2259
+  Title: Null pointers should not be dereferenced
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2275
+  Title: Composite format strings should not lead to unexpected behavior at runtime
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2290
+  Title: Field-like events should not be virtual
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2291
+  Title: Overflow checking should not be disabled for "Enumerable.Sum"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2292
+  Title: Trivial properties should be auto-implemented
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2302
+  Title: '"nameof" should be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2306
+  Title: '"async" and "await" should not be used as identifiers'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2325
+  Title: Methods and properties that don't access instance data should be static
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2326
+  Title: Unused type parameters should be removed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2327
+  Title: '"try" statements with identical "catch" and/or "finally" blocks should be merged'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2328
+  Title: '"GetHashCode" should not reference mutable fields'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2330
+  Title: Array covariance should not be used
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2333
+  Title: Redundant modifiers should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2339
+  Title: Public constant members should not be used
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2342
+  Title: Enumeration types should comply with a naming convention
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2344
+  Title: Enumeration type names should not have "Flags" or "Enum" suffixes
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2345
+  Title: Flags enumerations should explicitly initialize all their members
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2346
+  Title: Flags enumerations zero-value members should be named "None"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2357
+  Title: Fields should be private
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2360
+  Title: Optional parameters should not be used
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2365
+  Title: Properties should not make collection or array copies
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2368
+  Title: Public methods should not have multidimensional array parameters
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2372
+  Title: Exceptions should not be thrown from property getters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2376
+  Title: Write-only properties should not be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2386
+  Title: Mutable fields should not be "public static"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2387
+  Title: Child class fields should not shadow parent class fields
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2436
+  Title: Types and methods should not have too many generic parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2437
+  Title: Unnecessary bit operations should not be performed
+  Category: Blocker Code Smell
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: S2445
+  Title: Blocks should be synchronized on read-only fields
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2479
+  Title: Whitespace and control characters in string literals should be explicit
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2486
+  Title: Generic exceptions should not be ignored
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2551
+  Title: Shared resources should not be used for locking
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2583
+  Title: Conditionally executed code should be reachable
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2589
+  Title: Boolean expressions should not be gratuitous
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2612
+  Title: Setting loose file permissions is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2629
+  Title: Logging templates should be constant
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2674
+  Title: The length returned from a stream read should be checked
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2681
+  Title: Multiline blocks should be enclosed in curly braces
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2688
+  Title: '"NaN" should not be used in comparisons'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2692
+  Title: '"IndexOf" checks should not be for positive numbers'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2696
+  Title: Instance members should not write to "static" fields
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2699
+  Title: Tests should include assertions
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2701
+  Title: Literal boolean values should not be used in assertions
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2737
+  Title: '"catch" clauses should do more than rethrow'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2743
+  Title: Static fields should not be used in generic types
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2755
+  Title: XML parsers should not be vulnerable to XXE attacks
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2757
+  Title: Non-existent operators like "=+" should not be used
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2760
+  Title: Sequential tests should not check the same condition
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2761
+  Title: Doubled prefix operators "!!" and "~~" should not be used
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2857
+  Title: SQL keywords should be delimited by whitespace
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2925
+  Title: '"Thread.Sleep" should not be used in tests'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2930
+  Title: '"IDisposables" should be disposed'
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2931
+  Title: Classes with "IDisposable" members should implement "IDisposable"
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2933
+  Title: Fields that are only assigned in the constructor should be "readonly"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2934
+  Title: Property assignments should not be made for "readonly" fields not constrained to reference types
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2952
+  Title: Classes should "Dispose" of members from the classes' own "Dispose" methods
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S2953
+  Title: Methods named "Dispose" should implement "IDisposable.Dispose"
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2955
+  Title: Generic parameters not constrained to reference types should not be compared to "null"
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2970
+  Title: Assertions should be complete
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2971
+  Title: LINQ expressions should be simplified
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2995
+  Title: '"Object.ReferenceEquals" should not be used for value types'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2996
+  Title: '"ThreadStatic" fields should not be initialized'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S2997
+  Title: '"IDisposables" created in a "using" statement should not be returned'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3005
+  Title: '"ThreadStatic" should not be used on non-static fields'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3010
+  Title: Static fields should not be updated in constructors
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3011
+  Title: Reflection should not be used to increase accessibility of classes, methods, or fields
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3052
+  Title: Members should not be initialized to default values
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3059
+  Title: Types should not have members with visibility set higher than the type's visibility
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3060
+  Title: '"is" should not be used with "this"'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3063
+  Title: '"StringBuilder" data should be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3168
+  Title: '"async" methods should not return "void"'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3169
+  Title: Multiple "OrderBy" calls should not be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3172
+  Title: Delegates should not be subtracted
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3215
+  Title: '"interface" instances should not be cast to concrete types'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3216
+  Title: '"ConfigureAwait(false)" should be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3217
+  Title: '"Explicit" conversions of "foreach" loops should not be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3218
+  Title: Inner class members should not shadow outer class "static" or type members
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3220
+  Title: Method calls should not resolve ambiguously to overloads with "params"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3234
+  Title: '"GC.SuppressFinalize" should not be invoked for types without destructors'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3235
+  Title: Redundant parentheses should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3236
+  Title: Caller information arguments should not be provided explicitly
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3237
+  Title: '"value" contextual keyword should be used'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3240
+  Title: The simplest possible condition syntax should be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3241
+  Title: Methods should not return values that are never used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3242
+  Title: Method parameters should be declared with base types
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3244
+  Title: Anonymous delegates should not be used to unsubscribe from Events
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3246
+  Title: Generic type parameters should be co/contravariant when possible
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3247
+  Title: Duplicate casts should not be made
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3249
+  Title: Classes directly extending "object" should not call "base" in "GetHashCode" or "Equals"
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3251
+  Title: Implementations should be provided for "partial" methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3253
+  Title: Constructor and destructor declarations should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3254
+  Title: Default parameter values should not be passed as arguments
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3256
+  Title: '"string.IsNullOrEmpty" should be used'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3257
+  Title: Declarations and initializations should be as concise as possible
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3260
+  Title: Non-derived "private" classes and records should be "sealed"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3261
+  Title: Namespaces should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3262
+  Title: '"params" should be used on overrides'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3263
+  Title: 'Static fields should appear in the order they must be initialized '
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3264
+  Title: Events should be invoked
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3265
+  Title: Non-flags enums should not be used in bitwise operations
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3267
+  Title: Loops should be simplified with "LINQ" expressions
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3329
+  Title: Cipher Block Chaining IVs should be unpredictable
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3330
+  Title: Creating cookies without the "HttpOnly" flag is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3343
+  Title: Caller information parameters should come at the end of the parameter list
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3346
+  Title: Expressions used in "Debug.Assert" should not produce side effects
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3353
+  Title: Unchanged variables should be marked as "const"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3358
+  Title: Ternary operators should not be nested
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3363
+  Title: Date and time should not be used as a type for primary keys
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3366
+  Title: '"this" should not be exposed from constructors'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3376
+  Title: Attribute, EventArgs, and Exception type names should end with the type being extended
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3397
+  Title: '"base.Equals" should not be used to check for reference equality in "Equals" if "base" is not "object"'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3398
+  Title: '"private" methods called only by inner classes should be moved to those classes'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3400
+  Title: Methods should not return constants
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3415
+  Title: Assertion arguments should be passed in the correct order
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3416
+  Title: Loggers should be named for their enclosing types
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3427
+  Title: Method overloads with default parameter values should not overlap
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3431
+  Title: '"[ExpectedException]" should not be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3433
+  Title: Test method signatures should be correct
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3440
+  Title: Variables should not be checked against the values they're about to be assigned
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3441
+  Title: Redundant property names should be omitted in anonymous classes
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3442
+  Title: '"abstract" classes should not have "public" constructors'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3443
+  Title: Type should not be examined on "System.Type" instances
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3444
+  Title: Interfaces should not simply inherit from base interfaces with colliding members
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3445
+  Title: Exceptions should not be explicitly rethrown
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3447
+  Title: '"[Optional]" should not be used on "ref" or "out" parameters'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3449
+  Title: Right operands of shift operators should be integers
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3450
+  Title: Parameters with "[DefaultParameterValue]" attributes should also be marked "[Optional]"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3451
+  Title: '"[DefaultValue]" should not be used when "[DefaultParameterValue]" is meant'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3453
+  Title: Classes should not have only "private" constructors
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3456
+  Title: '"string.ToCharArray()" and "ReadOnlySpan<T>.ToArray()" should not be called redundantly'
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3457
+  Title: Composite format strings should be used correctly
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3458
+  Title: Empty "case" clauses that fall through to the "default" should be omitted
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3459
+  Title: Unassigned members should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3464
+  Title: Type inheritance should not be recursive
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3466
+  Title: Optional parameters should be passed to "base" calls
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3532
+  Title: Empty "default" clauses should be removed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3597
+  Title: '"ServiceContract" and "OperationContract" attributes should be used together'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3598
+  Title: One-way "OperationContract" methods should have "void" return type
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3600
+  Title: '"params" should not be introduced on overrides'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3603
+  Title: 'Methods with "Pure" attribute should return a value '
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3604
+  Title: Member initializer values should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3610
+  Title: Nullable type comparison should not be redundant
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3626
+  Title: Jump statements should not be redundant
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3655
+  Title: Empty nullable value should not be accessed
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3717
+  Title: Track use of "NotImplementedException"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3776
+  Title: Cognitive Complexity of methods should not be too high
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3869
+  Title: '"SafeHandle.DangerousGetHandle" should not be called'
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3871
+  Title: Exception types should be "public"
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3872
+  Title: Parameter names should not duplicate the names of their methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3874
+  Title: '"out" and "ref" parameters should not be used'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3875
+  Title: '"operator==" should not be overloaded on reference types'
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3876
+  Title: Strings or integral types should be used for indexers
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3877
+  Title: Exceptions should not be thrown from unexpected methods
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3878
+  Title: Arrays should not be created for params parameters
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3880
+  Title: Finalizers should not be empty
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3881
+  Title: '"IDisposable" should be implemented correctly'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3884
+  Title: '"CoSetProxyBlanket" and "CoInitializeSecurity" should not be used'
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3885
+  Title: '"Assembly.Load" should be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3887
+  Title: Mutable, non-private fields should not be "readonly"
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3889
+  Title: '"Thread.Resume" and "Thread.Suspend" should not be used'
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3897
+  Title: Classes that provide "Equals(<T>)" should implement "IEquatable<T>"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3898
+  Title: Value types should implement "IEquatable<T>"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3900
+  Title: Arguments of public methods should be validated against null
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S3902
+  Title: '"Assembly.GetExecutingAssembly" should not be called'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3903
+  Title: Types should be defined in named namespaces
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3904
+  Title: Assemblies should have version information
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3906
+  Title: Event Handlers should have the correct signature
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3908
+  Title: Generic event handlers should be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3909
+  Title: Collections should implement the generic interface
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3923
+  Title: All branches in a conditional structure should not have exactly the same implementation
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3925
+  Title: '"ISerializable" should be implemented correctly'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3926
+  Title: Deserialization methods should be provided for "OptionalField" members
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3927
+  Title: Serialization event handlers should be implemented correctly
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3928
+  Title: 'Parameter names used into ArgumentException constructors should match an existing one '
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3937
+  Title: Number patterns should be regular
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3949
+  Title: Calculations should not overflow
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3956
+  Title: '"Generic.List" instances should not be part of public APIs'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3962
+  Title: '"static readonly" constants should be "const" instead'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3963
+  Title: '"static" fields should be initialized inline'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3966
+  Title: Objects should not be disposed more than once
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3967
+  Title: Multidimensional arrays should not be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3971
+  Title: '"GC.SuppressFinalize" should not be called'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3972
+  Title: Conditionals should start on new lines
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3973
+  Title: A conditionally executed single line should be denoted by indentation
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3981
+  Title: Collection sizes and array length comparisons should make sense
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3984
+  Title: Exceptions should not be created without being thrown
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S3990
+  Title: Assemblies should be marked as CLS compliant
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3992
+  Title: Assemblies should explicitly specify COM visibility
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3993
+  Title: Custom attributes should be marked with "System.AttributeUsageAttribute"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3994
+  Title: URI Parameters should not be strings
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3995
+  Title: URI return values should not be strings
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3996
+  Title: URI properties should not be strings
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3997
+  Title: String URI overloads should call "System.Uri" overloads
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S3998
+  Title: Threads should not lock on objects with weak identity
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4000
+  Title: Pointers to unmanaged memory should not be visible
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4002
+  Title: Disposable types should declare finalizers
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4004
+  Title: Collection properties should be readonly
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4005
+  Title: '"System.Uri" arguments should be used instead of strings'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4015
+  Title: Inherited member visibility should not be decreased
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4016
+  Title: Enumeration members should not be named "Reserved"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4017
+  Title: Method signatures should not contain nested generic types
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4018
+  Title: All type parameters should be used in the parameter list to enable type inference
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4019
+  Title: Base class methods should not be hidden
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4022
+  Title: Enumerations should have "Int32" storage
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4023
+  Title: Interfaces should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4025
+  Title: Child class fields should not differ from parent class fields only by capitalization
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4026
+  Title: Assemblies should be marked with "NeutralResourcesLanguageAttribute"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4027
+  Title: Exceptions should provide standard constructors
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4035
+  Title: Classes implementing "IEquatable<T>" should be sealed
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4036
+  Title: Searching OS commands in PATH is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4039
+  Title: Interface methods should be callable by derived types
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4040
+  Title: Strings should be normalized to uppercase
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4041
+  Title: Type names should not match namespaces
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4047
+  Title: Generics should be used when appropriate
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4049
+  Title: Properties should be preferred
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4050
+  Title: Operators should be overloaded consistently
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4052
+  Title: Types should not extend outdated base types
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4055
+  Title: Literals should not be passed as localized parameters
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4056
+  Title: Overloads with a "CultureInfo" or an "IFormatProvider" parameter should be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4057
+  Title: Locales should be set for data types
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4058
+  Title: Overloads with a "StringComparison" parameter should be used
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4059
+  Title: Property names should not match get methods
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4060
+  Title: Non-abstract attributes should be sealed
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4061
+  Title: '"params" should be used instead of "varargs"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4069
+  Title: Operator overloads should have named alternatives
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4070
+  Title: Non-flags enums should not be marked with "FlagsAttribute"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4136
+  Title: Method overloads should be grouped together
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4143
+  Title: Collection elements should not be replaced unconditionally
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4144
+  Title: Methods should not have identical implementations
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4158
+  Title: Empty collections should not be accessed or iterated
+  Category: Minor Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4159
+  Title: Classes should implement their "ExportAttribute" interfaces
+  Category: Blocker Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4200
+  Title: Native methods should be wrapped
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4201
+  Title: Null checks should not be combined with "is" operator checks
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4210
+  Title: Windows Forms entry points should be marked with STAThread
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4211
+  Title: Members should not have conflicting transparency annotations
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4212
+  Title: Serialization constructors should be secured
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4214
+  Title: '"P/Invoke" methods should not be visible'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4220
+  Title: Events should have proper arguments
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4225
+  Title: Extension methods should not extend "object"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4226
+  Title: Extensions should be in separate namespaces
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4260
+  Title: '"ConstructorArgument" parameters should exist in constructors'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4261
+  Title: Methods should be named according to their synchronicities
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4275
+  Title: Getters and setters should access the expected fields
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4277
+  Title: '"Shared" parts should not be created with "new"'
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4347
+  Title: Secure random number generators should not output predictable values
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4423
+  Title: Weak SSL/TLS protocols should not be used
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4426
+  Title: Cryptographic keys should be robust
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4428
+  Title: '"PartCreationPolicyAttribute" should be used with "ExportAttribute"'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4433
+  Title: LDAP connections should be authenticated
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4456
+  Title: Parameter validation in yielding methods should be wrapped
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4457
+  Title: Parameter validation in "async"/"await" methods should be wrapped
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S4462
+  Title: Calls to "async" methods should not be blocking
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S4487
+  Title: Unread "private" fields should be removed
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4502
+  Title: Disabling CSRF protections is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4507
+  Title: Delivering code in production with debug features activated is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4524
+  Title: '"default" clauses should be first or last'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4545
+  Title: '"DebuggerDisplayAttribute" strings should reference existing members'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4581
+  Title: '"new Guid()" should not be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4583
+  Title: Calls to delegate's method "BeginInvoke" should be paired with calls to "EndInvoke"
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4586
+  Title: Non-async "Task/Task<T>" methods should not return null
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4635
+  Title: Start index should be used instead of calling Substring
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4663
+  Title: Comments should not be empty
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4790
+  Title: Using weak hashing algorithms is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4792
+  Title: Configuring loggers is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S4830
+  Title: Server certificates should be verified during SSL/TLS connections
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5034
+  Title: '"ValueTask" should be consumed correctly'
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5042
+  Title: Expanding archive files without controlling resource consumption is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5122
+  Title: Having a permissive Cross-Origin Resource Sharing policy is security-sensitive
+  Category: Minor Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5332
+  Title: Using clear-text protocols is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5344
+  Title: Passwords should not be stored in plaintext or with a fast hashing algorithm
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5443
+  Title: Using publicly writable directories is security-sensitive
+  Category: Critical Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5445
+  Title: Insecure temporary file creation methods should not be used
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5542
+  Title: Encryption algorithms should be used with secure mode and padding scheme
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5547
+  Title: Cipher algorithms should be robust
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5659
+  Title: JWT should be signed and verified with strong cipher algorithms
+  Category: Critical Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5693
+  Title: Allowing requests with excessive content length is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5753
+  Title: Disabling ASP.NET "Request Validation" feature is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5766
+  Title: Deserializing objects without performing data validation is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5773
+  Title: Types allowed to be deserialized should be restricted
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S5856
+  Title: Regular expressions should be syntactically valid
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6354
+  Title: Use a testable date/time provider
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6377
+  Title: XML signatures should be validated securely
+  Category: Major Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6419
+  Title: Azure Functions should be stateless
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6420
+  Title: Client instances should not be recreated on each Azure Function invocation
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6421
+  Title: Azure Functions should use Structured Error Handling
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6422
+  Title: Calls to "async" methods should not be blocking in Azure Functions
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6423
+  Title: Azure Functions should log all failures
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6424
+  Title: Interfaces for durable entities should satisfy the restrictions
+  Category: Blocker Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6444
+  Title: Not specifying a timeout for regular expressions is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6507
+  Title: Blocks should not be synchronized on local variables
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S6513
+  Title: '"ExcludeFromCodeCoverage" attributes should include a justification'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6561
+  Title: Avoid using "DateTime.Now" for benchmarking or timing operations
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6562
+  Title: Always set the "DateTimeKind" when creating new "DateTime" instances
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6563
+  Title: Use UTC when recording DateTime instants
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6566
+  Title: Use "DateTimeOffset" instead of "DateTime"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6575
+  Title: Use "TimeZoneInfo.FindSystemTimeZoneById" without converting the timezones with "TimezoneConverter"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6580
+  Title: Use a format provider when parsing date and time
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6585
+  Title: Don't hardcode the format when turning dates and times to strings
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6588
+  Title: Use the "UnixEpoch" field instead of creating "DateTime" instances that point to the beginning of the Unix epoch
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6602
+  Title: '"Find" method should be used instead of the "FirstOrDefault" extension'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6603
+  Title: The collection-specific "TrueForAll" method should be used instead of the "All" extension
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6605
+  Title: Collection-specific "Exists" method should be used instead of the "Any" extension
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6607
+  Title: The collection should be filtered before sorting by using "Where" before "OrderBy"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6608
+  Title: Prefer indexing instead of "Enumerable" methods on types implementing "IList"
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6609
+  Title: '"Min/Max" properties of "Set" types should be used instead of the "Enumerable" extension methods'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6610
+  Title: '"StartsWith" and "EndsWith" overloads that take a "char" should be used instead of the ones that take a "string"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6612
+  Title: The lambda parameter should be used instead of capturing arguments in "ConcurrentDictionary" methods
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6613
+  Title: '"First" and "Last" properties of "LinkedList" should be used instead of the "First()" and "Last()" extension methods'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6617
+  Title: '"Contains" should be used instead of "Any" for simple equality checks'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6618
+  Title: '"string.Create" should be used instead of "FormattableString"'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6640
+  Title: Using unsafe code blocks is security-sensitive
+  Category: Major Security Hotspot
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6664
+  Title: The code block contains too many logging calls
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6667
+  Title: Logging in a catch clause should pass the caught exception as a parameter.
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6668
+  Title: Logging arguments should be passed to the correct parameter
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6669
+  Title: Logger field or property name should comply with a naming convention
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6670
+  Title: '"Trace.Write" and "Trace.WriteLine" should not be used'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6672
+  Title: Generic logger injection should match enclosing type
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6673
+  Title: Log message template placeholders should be in the right order
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6674
+  Title: Log message template should be syntactically correct
+  Category: Critical Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6675
+  Title: '"Trace.WriteLineIf" should not be used with "TraceSwitch" levels'
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6677
+  Title: Message template placeholders should be unique
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6678
+  Title: Use PascalCase for named placeholders
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6781
+  Title: JWT secret keys should not be disclosed
+  Category: Blocker Vulnerability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6797
+  Title: Blazor query parameter type should be supported
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6798
+  Title: '[JSInvokable] attribute should only be used on public methods'
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6800
+  Title: Component parameter type should match the route parameter type constraint
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6802
+  Title: Using lambda expressions in loops should be avoided in Blazor markup section
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S6803
+  Title: Parameters with SupplyParameterFromQuery attribute should be used only in routable components
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: S6930
+  Title: Backslash should be avoided in route templates
+  Category: Major Bug
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6931
+  Title: ASP.NET controller actions should not have a route template starting with "/"
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6932
+  Title: Use model binding instead of reading raw request data
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6934
+  Title: A Route attribute should be added to the controller when a route template is specified at the action level
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6960
+  Title: Controllers should not have mixed responsibilities
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6961
+  Title: API Controllers should derive from ControllerBase instead of Controller
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6962
+  Title: You should pool HTTP connections with HttpClientFactory
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6964
+  Title: Value type property used as input in a controller action should be nullable, required or annotated with the JsonRequiredAttribute to avoid under-posting.
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6965
+  Title: REST API actions should be annotated with an HTTP verb attribute
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6966
+  Title: Awaitable method should be used
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6967
+  Title: ModelState.IsValid should be called in controller actions
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S6968
+  Title: Actions that return a value should be annotated with ProducesResponseTypeAttribute containing the return type
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S818
+  Title: Literal suffixes should be upper case
+  Category: Minor Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S881
+  Title: Increment (++) and decrement (--) operators should not be used in a method call or mixed with other operators in an expression
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: S907
+  Title: '"goto" statement should not be used'
+  Category: Major Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S927
+  Title: Parameter names should match base declaration and other partial definitions
+  Category: Critical Code Smell
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: S9999-cpd
+  Title: Copy-paste token calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-log
+  Title: Log generator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-metadata
+  Title: File metadata generator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-metrics
+  Title: Metrics calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-symbolRef
+  Title: Symbol reference calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-token-type
+  Title: Token type calculator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: S9999-warning
+  Title: Analysis Warning generator
+  Category: ''
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: false
+- Id: SA0001
+  Title: XML comment analysis disabled
+  Category: StyleCop.CSharp.SpecialRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA0002
+  Title: Invalid settings file
+  Category: StyleCop.CSharp.SpecialRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1000
+  Title: Keywords should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1001
+  Title: Commas should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1002
+  Title: Semicolons should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1003
+  Title: Symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1004
+  Title: Documentation lines should begin with single space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1005
+  Title: Single line comments should begin with single space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1006
+  Title: Preprocessor keywords should not be preceded by space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1007
+  Title: Operator keyword should be followed by space
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1008
+  Title: Opening parenthesis should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1009
+  Title: Closing parenthesis should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1010
+  Title: Opening square brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1011
+  Title: Closing square brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1012
+  Title: Opening braces should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1013
+  Title: Closing braces should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1014
+  Title: Opening generic brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1015
+  Title: Closing generic brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1016
+  Title: Opening attribute brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1017
+  Title: Closing attribute brackets should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1018
+  Title: Nullable type symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1019
+  Title: Member access symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1020
+  Title: Increment decrement symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1021
+  Title: Negative signs should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1022
+  Title: Positive signs should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1023
+  Title: Dereference and access of symbols should be spaced correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1024
+  Title: Colons Should Be Spaced Correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1025
+  Title: Code should not contain multiple whitespace in a row
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1026
+  Title: Code should not contain space after new or stackalloc keyword in implicitly typed array allocation
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1027
+  Title: Use tabs correctly
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1028
+  Title: Code should not contain trailing whitespace
+  Category: StyleCop.CSharp.SpacingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1100
+  Title: Do not prefix calls with base unless local implementation exists
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1101
+  Title: Prefix local calls with this
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1102
+  Title: Query clause should follow previous clause
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1103
+  Title: Query clauses should be on separate lines or all on one line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1104
+  Title: Query clause should begin on new line when previous clause spans multiple lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1105
+  Title: Query clauses spanning multiple lines should begin on own line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1106
+  Title: Code should not contain empty statements
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1107
+  Title: Code should not contain multiple statements on one line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1108
+  Title: Block statements should not contain embedded comments
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1109
+  Title: Block statements should not contain embedded regions
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1110
+  Title: Opening parenthesis or bracket should be on declaration line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1111
+  Title: Closing parenthesis should be on line of last parameter
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1112
+  Title: Closing parenthesis should be on line of opening parenthesis
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1113
+  Title: Comma should be on the same line as previous parameter
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1114
+  Title: Parameter list should follow declaration
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1115
+  Title: Parameter should follow comma
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1116
+  Title: Split parameters should start on line after declaration
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1117
+  Title: Parameters should be on same line or separate lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1118
+  Title: Parameter should not span multiple lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1119
+  Title: Statement should not use unnecessary parenthesis
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1119_p
+  Title: Statement should not use unnecessary parenthesis
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SA1120
+  Title: Comments should contain text
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1121
+  Title: Use built-in type alias
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1122
+  Title: Use string.Empty for empty strings
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1123
+  Title: Do not place regions within elements
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1124
+  Title: Do not use regions
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1125
+  Title: Use shorthand for nullable types
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1126
+  Title: Prefix calls correctly
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1127
+  Title: Generic type constraints should be on their own line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1128
+  Title: Put constructor initializers on their own line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1129
+  Title: Do not use default value type constructor
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1130
+  Title: Use lambda syntax
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1131
+  Title: Use readable conditions
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1132
+  Title: Do not combine fields
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1133
+  Title: Do not combine attributes
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1134
+  Title: Attributes should not share line
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1135
+  Title: Using directives should be qualified
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1136
+  Title: Enum values should be on separate lines
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1137
+  Title: Elements should have the same indentation
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1139
+  Title: Use literal suffix notation instead of casting
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1141
+  Title: Use tuple syntax
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1142
+  Title: Refer to tuple fields by name
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1200
+  Title: Using directives should be placed correctly
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1201
+  Title: Elements should appear in the correct order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1202
+  Title: Elements should be ordered by access
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1203
+  Title: Constants should appear before fields
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1204
+  Title: Static elements should appear before instance elements
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: true
+- Id: SA1205
+  Title: Partial elements should declare access
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1206
+  Title: Declaration keywords should follow order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1207
+  Title: Protected should come before internal
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1208
+  Title: System using directives should be placed before other using directives
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1209
+  Title: Using alias directives should be placed after other using directives
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1210
+  Title: Using directives should be ordered alphabetically by namespace
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1211
+  Title: Using alias directives should be ordered alphabetically by alias name
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1212
+  Title: Property accessors should follow order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1213
+  Title: Event accessors should follow order
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1214
+  Title: Readonly fields should appear before non-readonly fields
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1216
+  Title: Using static directives should be placed at the correct location
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1217
+  Title: Using static directives should be ordered alphabetically
+  Category: StyleCop.CSharp.OrderingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1300
+  Title: Element should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1301
+  Title: Element should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1302
+  Title: Interface names should begin with I
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1303
+  Title: Const field names should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1304
+  Title: Non-private readonly fields should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1305
+  Title: Field names should not use Hungarian notation
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1306
+  Title: Field names should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1307
+  Title: Accessible fields should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1308
+  Title: Variable names should not be prefixed
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1309
+  Title: Field names should not begin with underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - None
+  IsEverSuppressed: true
+- Id: SA1310
+  Title: Field names should not contain underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1311
+  Title: Static readonly fields should begin with upper-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1312
+  Title: Variable names should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1313
+  Title: Parameter names should begin with lower-case letter
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1314
+  Title: Type parameter names should begin with T
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1316
+  Title: Tuple element names should use correct casing
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1400
+  Title: Access modifier should be declared
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1401
+  Title: Fields should be private
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1402
+  Title: File may only contain a single type
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1403
+  Title: File may only contain a single namespace
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1404
+  Title: Code analysis suppression should have justification
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1405
+  Title: Debug.Assert should provide message text
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1406
+  Title: Debug.Fail should provide message text
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1407
+  Title: Arithmetic expressions should declare precedence
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1408
+  Title: Conditional expressions should declare precedence
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1409
+  Title: Remove unnecessary code
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1410
+  Title: Remove delegate parenthesis when possible
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1411
+  Title: Attribute constructor should not use unnecessary parenthesis
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1412
+  Title: Store files as UTF-8 with byte order mark
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1413
+  Title: Use trailing comma in multi-line initializers
+  Category: StyleCop.CSharp.MaintainabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1414
+  Title: Tuple types in signatures should have element names
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1500
+  Title: Braces for multi-line statements should not share line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1501
+  Title: Statement should not be on a single line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1502
+  Title: Element should not be on a single line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1503
+  Title: Braces should not be omitted
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1504
+  Title: All accessors should be single-line or multi-line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1505
+  Title: Opening braces should not be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1506
+  Title: Element documentation headers should not be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1507
+  Title: Code should not contain multiple blank lines in a row
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1508
+  Title: Closing braces should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1509
+  Title: Opening braces should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1510
+  Title: Chained statement blocks should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1511
+  Title: While-do footer should not be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1512
+  Title: Single-line comments should not be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1513
+  Title: Closing brace should be followed by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1514
+  Title: Element documentation header should be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1515
+  Title: Single-line comment should be preceded by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1516
+  Title: Elements should be separated by blank line
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1517
+  Title: Code should not contain blank lines at start of file
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1518
+  Title: Use line endings correctly at end of file
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1519
+  Title: Braces should not be omitted from multi-line child statement
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1520
+  Title: Use braces consistently
+  Category: StyleCop.CSharp.LayoutRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1600
+  Title: Elements should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1601
+  Title: Partial elements should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1602
+  Title: Enumeration items should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1603
+  Title: Documentation should contain valid XML
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1604
+  Title: Element documentation should have summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1605
+  Title: Partial element documentation should have summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1606
+  Title: Element documentation should have summary text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1607
+  Title: Partial element documentation should have summary text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1608
+  Title: Element documentation should not have default summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1609
+  Title: Property documentation should have value
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1610
+  Title: Property documentation should have value text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1611
+  Title: Element parameters should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1612
+  Title: Element parameter documentation should match element parameters
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1613
+  Title: Element parameter documentation should declare parameter name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1614
+  Title: Element parameter documentation should have text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1615
+  Title: Element return value should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1616
+  Title: Element return value documentation should have text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1617
+  Title: Void return value should not be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1618
+  Title: Generic type parameters should be documented
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1619
+  Title: Generic type parameters should be documented partial class
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1620
+  Title: Generic type parameter documentation should match type parameters
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1621
+  Title: Generic type parameter documentation should declare parameter name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1622
+  Title: Generic type parameter documentation should have text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1623
+  Title: Property summary documentation should match accessors
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1624
+  Title: Property summary documentation should omit accessor with restricted access
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1625
+  Title: Element documentation should not be copied and pasted
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1626
+  Title: Single-line comments should not use documentation style slashes
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1627
+  Title: Documentation text should not be empty
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1628
+  Title: Documentation text should begin with a capital letter
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1629
+  Title: Documentation text should end with a period
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1630
+  Title: Documentation text should contain whitespace
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1631
+  Title: Documentation should meet character percentage
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1632
+  Title: Documentation text should meet minimum character length
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1633
+  Title: File should have header
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - Note
+  IsEverSuppressed: true
+- Id: SA1634
+  Title: File header should show copyright
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1635
+  Title: File header should have copyright text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1636
+  Title: File header copyright text should match
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1637
+  Title: File header should contain file name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1638
+  Title: File header file name documentation should match file name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1639
+  Title: File header should have summary
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: false
+- Id: SA1640
+  Title: File header should have valid company text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1641
+  Title: File header company name text should match
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1642
+  Title: Constructor summary documentation should begin with standard text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1643
+  Title: Destructor summary documentation should begin with standard text
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1644
+  Title: Documentation headers should not contain blank lines
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1645
+  Title: Included documentation file does not exist
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1646
+  Title: Included documentation XPath does not exist
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1647
+  Title: Include node does not contain valid file and path
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1648
+  Title: inheritdoc should be used with inheriting class
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1649
+  Title: File name should match first type name
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SA1650
+  Title: Element documentation should be spelled correctly
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SA1651
+  Title: Do not use placeholder elements
+  Category: StyleCop.CSharp.DocumentationRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SX1101
+  Title: Do not prefix local calls with 'this.'
+  Category: StyleCop.CSharp.ReadabilityRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SX1309
+  Title: Field names should begin with underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SX1309S
+  Title: Static field names should begin with underscore
+  Category: StyleCop.CSharp.NamingRules
+  DefaultSeverity: Warning
+  IsEnabledByDefault: false
+  EffectiveSeverities:
+  - None
+  IsEverSuppressed: true
+- Id: SYSLIB1045
+  Title: Convert to 'GeneratedRegexAttribute'.
+  Category: Performance
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SYSLIB1054
+  Title: Use 'LibraryImportAttribute' instead of 'DllImportAttribute' to generate P/Invoke marshalling code at compile time
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SYSLIB1055
+  Title: Invalid 'CustomMarshallerAttribute' usage
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1056
+  Title: Specified marshaller type is invalid
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1057
+  Title: Marshaller type does not have the required shape
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1058
+  Title: Invalid 'NativeMarshallingAttribute' usage
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1060
+  Title: Specified marshaller type is invalid
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1061
+  Title: Marshaller type has incompatible method signatures
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1090
+  Title: "'GeneratedComInterfaceType' does not support the 'ComInterfaceType' value supplied to 'InterfaceTypeAttribute' on the same type."
+  Category: ComInterfaceGenerator
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1096
+  Title: Convert to 'GeneratedComInterface'
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SYSLIB1097
+  Title: Add 'GeneratedComClassAttribute' to enable passing objects of this type to COM
+  Category: Interoperability
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: SYSLIB1098
+  Title: .NET COM hosting with 'EnableComHosting' does not support interfaces with the 'GeneratedComInterfaceAttribute'
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: SYSLIB1099
+  Title: COM Interop APIs on 'System.Runtime.InteropServices.Marshal' do not support source-generated COM
+  Category: Interoperability
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD001
+  Title: Avoid legacy thread switching APIs
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD002
+  Title: Avoid problematic synchronous waits
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD003
+  Title: Avoid awaiting foreign Tasks
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD004
+  Title: Await SwitchToMainThreadAsync
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD010
+  Title: Invoke single-threaded types on Main thread
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD011
+  Title: Use AsyncLazy<T>
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD012
+  Title: Provide JoinableTaskFactory where allowed
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD100
+  Title: Avoid async void methods
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD101
+  Title: Avoid unsupported async delegates
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD102
+  Title: Implement internal logic asynchronously
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD103
+  Title: Call async methods when in an async method
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD104
+  Title: Offer async methods
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD105
+  Title: Avoid method overloads that assume TaskScheduler.Current
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD106
+  Title: Use InvokeAsync to raise async events
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD107
+  Title: Await Task within using expression
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD108
+  Title: Assert thread affinity unconditionally
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD109
+  Title: Switch instead of assert in async methods
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD110
+  Title: Observe result of async calls
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD111
+  Title: Use ConfigureAwait(bool)
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: VSTHRD112
+  Title: Implement System.IAsyncDisposable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD113
+  Title: Check for System.IAsyncDisposable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: VSTHRD114
+  Title: Avoid returning a null Task
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: VSTHRD200
+  Title: Use "Async" suffix for async methods
+  Category: Style
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  - None
+  IsEverSuppressed: true
+- Id: xUnit1000
+  Title: Test classes must be public
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1001
+  Title: Fact methods cannot have parameters
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1002
+  Title: Test methods cannot have multiple Fact or Theory attributes
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1003
+  Title: Theory methods must have test data
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1004
+  Title: Test methods should not be skipped
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit1005
+  Title: Fact methods should not have test data
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1006
+  Title: Theory methods should have parameters
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1007
+  Title: ClassData must point at a valid class
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1008
+  Title: Test data attribute should only be used on a Theory
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1009
+  Title: InlineData values must match the number of method parameters
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1010
+  Title: The value is not convertible to the method parameter type
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1011
+  Title: There is no matching method parameter
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1012
+  Title: Null should only be used for nullable parameters
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1013
+  Title: Public method should be marked as test
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1014
+  Title: MemberData should use nameof operator for member name
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1015
+  Title: MemberData must reference an existing member
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1016
+  Title: MemberData must reference a public member
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1017
+  Title: MemberData must reference a static member
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1018
+  Title: MemberData must reference a valid member kind
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1019
+  Title: MemberData must reference a member providing a valid data type
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1020
+  Title: MemberData must reference a property with a public getter
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1021
+  Title: MemberData should not have parameters if the referenced member is not a method
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1022
+  Title: Theory methods cannot have a parameter array
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1023
+  Title: Theory methods cannot have default parameter values
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1024
+  Title: Test methods cannot have overloads
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1025
+  Title: InlineData should be unique within the Theory it belongs to
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1026
+  Title: Theory methods should use all of their parameters
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1027
+  Title: Collection definition classes must be public
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1028
+  Title: Test method must have valid return type
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1029
+  Title: Local functions cannot be test functions
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1030
+  Title: Do not call ConfigureAwait(false) in test method
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1031
+  Title: Do not use blocking task operations in test method
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1032
+  Title: Test classes cannot be nested within a generic class
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1033
+  Title: Test classes decorated with 'Xunit.IClassFixture<TFixture>' or 'Xunit.ICollectionFixture<TFixture>' should add a constructor argument of type TFixture
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit1034
+  Title: Null should only be used for nullable parameters
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1035
+  Title: The value is not convertible to the method parameter type
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1036
+  Title: There is no matching method parameter
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1037
+  Title: There are fewer theory data type arguments than required by the parameters of the test method
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1038
+  Title: There are more theory data type arguments than allowed by the parameters of the test method
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1039
+  Title: The type argument to theory data is not compatible with the type of the corresponding test method parameter
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1040
+  Title: The type argument to theory data is nullable, while the type of the corresponding test method parameter is not
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1041
+  Title: Fixture arguments to test classes must have fixture sources
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1042
+  Title: The member referenced by the MemberData attribute returns untyped data rows
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit1043
+  Title: Constructors on classes derived from FactAttribute must be public when used on test methods
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1044
+  Title: Avoid using TheoryData type arguments that are not serializable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit1045
+  Title: Avoid using TheoryData type arguments that might not be serializable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit1046
+  Title: Avoid using TheoryDataRow arguments that are not serializable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit1047
+  Title: Avoid using TheoryDataRow arguments that might not be serializable
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit1048
+  Title: Avoid using 'async void' for test methods as it is deprecated in xUnit.net v3
+  Category: Usage
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1049
+  Title: Do not use 'async void' for test methods as it is no longer supported
+  Category: Usage
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit1050
+  Title: The class referenced by the ClassData attribute returns untyped data rows
+  Category: Usage
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit2000
+  Title: Constants and literals should be the expected argument
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2001
+  Title: Do not use invalid equality check
+  Category: Assertions
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: true
+- Id: xUnit2002
+  Title: Do not use null check on value type
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2003
+  Title: Do not use equality check to test for null value
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2004
+  Title: Do not use equality check to test for boolean conditions
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2005
+  Title: Do not use identity check on value type
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2006
+  Title: Do not use invalid string equality check
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2007
+  Title: Do not use typeof expression to check the type
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2008
+  Title: Do not use boolean check to match on regular expressions
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2009
+  Title: Do not use boolean check to check for substrings
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2010
+  Title: Do not use boolean check to check for string equality
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2011
+  Title: Do not use empty collection check
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2012
+  Title: Do not use boolean check to check if a value exists in a collection
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2013
+  Title: Do not use equality check to check for collection size.
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2014
+  Title: Do not use throws check to check for asynchronously thrown exception
+  Category: Assertions
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2015
+  Title: Do not use typeof expression to check the exception type
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2016
+  Title: Keep precision in the allowed range when asserting equality of doubles or decimals.
+  Category: Assertions
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2017
+  Title: Do not use Contains() to check if a value exists in a collection
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2018
+  Title: Do not compare an object's exact type to an abstract class or interface
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2020
+  Title: Do not use always-failing boolean assertions
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2021
+  Title: Async assertions should be awaited
+  Category: Assertions
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2022
+  Title: Boolean assertions should not be negated
+  Category: Assertions
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit2023
+  Title: Do not use collection methods for single-item collections
+  Category: Assertions
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit2024
+  Title: Do not use boolean asserts for simple equality tests
+  Category: Assertions
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit2025
+  Title: The boolean assertion statement can be simplified
+  Category: Assertions
+  DefaultSeverity: Note
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Note
+  IsEverSuppressed: false
+- Id: xUnit2026
+  Title: Comparison of sets must be done with IEqualityComparer
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2027
+  Title: Comparison of sets to linear containers have undefined results
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2028
+  Title: Do not use Assert.Empty or Assert.NotEmpty with problematic types
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit2029
+  Title: Do not use Empty() to check if a value does not exist in a collection
+  Category: Assertions
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit3000
+  Title: Classes which cross AppDomain boundaries must derive directly or indirectly from LongLivedMarshalByRefObject
+  Category: Extensibility
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: xUnit3001
+  Title: Classes that implement Xunit.Abstractions.IXunitSerializable must have a public parameterless constructor
+  Category: Extensibility
+  DefaultSeverity: Error
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Error
+  IsEverSuppressed: false
+- Id: CS1591
+  Title: Missing XML comment for publicly visible type or member
+  Category: Compiler
+  DefaultSeverity: Warning
+  IsEnabledByDefault: true
+  EffectiveSeverities:
+  - Warning
+  IsEverSuppressed: true


### PR DESCRIPTION
Add [SquiggleCop](https://github.com/MattKotsenas/SquiggleCop) to baseline the analyzers and their configuration. This intends to prevent accidental changes / regressions to the project, such as #165.

Changes made
- Add `SquiggleCop.Tasks` and wire into the existing `$(PedanticMode)` to validate baselines
- Add `SquiggleCop.Tool` to support ad-hoc baselining / troubleshooting
- Update `CONTRIBUTING.md` with re-baselining procedure
- Update SDK in `global.json` to latest version and disable rollforward to support reproducible build
- Update pipelines to upload SARIF files to aid debugging