### PR TITLE
Update release.yml to use Ubuntu package instead of Windows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
         uses: actions/download-artifact@v4
         with:
           path: packages
-          pattern: packages-windows-*
+          pattern: packages-ubuntu-*
           merge-multiple: true
       - name: Publish NuGet package
         shell: pwsh


### PR DESCRIPTION
Updated the workflow configuration for package downloads to target Ubuntu instead of Windows. Windows builds will be removed from the workflow in a future PR.