### PR TITLE
Bump GetPackFromProject to fix race in .NET 9 SDK

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -21,7 +21,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="BenchmarkDotNet" Version="0.13.12" />
-    <PackageVersion Include="GetPackFromProject" Version="1.0.6" />
+    <PackageVersion Include="GetPackFromProject" Version="1.0.10" />
     <PackageVersion Include="Nerdbank.GitVersioning" Version="3.6.146" />
     <PackageVersion Include="System.CommandLine" Version="2.0.0-beta1.21216.1" />
     <PackageVersion Include="System.CommandLine.Rendering" Version="2.0.0-beta1.20074.1" />


### PR DESCRIPTION
Bump `GetPackFromProject` to latest version to pick up fix for race condition in .NET 9 SDK that results in flaky build failures in test projects.