### PR TITLE
Remove false positive for Moq1200 when using parameterized lambda

### DIFF
--- a/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -99,9 +99,9 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         return targetSymbol.IsInstanceOf(knownSymbols.MockBehavior);
     }
 
-    private static bool IsArgumentMockBehavior(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols, ArgumentListSyntax? argumentList, int argumentOrdinal)
+    private static bool IsArgumentMockBehavior(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols, ArgumentListSyntax? argumentList, uint argumentOrdinal)
     {
-        ExpressionSyntax? expression = argumentList?.Arguments.Count > argumentOrdinal ? argumentList.Arguments[argumentOrdinal].Expression : null;
+        ExpressionSyntax? expression = argumentList?.Arguments.Count > argumentOrdinal ? argumentList.Arguments[(int)argumentOrdinal].Expression : null;
 
         return IsExpressionMockBehavior(context, knownSymbols, expression);
     }

--- a/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -99,16 +99,9 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         return targetSymbol.IsInstanceOf(knownSymbols.MockBehavior);
     }
 
-    private static bool IsFirstArgumentMockBehavior(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols, ArgumentListSyntax? argumentList)
+    private static bool IsArgumentMockBehavior(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols, ArgumentListSyntax? argumentList, int argumentOrdinal)
     {
-        ExpressionSyntax? expression = argumentList?.Arguments[0].Expression;
-
-        return IsExpressionMockBehavior(context, knownSymbols, expression);
-    }
-
-    private static bool IsSecondArgumentMockBehavior(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols, ArgumentListSyntax? argumentList)
-    {
-        ExpressionSyntax? expression = argumentList?.Arguments[1].Expression;
+        ExpressionSyntax? expression = argumentList?.Arguments.Count > argumentOrdinal ? argumentList.Arguments[argumentOrdinal].Expression : null;
 
         return IsExpressionMockBehavior(context, knownSymbols, expression);
     }
@@ -416,12 +409,12 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 
         if (hasMockBehavior && arguments.Length > 0)
         {
-            if (arguments.Length >= 1 && IsFirstArgumentMockBehavior(context, knownSymbols, argumentList))
+            if (arguments.Length >= 1 && IsArgumentMockBehavior(context, knownSymbols, argumentList, 0))
             {
                 // They passed a mock behavior as the first argument; ignore as Moq swallows it
                 arguments = arguments.RemoveAt(0);
             }
-            else if (arguments.Length >= 2 && IsSecondArgumentMockBehavior(context, knownSymbols, argumentList))
+            else if (arguments.Length >= 2 && IsArgumentMockBehavior(context, knownSymbols, argumentList, 1))
             {
                 // They passed a mock behavior as the second argument; ignore as Moq swallows it
                 arguments = arguments.RemoveAt(1);

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Expressions.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Expressions.cs
@@ -1,0 +1,36 @@
+﻿using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.ConstructorArgumentsShouldMatchAnalyzer>;
+
+namespace Moq.Analyzers.Test;
+
+public partial class ConstructorArgumentsShouldMatchAnalyzerTests
+{
+    public static IEnumerable<object[]> ExpressionTestData()
+    {
+        return new object[][]
+        {
+            ["""_ = new Mock<Calculator>(() => new Calculator(), MockBehavior.Loose);"""]
+        }.WithNamespaces().WithMoqReferenceAssemblyGroups();
+    }
+
+    [Theory]
+    [MemberData(nameof(ExpressionTestData))]
+    public async Task ExpressionConstructor(string referenceAssemblyGroup, string @namespace, string mock)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $@"
+            {@namespace}
+            public class Calculator
+            {{
+                 public int Add(int a, int b) => a + b;
+            }}
+            internal class UnitTest
+            {{
+                private void Test()
+                {{
+                    {mock}
+                }}
+            }}
+            ",
+            referenceAssemblyGroup);
+    }
+}

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Expressions.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Expressions.cs
@@ -14,7 +14,7 @@ public partial class ConstructorArgumentsShouldMatchAnalyzerTests
 
     [Theory]
     [MemberData(nameof(ExpressionTestData))]
-    public async Task ExpressionConstructor(string referenceAssemblyGroup, string @namespace, string mock)
+    public async Task ShouldPassIfExpressionWithDefaultCtorIsUsedWithMockBehavior(string referenceAssemblyGroup, string @namespace, string mock)
     {
         await Verifier.VerifyAnalyzerAsync(
             $@"

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Expressions.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Expressions.cs
@@ -9,6 +9,9 @@ public partial class ConstructorArgumentsShouldMatchAnalyzerTests
         return new object[][]
         {
             ["""_ = new Mock<Calculator>(() => new Calculator(), MockBehavior.Loose);"""],
+            ["""_ = new Mock<Calculator>(() => new Calculator(), MockBehavior.Strict);"""],
+            ["""_ = new Mock<Calculator>(() => new Calculator(), MockBehavior.Default);"""],
+            ["""_ = new Mock<Calculator>(() => new Calculator());"""],
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Expressions.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Expressions.cs
@@ -8,7 +8,7 @@ public partial class ConstructorArgumentsShouldMatchAnalyzerTests
     {
         return new object[][]
         {
-            ["""_ = new Mock<Calculator>(() => new Calculator(), MockBehavior.Loose);"""]
+            ["""_ = new Mock<Calculator>(() => new Calculator(), MockBehavior.Loose);"""],
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 


### PR DESCRIPTION
When using Moq's expression features for type construction, the Moq1200 analyzer was firing unexpectedly indicating a matching constructor on the type was not found. The `ConstructorArgumentsShouldMatchAnalyzer` was extracting the parameters from the Mock type and comparing them to the parameters of the constructed type as is, including the lambda and the `MockBehavior`.

Example:

```csharp
_ = new Mock<Calculator>(() => new Calculator(), MockBehavior.Loose);
```

> See #234 for more details

This is incorrect for several reasons:

1. The parenthesized lambda is not itself a parameter for the target type, but rather the body
2. The `MockBehavior` would not likely be a parameter on the target type

Correct analysis would be to drop the `MockBehavior` argument as with other configurations of the `Mock<T>` type, and use the body of the lambda. However, using the body of the lambda is not necessary. The purpose of this analyzer is to detect errors that would not be caught at compile time that would result in a runtime error. In this case, using a constructor not available on the type would result in a compiler error. As such, the constructor detection method has been updated to return a tertiary result: `true` when there is a matching constructor found, `false` when there is not, and `null` when the constructor is a lambda (i.e., the constructor should be ignored).

Changes:

- Add unit test for issue #234
- Add support to ignore parameterized lambda arguments when performing constructor detection
- Add support `MockBehavior` definitions to be in ordinal position 0 or 1

Fixes #234 