### PR TITLE
Add AnalyzerUtilities to NuGet package

### DIFF
--- a/src/Analyzers/Moq.Analyzers.csproj
+++ b/src/Analyzers/Moq.Analyzers.csproj
@@ -7,6 +7,7 @@
     <IncludeBuildOutput>false</IncludeBuildOutput><!-- Don't place the output assembly in the package's lib/ folder -->
     <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking><!-- Don't add the TargetFramework as a package dependency -->
     <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules><!-- Resolves RS1036 -->
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies><!-- Because we're a compiler plugin, we need to bundle any dependencies into our package -->
   </PropertyGroup>
 
   <PropertyGroup Label="Package metadata">
@@ -39,6 +40,7 @@
     <None Update="tools\*.ps1" CopyToOutputDirectory="Always" Pack="true" PackagePath="" />
     <None Include="$(OutputPath)\Moq.Analyzers.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
     <None Include="$(OutputPath)\Moq.CodeFixes.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+    <None Include="$(OutputPath)\Microsoft.CodeAnalysis.AnalyzerUtilities.dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
+++ b/tests/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
@@ -4,6 +4,7 @@
 |-- analyzers
 |   |-- dotnet
 |   |   |-- cs
+|   |   |   |-- Microsoft.CodeAnalysis.AnalyzerUtilities.dll
 |   |   |   |-- Moq.Analyzers.dll
 |   |   |   |-- Moq.CodeFixes.dll
 |-- tools


### PR DESCRIPTION
This fixes a regression caused by #290.

`Microsoft.CodeAnalysis.AnalyzerUtilities` is not one of the assemblies provided by the host (i.e. compiler), so we need to include it in our own package.

I'm not sure how to write an automated test for this. Our current tests don't use the NuGet package. Doing something like `dotnet format` in theory should work, but when I tried that it passed even without this change.

This does result in a new package contents baseline, so we can chalk this one up to reviewer error and revisit if we find a better solution.