### PR TITLE
Add rule suppression docs to README and each rule

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,12 @@ dotnet add package Moq.Analyzers
 > NOTE: You must use a [supported version](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) of
 > the .NET SDK (i.e. 6.0 or later).
 
+### Configuring rules
+
+Moq.Analyzers follows existing conventions for enabling, disabling, or suppressing rules. See
+[Suppress code analysis warnings - .NET | Microsoft Learn](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings)
+for documentation on how to configure rules for your project.
+
 ## Contributions welcome
 
 Moq.Analyzers continues to evolve and add new features. Any help will be appreciated. You can report issues,

--- a/docs/rules/Moq1000.md
+++ b/docs/rules/Moq1000.md
@@ -28,3 +28,26 @@ class MyClass { }
 
 var mock = new Mock<MyClass>();
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable Moq1000
+var mock = new Mock<MyClass>(); // Moq1000: Sealed classes cannot be mocked
+#pragma warning restore Moq1000
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.Moq1000.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs/rules/Moq1000.md
+++ b/docs/rules/Moq1000.md
@@ -1,10 +1,10 @@
 # Moq1000: Sealed classes cannot be mocked
 
-| Item | Value |
-| --- | --- |
-| Enabled | True |
+| Item     | Value   |
+| -------- | ------- |
+| Enabled  | True    |
 | Severity | Warning |
-| CodeFix | False |
+| CodeFix  | False   |
 ---
 
 Mocking requires generating a subclass of the class to be mocked. Sealed classes cannot be subclassed. To fix:

--- a/docs/rules/Moq1001.md
+++ b/docs/rules/Moq1001.md
@@ -33,3 +33,26 @@ interface IMyService
 
 var mock = new Mock<IMyService>();
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable Moq1001
+var mock = new Mock<IMyService>("123"); // Moq1001: Mocked interfaces cannot have constructor parameters
+#pragma warning restore Moq1001
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.Moq1001.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs/rules/Moq1001.md
+++ b/docs/rules/Moq1001.md
@@ -1,10 +1,10 @@
 # Moq1001: Mocked interfaces cannot have constructor parameters
 
-| Item | Value |
-| --- | --- |
-| Enabled | True |
+| Item     | Value   |
+| -------- | ------- |
+| Enabled  | True    |
 | Severity | Warning |
-| CodeFix | False |
+| CodeFix  | False   |
 ---
 
 Mocking interfaces requires generating a class on-the-fly that implements the interface. That generated class is

--- a/docs/rules/Moq1002.md
+++ b/docs/rules/Moq1002.md
@@ -32,3 +32,26 @@ class MyClass
 
 var mock = new Mock<MyClass>("three");
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable Moq1002
+var mock = new Mock<MyClass>(3); // Moq1002: Parameters provided into mock do not match any existing constructors
+#pragma warning restore Moq1002
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.Moq1002.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs/rules/Moq1002.md
+++ b/docs/rules/Moq1002.md
@@ -1,10 +1,10 @@
 # Moq1002: Parameters provided into mock do not match any existing constructors
 
-| Item | Value |
-| --- | --- |
-| Enabled | True |
+| Item     | Value   |
+| -------- | ------- |
+| Enabled  | True    |
 | Severity | Warning |
-| CodeFix | False |
+| CodeFix  | False   |
 ---
 
 In order to construct the mocked type, constructor parameters must match a constructor. To fix:

--- a/docs/rules/Moq1100.md
+++ b/docs/rules/Moq1100.md
@@ -37,3 +37,28 @@ var mock = new Mock<IMyService>()
     .Setup(x => x.Do(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<DateTime>()))
     .Callback((int i, string s, DateTime dt) => { });
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable Moq1100
+var mock = new Mock<IMyService>()
+    .Setup(x => x.Do(It.IsAny<int>(), It.IsAny<string>(), It.IsAny<DateTime>()))
+    .Callback((string s1, int i1) => { }); // Moq1100: Callback signature must match the signature of the mocked method
+#pragma warning restore Moq1100
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.Moq1100.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs/rules/Moq1100.md
+++ b/docs/rules/Moq1100.md
@@ -1,10 +1,10 @@
 # Moq1100: Callback signature must match the signature of the mocked method
 
-| Item | Value |
-| --- | --- |
-| Enabled | True |
+| Item     | Value   |
+| -------- | ------- |
+| Enabled  | True    |
 | Severity | Warning |
-| CodeFix | True |
+| CodeFix  | True    |
 ---
 
 The signature of the `.Callback()` method must match the signature of the `.Setup()` method. To fix:

--- a/docs/rules/Moq1101.md
+++ b/docs/rules/Moq1101.md
@@ -30,3 +30,26 @@ interface IMyInterface
 
 var mock = new Mock<IMyInterface>().Setup(x => x.Method());
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable Moq1101
+var mock = new Mock<IMyInterface>().SetupGet(x => x.Method()); // Moq1101: SetupGet/SetupSet should be used for properties, not for methods
+#pragma warning restore Moq1101
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.Moq1101.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs/rules/Moq1101.md
+++ b/docs/rules/Moq1101.md
@@ -1,10 +1,10 @@
 # Moq1101: SetupGet/SetupSet should be used for properties, not for methods
 
-| Item | Value |
-| --- | --- |
-| Enabled | True |
+| Item     | Value   |
+| -------- | ------- |
+| Enabled  | True    |
 | Severity | Warning |
-| CodeFix | False |
+| CodeFix  | False   |
 ---
 
 `.SetupGet()` and `.SetupSet()` are methods for mocking properties, not methods. Use `.Setup()` to mock methods instead.

--- a/docs/rules/Moq1200.md
+++ b/docs/rules/Moq1200.md
@@ -34,3 +34,27 @@ class SampleClass
 var mock = new Mock<SampleClass>()
     .Setup(x => x.Property);
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable Moq1200
+var mock = new Mock<SampleClass>()
+    .Setup(x => x.Property); // Moq1200: Setup should be used only for overridable members
+#pragma warning restore Moq1200
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.Moq1200.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs/rules/Moq1200.md
+++ b/docs/rules/Moq1200.md
@@ -1,10 +1,10 @@
 # Moq1200: Setup should be used only for overridable members
 
-| Item | Value |
-| --- | --- |
-| Enabled | True |
+| Item     | Value |
+| -------- | ----- |
+| Enabled  | True  |
 | Severity | Error |
-| CodeFix | False |
+| CodeFix  | False |
 ---
 
 Mocking requires generating a subclass of the class to be mocked. Methods not marked `virtual` cannot be overridden.

--- a/docs/rules/Moq1201.md
+++ b/docs/rules/Moq1201.md
@@ -1,10 +1,10 @@
 # Moq1201: Setup of async methods should use `.ReturnsAsync` instance instead of `.Result`
 
-| Item | Value |
-| --- | --- |
-| Enabled | True |
+| Item     | Value |
+| -------- | ----- |
+| Enabled  | True  |
 | Severity | Error |
-| CodeFix | False |
+| CodeFix  | False |
 ---
 
 Moq now supports the `.ReturnsAsync()` method to support mocking async methods. Use it instead of returning `.Result`,

--- a/docs/rules/Moq1201.md
+++ b/docs/rules/Moq1201.md
@@ -33,3 +33,27 @@ class AsyncClient
 var mock = new Mock<AsyncClient>()
     .Setup(c => c.GetAsync()).ReturnsAsync(string.Empty);
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable Moq1201
+var mock = new Mock<AsyncClient>()
+    .Setup(c => c.GetAsync().Result); // Moq1201: Setup of async methods should use .ReturnsAsync instance instead of .Result
+#pragma warning restore Moq1201
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.Moq1201.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs/rules/Moq1300.md
+++ b/docs/rules/Moq1300.md
@@ -1,10 +1,10 @@
 # Moq1300: `Mock.As()` should take interfaces only
 
-| Item | Value |
-| --- | --- |
-| Enabled | True |
+| Item     | Value |
+| -------- | ----- |
+| Enabled  | True  |
 | Severity | Error |
-| CodeFix | False |
+| CodeFix  | False |
 ---
 
 The `.As()` method is used when a mocked object must implement multiple interfaces. It cannot be used with abstract or

--- a/docs/rules/Moq1300.md
+++ b/docs/rules/Moq1300.md
@@ -45,3 +45,27 @@ class SampleClass
 
 var mock = new Mock<ISampleInterface>();
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable Moq1300
+var mock = new Mock<SampleClass>()
+    .As<SampleClass>(); // Moq1300: Mock.As() should take interfaces only
+#pragma warning restore Moq1300
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.Moq1300.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs/rules/Moq1400.md
+++ b/docs/rules/Moq1400.md
@@ -1,10 +1,10 @@
 # Moq1400: Explicitly choose a mocking behavior instead of relying on the default (Loose) behavior
 
-| Item | Value |
-| --- | --- |
-| Enabled | True |
+| Item     | Value   |
+| -------- | ------- |
+| Enabled  | True    |
 | Severity | Warning |
-| CodeFix | False |
+| CodeFix  | False   |
 ---
 
 Mocks use the `MockBehavior.Loose` by default. Some people find this default behavior undesirable, as it can lead to

--- a/docs/rules/Moq1400.md
+++ b/docs/rules/Moq1400.md
@@ -46,3 +46,26 @@ var mock = new Mock<ISample>(MockBehavior.Strict); // Or `MockBehavior.Loose`
 var mock2 = new Mock.Of<ISample>(MockBehavior.Strict); // Or `MockBehavior.Loose`
 var repo = new MockRepository(MockBehavior.Strict); // Or `MockBehavior.Loose`
 ```
+
+## Suppress a warning
+
+If you just want to suppress a single violation, add preprocessor directives to
+your source file to disable and then re-enable the rule.
+
+```csharp
+#pragma warning disable Moq1400
+var mock = new Mock<ISample>(); // Moq1400: Moq: Explicitly choose a mock behavior
+#pragma warning restore Moq1400
+```
+
+To disable the rule for a file, folder, or project, set its severity to `none`
+in the
+[configuration file](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/configuration-files).
+
+```ini
+[*.{cs,vb}]
+dotnet_diagnostic.Moq1400.severity = none
+```
+
+For more information, see
+[How to suppress code analysis warnings](https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/suppress-warnings).

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -1,13 +1,13 @@
 # Diagnostics / rules
 
-| ID | Title |
-| --- | --- |
-| [Moq1000](./Moq1000.md) | Sealed classes cannot be mocked |
-| [Moq1001](./Moq1001.md) | Mocked interfaces cannot have constructor parameters |
-| [Moq1002](./Moq1002.md) | Parameters provided into mock do not match any existing constructors |
-| [Moq1100](./Moq1100.md) | Callback signature must match the signature of the mocked method |
-| [Moq1101](./Moq1101.md) | SetupGet/SetupSet should be used for properties, not for methods |
-| [Moq1200](./Moq1200.md) | Setup should be used only for overridable members |
-| [Moq1201](./Moq1201.md) | Setup of async methods should use `.ReturnsAsync` instance instead of `.Result` |
-| [Moq1300](./Moq1300.md) | `Mock.As()` should take interfaces only |
+| ID                      | Title                                                                                   |
+| ----------------------- | --------------------------------------------------------------------------------------- |
+| [Moq1000](./Moq1000.md) | Sealed classes cannot be mocked                                                         |
+| [Moq1001](./Moq1001.md) | Mocked interfaces cannot have constructor parameters                                    |
+| [Moq1002](./Moq1002.md) | Parameters provided into mock do not match any existing constructors                    |
+| [Moq1100](./Moq1100.md) | Callback signature must match the signature of the mocked method                        |
+| [Moq1101](./Moq1101.md) | SetupGet/SetupSet should be used for properties, not for methods                        |
+| [Moq1200](./Moq1200.md) | Setup should be used only for overridable members                                       |
+| [Moq1201](./Moq1201.md) | Setup of async methods should use `.ReturnsAsync` instance instead of `.Result`         |
+| [Moq1300](./Moq1300.md) | `Mock.As()` should take interfaces only                                                 |
 | [Moq1400](./Moq1400.md) | Explicitly choose a mocking behavior instead of relying on the default (Loose) behavior |

--- a/docs/rules/README.md
+++ b/docs/rules/README.md
@@ -10,3 +10,4 @@
 | [Moq1200](./Moq1200.md) | Setup should be used only for overridable members |
 | [Moq1201](./Moq1201.md) | Setup of async methods should use `.ReturnsAsync` instance instead of `.Result` |
 | [Moq1300](./Moq1300.md) | `Mock.As()` should take interfaces only |
+| [Moq1400](./Moq1400.md) | Explicitly choose a mocking behavior instead of relying on the default (Loose) behavior |


### PR DESCRIPTION
Fixes #238

- Add a generic section on rule configuration to suppress / upgrade rule severity
- Add a section on how to suppress the rule to each rule's doc (format the same as the CAXXX rules)
- Add missing Moq1400 from `//docs/README.md`
- Fix table alignment / padding in `//docs/rules/*.md`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Added a "Configuring rules" section to the README for clearer guidance on enabling and disabling analyzer rules.
	- Introduced a new rule regarding mocking behavior in the rules README.

- **Documentation**
	- Enhanced clarity and usability in multiple documentation files related to Moq rules, including guidance on suppressing warnings and improved table formatting.

- **Bug Fixes**
	- Improved readability and structure across various rule documents to aid developers in understanding and implementing the Moq library effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->