### PR TITLE
Align .editorconfig with dotnet new template

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -5,7 +5,18 @@ root = true
 indent_style = space
 
 # Xml files
-[*.{xml,props,targets}]
+[*.xml]
+indent_size = 2
+
+# Xml project files
+[*.{csproj,fsproj,vbproj,proj}]
+indent_size = 2
+
+# Xml config files
+[*.{props,targets,config,nuspec}]
+indent_size = 2
+
+[*.json]
 indent_size = 2
 
 # Verify settings

--- a/build/perf/baseline.json
+++ b/build/perf/baseline.json
@@ -1,5 +1,5 @@
 {
-    "release": "0.1.1",
-    "label": "v.0.1.1",
-    "sha": "3b1676be5d637fb80595c04bdef8bdbce198cd32"
-  }
+  "release": "0.1.1",
+  "label": "v.0.1.1",
+  "sha": "3b1676be5d637fb80595c04bdef8bdbce198cd32"
+}

--- a/build/targets/codeanalysis/stylecop.json
+++ b/build/targets/codeanalysis/stylecop.json
@@ -1,12 +1,12 @@
 {
-    "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
-    "settings": {
-        "layoutRules": {
-            "newlineAtEndOfFile": "require"
-        },
-        "orderingRules": {
-            "systemUsingDirectivesFirst": true,
-            "usingDirectivesPlacement": "outsideNamespace"
-        }
+  "$schema": "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
+  "settings": {
+    "layoutRules": {
+      "newlineAtEndOfFile": "require"
+    },
+    "orderingRules": {
+      "systemUsingDirectivesFirst": true,
+      "usingDirectivesPlacement": "outsideNamespace"
     }
+  }
 }


### PR DESCRIPTION
Align .editorconfig with the updated `dotnet new` template.

The effect of this change is to set 2-space indent for `*.json`. That's important to make the code review bots stop complaining about indentation.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated indentation settings for XML and JSON files to improve consistency.
	- Improved formatting of JSON files for better readability without altering content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->