### PR TITLE
Update Compiler.props LangVersion

### DIFF
--- a/build/targets/compiler/Compiler.props
+++ b/build/targets/compiler/Compiler.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <ImplicitUsings>enable</ImplicitUsings>
-    <LangVersion>12.0</LangVersion>
+    <LangVersion>default</LangVersion>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 


### PR DESCRIPTION
The property was tied to a specific (and incidentally the latest version). However, with the release of .NET 9, lang version is no longer 12.0. This change updates the `LangVersion` property to `default`, which is the same as `latestMajor` which is the latest released major version of the compiler

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated compiler language version to use default settings instead of a specific version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->