### PR TITLE
Update SquiggleCop and remove ErrorLog property

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -17,7 +17,7 @@
       "rollForward": false
     },
     "squigglecop.tool": {
-      "version": "1.0.8",
+      "version": "1.0.13",
       "commands": [
         "dotnet-squigglecop"
       ],

--- a/build/targets/codeanalysis/CodeAnalysis.targets
+++ b/build/targets/codeanalysis/CodeAnalysis.targets
@@ -5,20 +5,4 @@
     <MSBuildTreatWarningsAsErrors>$(PedanticMode)</MSBuildTreatWarningsAsErrors>
     <SquiggleCop_Enabled>$(PedanticMode)</SquiggleCop_Enabled>
   </PropertyGroup>
-
-  <Target Name="SetErrorLog" BeforeTargets="CoreCompile">
-    <!--
-      ErrorLog is needed for SquiggleCop.
-
-      The value is set in a Target and not directly as a property because `$(IntermediateOutputPath)` and `$(OutputPath)`
-      are calculated properties and thus shouldn't be relied on during the initial property evaluation phase.
-      See https://github.com/dotnet/sdk/issues/41852.
-
-      We use `$(IntermediateOutputPath)` to ensure the file ends up in the `obj/` folder and not with sources to clearly
-      delineate inputs and outputs.
-    -->
-    <PropertyGroup Condition=" '$(ErrorLog)' == '' ">
-      <ErrorLog>$(IntermediateOutputPath)/$(MSBuildProjectName).sarif,version=2.1</ErrorLog>
-    </PropertyGroup>
-  </Target>
 </Project>

--- a/build/targets/codeanalysis/Packages.props
+++ b/build/targets/codeanalysis/Packages.props
@@ -5,7 +5,7 @@
     <PackageVersion Include="Roslynator.Analyzers" Version="4.12.4" />
     <PackageVersion Include="StyleCop.Analyzers" Version="1.2.0-beta.556" />
     <PackageVersion Include="SonarAnalyzer.CSharp" Version="9.30.0.95878" />    
-    <PackageVersion Include="SquiggleCop.Tasks" Version="1.0.8" />
+    <PackageVersion Include="SquiggleCop.Tasks" Version="1.0.13" />
     <PackageVersion Include="Microsoft.VisualStudio.Threading.Analyzers" Version="17.10.48" />
     <PackageVersion Include="ExhaustiveMatching.Analyzer" Version="0.5.0" />
   </ItemGroup>


### PR DESCRIPTION
- Update SquiggleCop to the latest version
- Remove the `SetErrorLog` target now that SquiggleCop does so automatically