### PR TITLE
Bug/fix issue 143

### DIFF
--- a/src/Moq.Analyzers/Common/ISymbolExtensions.cs
+++ b/src/Moq.Analyzers/Common/ISymbolExtensions.cs
@@ -47,4 +47,14 @@ internal static class ISymbolExtensions
         return symbol.DeclaredAccessibility != Accessibility.Private
                 && symbol is IMethodSymbol { MethodKind: MethodKind.Constructor } and { IsStatic: false };
     }
+
+    public static bool IsMethodReturnTypeTask(this ISymbol methodSymbol)
+    {
+        string type = methodSymbol.ToDisplayString();
+        return string.Equals(type, "System.Threading.Tasks.Task", StringComparison.Ordinal)
+               || string.Equals(type, "System.Threading.ValueTask", StringComparison.Ordinal)
+               || type.StartsWith("System.Threading.Tasks.Task<", StringComparison.Ordinal)
+               || (type.StartsWith("System.Threading.Tasks.ValueTask<", StringComparison.Ordinal)
+                   && type.EndsWith(".Result", StringComparison.Ordinal));
+    }
 }

--- a/src/Moq.Analyzers/Common/ISymbolExtensions.cs
+++ b/src/Moq.Analyzers/Common/ISymbolExtensions.cs
@@ -1,4 +1,6 @@
-﻿namespace Moq.Analyzers.Common;
+﻿using System.Runtime.CompilerServices;
+
+namespace Moq.Analyzers.Common;
 
 internal static class ISymbolExtensions
 {
@@ -56,5 +58,11 @@ internal static class ISymbolExtensions
                || type.StartsWith("System.Threading.Tasks.Task<", StringComparison.Ordinal)
                || (type.StartsWith("System.Threading.Tasks.ValueTask<", StringComparison.Ordinal)
                    && type.EndsWith(".Result", StringComparison.Ordinal));
+    }
+
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
+    public static bool IsOverridable(this ISymbol symbol)
+    {
+        return !symbol.IsSealed && (symbol.IsVirtual || symbol.IsAbstract || symbol.IsOverride);
     }
 }

--- a/src/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Runtime.CompilerServices;
+using ISymbolExtensions = Microsoft.CodeAnalysis.ISymbolExtensions;
 
 namespace Moq.Analyzers;
 
@@ -71,7 +72,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
                     return;
                 }
 
-                if (IsMethodOverridable(propertySymbol))
+                if (propertySymbol.IsOverridable())
                 {
                     return;
                 }
@@ -83,7 +84,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
 
                 break;
             case IMethodSymbol methodSymbol:
-                if (IsMethodOverridable(methodSymbol) || methodSymbol.IsMethodReturnTypeTask())
+                if (methodSymbol.IsOverridable() || methodSymbol.IsMethodReturnTypeTask())
                 {
                     return;
                 }
@@ -93,12 +94,6 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
 
         Diagnostic diagnostic = mockedMemberExpression.CreateDiagnostic(Rule);
         context.ReportDiagnostic(diagnostic);
-    }
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static bool IsMethodOverridable(ISymbol methodSymbol)
-    {
-        return !methodSymbol.IsSealed && (methodSymbol.IsVirtual || methodSymbol.IsAbstract || methodSymbol.IsOverride);
     }
 
     private static bool IsTaskResultProperty(IPropertySymbol propertySymbol, SyntaxNodeAnalysisContext context)

--- a/src/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Moq.Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,3 +1,5 @@
+using System.Runtime.CompilerServices;
+
 namespace Moq.Analyzers;
 
 /// <summary>
@@ -34,26 +36,87 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
     {
         InvocationExpressionSyntax setupInvocation = (InvocationExpressionSyntax)context.Node;
 
-        if (setupInvocation.Expression is MemberAccessExpressionSyntax memberAccessExpression && context.SemanticModel.IsMoqSetupMethod(memberAccessExpression, context.CancellationToken))
+        if (setupInvocation.Expression is not MemberAccessExpressionSyntax memberAccessExpression
+            || !context.SemanticModel.IsMoqSetupMethod(memberAccessExpression, context.CancellationToken))
         {
-            ExpressionSyntax? mockedMemberExpression = setupInvocation.FindMockedMemberExpressionFromSetupMethod();
-            if (mockedMemberExpression == null)
-            {
-                return;
-            }
-
-            SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
-            if (symbolInfo.Symbol is IPropertySymbol or IMethodSymbol
-                && !IsMethodOverridable(symbolInfo.Symbol))
-            {
-                Diagnostic diagnostic = mockedMemberExpression.CreateDiagnostic(Rule);
-                context.ReportDiagnostic(diagnostic);
-            }
+            return;
         }
+
+        ExpressionSyntax? mockedMemberExpression = setupInvocation.FindMockedMemberExpressionFromSetupMethod();
+        if (mockedMemberExpression == null)
+        {
+            return;
+        }
+
+        SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
+        ISymbol? symbol = symbolInfo.Symbol;
+
+        if (symbol is null)
+        {
+            return;
+        }
+
+        // Skip if it's part of an interface
+        if (symbol.ContainingType.TypeKind == TypeKind.Interface)
+        {
+            return;
+        }
+
+        switch (symbol)
+        {
+            case IPropertySymbol propertySymbol:
+                // Check if the property is Task<T>.Result and skip diagnostic if it is
+                if (IsTaskResultProperty(propertySymbol, context))
+                {
+                    return;
+                }
+
+                if (IsMethodOverridable(propertySymbol))
+                {
+                    return;
+                }
+
+                if (propertySymbol.IsMethodReturnTypeTask())
+                {
+                    return;
+                }
+
+                break;
+            case IMethodSymbol methodSymbol:
+                if (IsMethodOverridable(methodSymbol) || methodSymbol.IsMethodReturnTypeTask())
+                {
+                    return;
+                }
+
+                break;
+        }
+
+        Diagnostic diagnostic = mockedMemberExpression.CreateDiagnostic(Rule);
+        context.ReportDiagnostic(diagnostic);
     }
 
+    [MethodImpl(MethodImplOptions.AggressiveInlining)]
     private static bool IsMethodOverridable(ISymbol methodSymbol)
     {
         return !methodSymbol.IsSealed && (methodSymbol.IsVirtual || methodSymbol.IsAbstract || methodSymbol.IsOverride);
+    }
+
+    private static bool IsTaskResultProperty(IPropertySymbol propertySymbol, SyntaxNodeAnalysisContext context)
+    {
+        // Check if the property is named "Result"
+        if (!string.Equals(propertySymbol.Name, "Result", StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        // Check if the containing type is Task<T>
+        INamedTypeSymbol? taskOfTType = context.SemanticModel.Compilation.GetTypeByMetadataName("System.Threading.Tasks.Task`1");
+
+        if (taskOfTType == null)
+        {
+            return false; // If Task<T> type cannot be found, we skip it
+        }
+
+        return SymbolEqualityComparer.Default.Equals(propertySymbol.ContainingType, taskOfTType);
     }
 }

--- a/src/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/src/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -1,6 +1,4 @@
-﻿using ISymbolExtensions = Moq.Analyzers.Common.ISymbolExtensions;
-
-namespace Moq.Analyzers;
+﻿namespace Moq.Analyzers;
 
 /// <summary>
 /// Setup of async method should use ReturnsAsync instead of .Result.
@@ -46,18 +44,12 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
 
             SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
             if ((symbolInfo.Symbol is IPropertySymbol || symbolInfo.Symbol is IMethodSymbol)
-                && !IsMethodOverridable(symbolInfo.Symbol)
+                && !symbolInfo.Symbol.IsOverridable()
                 && symbolInfo.Symbol.IsMethodReturnTypeTask())
             {
                 Diagnostic diagnostic = mockedMemberExpression.GetLocation().CreateDiagnostic(Rule);
                 context.ReportDiagnostic(diagnostic);
             }
         }
-    }
-
-    private static bool IsMethodOverridable(ISymbol methodSymbol)
-    {
-        return !methodSymbol.IsSealed
-               && (methodSymbol.IsVirtual || methodSymbol.IsAbstract || methodSymbol.IsOverride);
     }
 }

--- a/src/Moq.Analyzers/SquiggleCop.Baseline.yaml
+++ b/src/Moq.Analyzers/SquiggleCop.Baseline.yaml
@@ -331,7 +331,7 @@
 - {Id: EM0105, Title: Duplicate Case Type, Category: Logic, DefaultSeverity: Error, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: EnableGenerateDocumentationFile, Title: Set MSBuild property 'GenerateDocumentationFile' to 'true', Category: Style, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: IDE0004, Title: Remove Unnecessary Cast, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
-- {Id: IDE0005, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: IDE0005, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0005_gen, Title: Using directive is unnecessary., Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: IDE0007, Title: Use implicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: IDE0008, Title: Use explicit type, Category: Style, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}

--- a/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -1,8 +1,9 @@
+using Xunit.Abstractions;
 using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.SetupShouldBeUsedOnlyForOverridableMembersAnalyzer>;
 
 namespace Moq.Analyzers.Test;
 
-public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests
+public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests(ITestOutputHelper output)
 {
     public static IEnumerable<object[]> TestData()
     {
@@ -24,44 +25,48 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests
     [MemberData(nameof(TestData))]
     public async Task ShouldAnalyzeSetupForOverridableMembers(string referenceAssemblyGroup, string @namespace, string mock)
     {
+        string source = $$"""
+                                {{@namespace}}
+
+                                public interface ISampleInterface
+                                {
+                                    int Calculate(int a, int b);
+                                    int TestProperty { get; set; }
+                                }
+
+                                public interface IParameterlessAsyncMethod
+                                {
+                                    Task<bool> DoSomethingAsync();
+                                }
+
+                                public abstract class BaseSampleClass
+                                {
+                                    public int Calculate() => 0;
+                                    public abstract int Calculate(int a, int b);
+                                    public abstract int Calculate(int a, int b, int c);
+                                }
+
+                                public class SampleClass : BaseSampleClass
+                                {
+                                    public override int Calculate(int a, int b) => 0;
+                                    public sealed override int Calculate(int a, int b, int c) => 0;
+                                    public virtual int DoSth() => 0;
+                                    public int Property { get; set; }
+                                }
+
+                                internal class UnitTest
+                                {
+                                    private void Test()
+                                    {
+                                        {{mock}}
+                                    }
+                                }
+                                """;
+
+        output.WriteLine(source);
+
         await Verifier.VerifyAnalyzerAsync(
-                $$"""
-                {{@namespace}}
-
-                public interface ISampleInterface
-                {
-                    int Calculate(int a, int b);
-                    int TestProperty { get; set; }
-                }
-                
-                public interface IParameterlessAsyncMethod
-                {
-                    Task<bool> DoSomethingAsync();
-                }
-
-                public abstract class BaseSampleClass
-                {
-                    public int Calculate() => 0;
-                    public abstract int Calculate(int a, int b);
-                    public abstract int Calculate(int a, int b, int c);
-                }
-
-                public class SampleClass : BaseSampleClass
-                {
-                    public override int Calculate(int a, int b) => 0;
-                    public sealed override int Calculate(int a, int b, int c) => 0;
-                    public virtual int DoSth() => 0;
-                    public int Property { get; set; }
-                }
-
-                internal class UnitTest
-                {
-                    private void Test()
-                    {
-                        {{mock}}
-                    }
-                }
-                """,
+                source,
                 referenceAssemblyGroup);
     }
 }

--- a/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -16,6 +16,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests
             ["""new Mock<ISampleInterface>().Setup(x => x.TestProperty);"""],
             ["""new Mock<SampleClass>().Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>()));"""],
             ["""new Mock<SampleClass>().Setup(x => x.DoSth());"""],
+            ["""new Mock<IParameterlessAsyncMethod>().Setup(x => x.DoSomethingAsync().Result).Returns(true);"""],
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 
@@ -31,6 +32,11 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests
                 {
                     int Calculate(int a, int b);
                     int TestProperty { get; set; }
+                }
+                
+                public interface IParameterlessAsyncMethod
+                {
+                    Task<bool> DoSomethingAsync();
                 }
 
                 public abstract class BaseSampleClass


### PR DESCRIPTION
Add improved detections for overridable members in Moq1200. Rule 1201 recommends the user not use `.Setup` for async methods; however, in cases where that is suppressed, Moq1200 was incorrectly indicating the `.Result` property was not overridable. Moq1200 now shares the same logic as 1201 and will not perform analysis when the condition is observed.

## Changes

- Move detection for Async return to common location
- Update Moq1200 with detection logic from Moq1201
- Add test case from #143 to catch issue

Resolves #143