### PR TITLE
Bug/fix issue 144

### DIFF
--- a/src/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/src/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -32,6 +32,15 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
     [System.Diagnostics.CodeAnalysis.SuppressMessage("Maintainability", "AV1500:Member or local function contains too many statements", Justification = "Tracked in https://github.com/rjmurillo/moq.analyzers/issues/90")]
     private static void Analyze(SyntaxNodeAnalysisContext context)
     {
+        // Check Moq version and skip analysis if the version is 4.16.0 or later
+        AssemblyIdentity? moqAssembly = context.Compilation.ReferencedAssemblyNames.FirstOrDefault(a => a.Name.Equals("Moq", StringComparison.OrdinalIgnoreCase));
+
+        if (moqAssembly != null && moqAssembly.Version >= new Version(4, 16, 0))
+        {
+            // Skip analysis for Moq 4.16.0 or later
+            return;
+        }
+
         InvocationExpressionSyntax setupInvocation = (InvocationExpressionSyntax)context.Node;
 
         if (setupInvocation.Expression is not MemberAccessExpressionSyntax memberAccessExpression ||

--- a/tests/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodCodeFixTests.cs
+++ b/tests/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodCodeFixTests.cs
@@ -1,4 +1,3 @@
-using Xunit.Abstractions;
 using Verifier = Moq.Analyzers.Test.Helpers.CodeFixVerifier<Moq.Analyzers.CallbackSignatureShouldMatchMockedMethodAnalyzer, Moq.CodeFixes.CallbackSignatureShouldMatchMockedMethodCodeFix>;
 
 namespace Moq.Analyzers.Test;

--- a/tests/Moq.Analyzers.Test/GlobalUsings.cs
+++ b/tests/Moq.Analyzers.Test/GlobalUsings.cs
@@ -1,1 +1,2 @@
 global using Moq.Analyzers.Test.Helpers;
+global using Xunit.Abstractions;

--- a/tests/Moq.Analyzers.Test/Helpers/TestDataExtensions.cs
+++ b/tests/Moq.Analyzers.Test/Helpers/TestDataExtensions.cs
@@ -20,6 +20,14 @@ internal static class TestDataExtensions
         }
     }
 
+    public static IEnumerable<object[]> WithOldMoqReferenceAssemblyGroups(this IEnumerable<object[]> data)
+    {
+        foreach (object[] item in data)
+        {
+            yield return item.Prepend(ReferenceAssemblyCatalog.Net80WithOldMoq).ToArray();
+        }
+    }
+
     public static IEnumerable<object[]> WithNewMoqReferenceAssemblyGroups(this IEnumerable<object[]> data)
     {
         foreach (object[] item in data)

--- a/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -1,4 +1,3 @@
-using Xunit.Abstractions;
 using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.SetupShouldBeUsedOnlyForOverridableMembersAnalyzer>;
 
 namespace Moq.Analyzers.Test;

--- a/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
@@ -15,7 +15,7 @@ public class SetupShouldNotIncludeAsyncResultAnalyzerTests(ITestOutputHelper out
 
             // Starting with Moq 4.16, you can simply .Setup the returned tasks's .Result property
             ["""new Mock<AsyncClient>().Setup(c => {|Moq1201:c.GenericTaskAsync().Result|});"""],
-        }.WithNamespaces().WithMoqReferenceAssemblyGroups();
+        }.WithNamespaces().WithOldMoqReferenceAssemblyGroups();
     }
 
     [Theory]

--- a/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
@@ -2,14 +2,18 @@ using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.Setup
 
 namespace Moq.Analyzers.Test;
 
-public class SetupShouldNotIncludeAsyncResultAnalyzerTests
+public class SetupShouldNotIncludeAsyncResultAnalyzerTests(ITestOutputHelper output)
 {
     public static IEnumerable<object[]> TestData()
     {
         return new object[][]
         {
             ["""new Mock<AsyncClient>().Setup(c => c.TaskAsync());"""],
+
+            // Prior to Moq 4.16, the setup helper ReturnsAsync(), ThrowsAsync() are preferred
             ["""new Mock<AsyncClient>().Setup(c => c.GenericTaskAsync()).ReturnsAsync(string.Empty);"""],
+
+            // Starting with Moq 4.16, you can simply .Setup the returned tasks's .Result property
             ["""new Mock<AsyncClient>().Setup(c => {|Moq1201:c.GenericTaskAsync().Result|});"""],
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
@@ -18,25 +22,30 @@ public class SetupShouldNotIncludeAsyncResultAnalyzerTests
     [MemberData(nameof(TestData))]
     public async Task ShouldAnalyzeSetupForAsyncResult(string referenceAssemblyGroup, string @namespace, string mock)
     {
+        string source =
+            $$"""
+              {{@namespace}}
+
+              public class AsyncClient
+              {
+                  public virtual Task TaskAsync() => Task.CompletedTask;
+              
+                  public virtual Task<string> GenericTaskAsync() => Task.FromResult(string.Empty);
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      {{mock}}
+                  }
+              }
+              """;
+
+        output.WriteLine(source);
+
         await Verifier.VerifyAnalyzerAsync(
-                $$"""
-                {{@namespace}}
-
-                public class AsyncClient
-                {
-                    public virtual Task TaskAsync() => Task.CompletedTask;
-
-                    public virtual Task<string> GenericTaskAsync() => Task.FromResult(string.Empty);
-                }
-
-                internal class UnitTest
-                {
-                    private void Test()
-                    {
-                        {{mock}}
-                    }
-                }
-                """,
+                source,
                 referenceAssemblyGroup);
     }
 }


### PR DESCRIPTION
Starting with Moq 4.16 you can use `mock.Setup` to return the task's `.Result` property. This works in nearly all setup and verification purposes.

This was previously prohibited. In earlier versions than 4.16.0, you need to use setup helper methods like `.Setup.ReturnsAsync`

## Changes

- Introduced a version check for the Moq library to enhance analysis accuracy.
- Added a new method for grouping test data related to older Moq reference assemblies.
- Improved tests for Moq1201 to include comments about the nuance of #144 and added test output for easier debugging

Resolves #144