### PR TITLE
Disable rollForward for SDK in global.json

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-    "version": "8.0.101",
-    "rollForward": "latestFeature"
+    "version": "8.0.303",
+    "rollForward": "disable"
   },
   "msbuild-sdks": {
     "DotNet.ReproducibleBuilds.Isolated": "1.2.4"


### PR DESCRIPTION
Update .NET SDK to the latest released version and disable `rollForward`.

Updates to the .NET SDK feature band can introduce new / updated analyzers (for instance, 8.0.400 adds [IDE0320](https://github.com/dotnet/roslyn/pull/73012)). As a result, updating the feature band isn't "safe" to do from a build reproducibility perspective. It will also conflict with #166.

That means the roll forward options available to us are:

- `patch`
- `latestPatch`
- `disable`

However, GitHub Actions don't support these options (tracked by https://github.com/actions/setup-dotnet/issues/448). Thus, the only `rollForward` strategy that currently does the same thing locally and in CI is `disabled`.

Once 448 is fixed, we can / should probably switch to `latestPatch` (tracked by #171).

This 'gotcha' is also added to the SquiggleCop documentation [here](https://github.com/MattKotsenas/SquiggleCop?tab=readme-ov-file#common-sources-of-baseline-mismatches).

