### PR TITLE
Pilot ARM64 actions runners

### DIFF
--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -5,7 +5,7 @@ permissions:
   contents: write
 jobs:
   dependabot:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     # Checking the actor will prevent your Action run failing on non-Dependabot
     # PRs but also ensures that it only does work for Dependabot PRs.
     if: ${{ github.actor == 'dependabot[bot]' || github.actor == 'dependabot-preview[bot]' }}

--- a/.github/workflows/dependabot-auto-approve.yml
+++ b/.github/workflows/dependabot-auto-approve.yml
@@ -6,7 +6,7 @@ on: [pull_request_target]
 jobs:
   autoapprove:
     name: Auto-Approve a PR by dependabot
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Auto approve
         uses: cognitedata/auto-approve-dependabot-action@v3.0.1

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -11,7 +11,7 @@ jobs:
   label_issues:
     name: "Issue: add labels"
     if: ${{ github.event.action == 'opened' || github.event.action == 'reopened' }}
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     permissions:
       issues: write
     steps:

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -10,7 +10,7 @@ on: [pull_request_target]
 
 jobs:
     add_label:
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-24.04-arm
         permissions:
             contents: read
             pull-requests: write

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
     strategy:
       fail-fast: false # Run all OSes, even if one fails, to help narrow down issues that only impact some platforms
       matrix:
-        os: [windows-latest, ubuntu-latest]
+        os: [windows-latest, ubuntu-24.04-arm]
 
     runs-on: ${{ matrix.os }}
 

--- a/.github/workflows/milestone-tracking.yml
+++ b/.github/workflows/milestone-tracking.yml
@@ -7,7 +7,7 @@ permissions:
   pull-requests: write
 jobs:
   add_milestone:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     if: ${{ github.repository == 'rjmurillo/moq.analyzers' && github.event.pull_request.merged_at != null && github.event.pull_request.milestone == null && github.event.pull_request.base.ref == 'main' }}
     steps:
     - name: Get milestone data

--- a/.github/workflows/pr-labeler-current-milestone.yml
+++ b/.github/workflows/pr-labeler-current-milestone.yml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
     
     # Label PRs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
 
   publish:
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-arm
     steps:
       - name: Download packages
         uses: actions/download-artifact@v4


### PR DESCRIPTION
Try out the new ARM64-based GitHub Actions runners. There's no _need_ to switch to these, just piloting to see if there are any performance or functionality issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated GitHub Actions workflow configurations to use `ubuntu-24.04-arm` runner across multiple workflow files
	- Replaced `ubuntu-latest` with `ubuntu-24.04-arm` in workflow environments
	- No functional changes to workflow logic or steps

<!-- end of auto-generated comment: release notes by coderabbit.ai -->