### PR TITLE
Remove forced lf in .editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -28,7 +28,6 @@ indent_size = 4
 tab_width = 4
 
 # New line preferences
-end_of_line = lf
 insert_final_newline = true
 
 #### .NET Coding Conventions ####


### PR DESCRIPTION
#215 added the new `.gitattributes` from .NET, which does git normalization and lets IDEs use the OS default. This avoids a bunch of eol churn because some tools respect `.editorconfig` and some do not. However, I forgot to remove the forced lf in .editorconfig which meant we still got eol churn caused by tools that _did_ respect .editorconfig.

This change removes eol settings from .editorconfig and should (finally) fix eol churn.