### PR TITLE
Add IOperation to DiagnosticExtensions and clean up overloads

### DIFF
--- a/src/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/src/Moq.Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -58,7 +58,7 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
 
         if (mockedMethodArguments.Count != lambdaParameters.Count)
         {
-            Diagnostic diagnostic = callbackLambda.ParameterList.GetLocation().CreateDiagnostic(Rule);
+            Diagnostic diagnostic = callbackLambda.ParameterList.CreateDiagnostic(Rule);
             context.ReportDiagnostic(diagnostic);
         }
         else
@@ -96,7 +96,7 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
 
             if (!HasConversion(context.SemanticModel, mockedMethodTypeSymbol, lambdaParameterTypeSymbol))
             {
-                Diagnostic diagnostic = lambdaParameters[argumentIndex].GetLocation().CreateDiagnostic(Rule);
+                Diagnostic diagnostic = lambdaParameters[argumentIndex].CreateDiagnostic(Rule);
                 context.ReportDiagnostic(diagnostic);
             }
         }

--- a/src/Moq.Analyzers/Common/DiagnosticExtensions.cs
+++ b/src/Moq.Analyzers/Common/DiagnosticExtensions.cs
@@ -5,23 +5,20 @@ internal static class DiagnosticExtensions
     public static Diagnostic CreateDiagnostic(
         this SyntaxNode node,
         DiagnosticDescriptor rule,
-        params object?[]? messageArgs)
-        => node.CreateDiagnostic(rule, properties: null, messageArgs);
+        params object?[]? messageArgs) => node.CreateDiagnostic(rule, properties: null, messageArgs);
 
     public static Diagnostic CreateDiagnostic(
         this SyntaxNode node,
         DiagnosticDescriptor rule,
         ImmutableDictionary<string, string?>? properties,
-        params object?[]? messageArgs)
-        => node.CreateDiagnostic(rule, additionalLocations: Array.Empty<Location>(), properties, messageArgs);
+        params object?[]? messageArgs) => node.CreateDiagnostic(rule, additionalLocations: null, properties, messageArgs);
 
     public static Diagnostic CreateDiagnostic(
         this SyntaxNode node,
         DiagnosticDescriptor rule,
         IEnumerable<Location>? additionalLocations,
         ImmutableDictionary<string, string?>? properties,
-        params object?[]? messageArgs)
-        => node
+        params object?[]? messageArgs) => node
             .GetLocation()
             .CreateDiagnostic(
                 rule: rule,
@@ -32,19 +29,13 @@ internal static class DiagnosticExtensions
     public static Diagnostic CreateDiagnostic(
         this Location location,
         DiagnosticDescriptor rule,
-        params object?[]? messageArgs)
-        => location
-            .CreateDiagnostic(
-                rule: rule,
-                properties: ImmutableDictionary<string, string?>.Empty,
-                messageArgs: messageArgs);
+        params object?[]? messageArgs) => location.CreateDiagnostic(rule, properties: null, messageArgs);
 
     public static Diagnostic CreateDiagnostic(
         this Location location,
         DiagnosticDescriptor rule,
         ImmutableDictionary<string, string?>? properties,
-        params object?[]? messageArgs)
-        => location.CreateDiagnostic(rule, Array.Empty<Location>(), properties, messageArgs);
+        params object?[]? messageArgs) => location.CreateDiagnostic(rule, additionalLocations: null, properties, messageArgs);
 
     public static Diagnostic CreateDiagnostic(
         this Location location,
@@ -58,11 +49,24 @@ internal static class DiagnosticExtensions
             location = Location.None;
         }
 
-        return Diagnostic.Create(
-            descriptor: rule,
-            location: location,
-            additionalLocations: additionalLocations,
-            properties: properties,
-            messageArgs: messageArgs);
+        return Diagnostic.Create(rule, location, additionalLocations, properties, messageArgs);
     }
+
+    public static Diagnostic CreateDiagnostic(
+        this IOperation operation,
+        DiagnosticDescriptor rule,
+        params object?[]? messageArgs) => operation.CreateDiagnostic(rule, properties: null, messageArgs);
+
+    public static Diagnostic CreateDiagnostic(
+    this IOperation operation,
+    DiagnosticDescriptor rule,
+    ImmutableDictionary<string, string?>? properties,
+    params object?[]? messageArgs) => operation.CreateDiagnostic(rule, additionalLocations: null, properties, messageArgs);
+
+    public static Diagnostic CreateDiagnostic(
+        this IOperation operation,
+        DiagnosticDescriptor rule,
+        IEnumerable<Location>? additionalLocations,
+        ImmutableDictionary<string, string?>? properties,
+        params object?[]? messageArgs) => operation.Syntax.CreateDiagnostic(rule, additionalLocations, properties, messageArgs);
 }

--- a/src/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Moq.Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -139,7 +139,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        Diagnostic? diagnostic = argumentList?.GetLocation().CreateDiagnostic(ClassMustHaveMatchingConstructor, argumentList);
+        Diagnostic? diagnostic = argumentList?.CreateDiagnostic(ClassMustHaveMatchingConstructor, argumentList);
         if (diagnostic != null)
         {
             context.ReportDiagnostic(diagnostic);
@@ -157,7 +157,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        Diagnostic? diagnostic = argumentList?.GetLocation().CreateDiagnostic(InterfaceMustNotHaveConstructorParameters, argumentList);
+        Diagnostic? diagnostic = argumentList?.CreateDiagnostic(InterfaceMustNotHaveConstructorParameters, argumentList);
         if (diagnostic != null)
         {
             context.ReportDiagnostic(diagnostic);

--- a/src/Moq.Analyzers/SetExplicitMockBehaviorAnalyzer.cs
+++ b/src/Moq.Analyzers/SetExplicitMockBehaviorAnalyzer.cs
@@ -98,7 +98,7 @@ public class SetExplicitMockBehaviorAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        context.ReportDiagnostic(creationOperation.Syntax.GetLocation().CreateDiagnostic(Rule));
+        context.ReportDiagnostic(creationOperation.CreateDiagnostic(Rule));
     }
 
     private static void AnalyzeInvocation(OperationAnalysisContext context, ImmutableArray<IMethodSymbol> wellKnownOfMethods, INamedTypeSymbol mockBehaviorSymbol)
@@ -126,7 +126,7 @@ public class SetExplicitMockBehaviorAnalyzer : DiagnosticAnalyzer
             }
         }
 
-        context.ReportDiagnostic(invocationOperation.Syntax.GetLocation().CreateDiagnostic(Rule));
+        context.ReportDiagnostic(invocationOperation.CreateDiagnostic(Rule));
     }
 
     private static bool IsExplicitBehavior(string symbolName)

--- a/src/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/src/Moq.Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -63,7 +63,7 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        Diagnostic diagnostic = mockedMemberExpression.GetLocation().CreateDiagnostic(Rule);
+        Diagnostic diagnostic = mockedMemberExpression.CreateDiagnostic(Rule);
         context.ReportDiagnostic(diagnostic);
     }
 }


### PR DESCRIPTION
This is a small, preparatory refactoring change. No behavior differences.

- Add `IOperation` overload to `DiagnosticExtensions` to simplify creating diagnostics
- Align overloads to pass `null` for optional parameters instead of a mix of nulls and empty collections
- Use the most appropriate overload in `.CreateDiagnostic()` calls to simplify code slightly