### PR TITLE
Move "upload binlogs" CI step earlier in pipeline and run even if failed

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -66,6 +66,14 @@ jobs:
     - name: Test
       run: dotnet test --no-build --configuration Release --settings ./build/targets/tests/test.runsettings
 
+    - name: Upload binlogs
+      uses: actions/upload-artifact@v4
+      if: success() || failure()
+      with:
+        name: binlogs-${{ matrix.os }}
+        path: ./artifacts/logs
+        if-no-files-found: error
+
     - name: Upload *.received.* files
       uses: actions/upload-artifact@v4
       if: failure()
@@ -106,13 +114,6 @@ jobs:
       with:
         project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
         coverage-reports: ${{ github.workspace }}/artifacts/TestResults/coverage/Cobertura.xml
-
-    - name: Upload binlogs
-      uses: actions/upload-artifact@v4
-      with:
-        name: binlogs-${{ matrix.os }}
-        path: ./artifacts/logs
-        if-no-files-found: error
 
     - name: Upload packages
       uses: actions/upload-artifact@v4


### PR DESCRIPTION
Currently, the "upload binlogs" step is too far down in the CI pipeline (and also doesn't run if the build fails). Move it up a bit so that the order of log upload mirrors the order of actions and add `success() || failure()` so they are uploaded even during build failures.