### PR TITLE
Refactor SetupShouldOnlyBeUsedForOverridableMembersAnalyzer to IOperation

### DIFF
--- a/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -38,7 +38,11 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Should be fixed. Ignoring for now to avoid additional churn as part of larger refactor.")]
     private static void AnalyzeInvocation(OperationAnalysisContext context)
     {
-        IInvocationOperation invocationOperation = (IInvocationOperation)context.Operation;
+        if (context.Operation is not IInvocationOperation invocationOperation)
+        {
+            return;
+        }
+
         SemanticModel? semanticModel = invocationOperation.SemanticModel;
 
         if (semanticModel == null)

--- a/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -51,7 +51,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
         IMethodSymbol targetMethod = invocationOperation.TargetMethod;
 
         // 1. Check if the invoked method is a Moq Setup method
-        if (!semanticModel.IsMoqSetupMethod(knownSymbols, targetMethod, context.CancellationToken))
+        if (!targetMethod.IsMoqSetupMethod(knownSymbols))
         {
             return;
         }

--- a/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -29,9 +29,6 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-        // Instead of registering a syntax node action on InvocationExpression,
-        // we now register an operation action on IInvocationOperation.
         context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
     }
 
@@ -140,7 +137,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
         IOperation argumentOperation = moqSetupInvocation.Arguments[0].Value;
 
         // 1) Unwrap conversions (Roslyn often wraps lambdas in IConversionOperation).
-        argumentOperation = argumentOperation.UnwrapConversion();
+        argumentOperation = argumentOperation.WalkDownImplicitConversion();
 
         if (argumentOperation is IAnonymousFunctionOperation lambdaOperation)
         {

--- a/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -143,7 +143,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
         {
             // If it's a simple lambda of the form x => x.SomeMember,
             // the body often ends up as an IPropertyReferenceOperation or IInvocationOperation.
-            return lambdaOperation.Body.TryGetReferencedMemberSymbolFromLambda();
+            return lambdaOperation.Body.GetReferencedMemberSymbolFromLambda();
         }
 
         // Sometimes it might be a delegate creation or something else. Handle other patterns if needed.

--- a/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Moq.Analyzers;
 
@@ -28,51 +29,52 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+
+        // Instead of registering a syntax node action on InvocationExpression,
+        // we now register an operation action on IInvocationOperation.
+        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
     }
 
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Should be fixed. Ignoring for now to avoid additional churn as part of larger refactor.")]
-    private static void Analyze(SyntaxNodeAnalysisContext context)
+    private static void AnalyzeInvocation(OperationAnalysisContext context)
     {
-        InvocationExpressionSyntax setupInvocation = (InvocationExpressionSyntax)context.Node;
+        IInvocationOperation invocationOperation = (IInvocationOperation)context.Operation;
+        SemanticModel? semanticModel = invocationOperation.SemanticModel;
 
-        MoqKnownSymbols knownSymbols = new(context.SemanticModel.Compilation);
-
-        if (setupInvocation.Expression is not MemberAccessExpressionSyntax memberAccessExpression)
+        if (semanticModel == null)
         {
             return;
         }
 
-        SymbolInfo memberAccessSymbolInfo = context.SemanticModel.GetSymbolInfo(memberAccessExpression, context.CancellationToken);
-        if (memberAccessSymbolInfo.Symbol is null || !context.SemanticModel.IsMoqSetupMethod(knownSymbols, memberAccessSymbolInfo.Symbol, context.CancellationToken))
+        MoqKnownSymbols knownSymbols = new(semanticModel.Compilation);
+        IMethodSymbol targetMethod = invocationOperation.TargetMethod;
+
+        // 1. Check if the invoked method is a Moq Setup method
+        if (!semanticModel.IsMoqSetupMethod(knownSymbols, targetMethod, context.CancellationToken))
         {
             return;
         }
 
-        ExpressionSyntax? mockedMemberExpression = setupInvocation.FindMockedMemberExpressionFromSetupMethod();
-        if (mockedMemberExpression == null)
+        // 2. Attempt to locate the member reference from the Setup expression argument.
+        //    Typically, Moq setup calls have a single lambda argument like x => x.SomeMember.
+        //    We'll extract that member reference or invocation to see whether it is overridable.
+        ISymbol? mockedMemberSymbol = TryGetMockedMemberSymbol(invocationOperation);
+        if (mockedMemberSymbol == null)
         {
             return;
         }
 
-        SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(mockedMemberExpression, context.CancellationToken);
-        ISymbol? symbol = symbolInfo.Symbol;
-
-        if (symbol is null)
+        // 3. Skip if the symbol is part of an interface, those are always "overridable".
+        if (mockedMemberSymbol.ContainingType?.TypeKind == TypeKind.Interface)
         {
             return;
         }
 
-        // Skip if it's part of an interface
-        if (symbol.ContainingType.TypeKind == TypeKind.Interface)
-        {
-            return;
-        }
-
-        switch (symbol)
+        // 4. Check if symbol is a property or method, and if it is overridable or is returning a Task (which Moq allows).
+        switch (mockedMemberSymbol)
         {
             case IPropertySymbol propertySymbol:
-                // Check if the property is Task<T>.Result and skip diagnostic if it is
+                // If the property is Task<T>.Result, skip diagnostic
                 if (IsTaskResultProperty(propertySymbol, knownSymbols))
                 {
                     return;
@@ -84,6 +86,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
                 }
 
                 break;
+
             case IMethodSymbol methodSymbol:
                 if (methodSymbol.IsOverridable() || methodSymbol.IsMethodReturnTypeTask())
                 {
@@ -91,12 +94,54 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
                 }
 
                 break;
+
+            default:
+                // If it's not a property or method, we do not issue a diagnostic
+                return;
         }
 
-        Diagnostic diagnostic = mockedMemberExpression.CreateDiagnostic(Rule);
+        // 5. If we reach here, the member is neither overridable nor allowed by Moq
+        //    So we report the diagnostic.
+        //
+        // NOTE: The location is on the invocationOperation, which is fairly broad
+        Diagnostic diagnostic = invocationOperation.Syntax.CreateDiagnostic(Rule);
         context.ReportDiagnostic(diagnostic);
     }
 
+    /// <summary>
+    /// Attempts to resolve the symbol representing the member (property or method)
+    /// being referenced in the Setup(...) call. Returns null if it cannot be determined.
+    /// </summary>
+    private static ISymbol? TryGetMockedMemberSymbol(IInvocationOperation moqSetupInvocation)
+    {
+        // Usually the first argument to a Moq Setup(...) is a lambda expression like x => x.Property
+        // or x => x.Method(...). We can look at moqSetupInvocation.Arguments[0].Value to see this.
+        //
+        // In almost all Moq setups, the first argument is the expression (lambda) to be analyzed.
+        if (moqSetupInvocation.Arguments.Length == 0)
+        {
+            return null;
+        }
+
+        IOperation argumentOperation = moqSetupInvocation.Arguments[0].Value;
+
+        // 1) Unwrap conversions (Roslyn often wraps lambdas in IConversionOperation).
+        argumentOperation = argumentOperation.UnwrapConversion();
+
+        if (argumentOperation is IAnonymousFunctionOperation lambdaOperation)
+        {
+            // If it's a simple lambda of the form x => x.SomeMember,
+            // the body often ends up as an IPropertyReferenceOperation or IInvocationOperation.
+            return lambdaOperation.Body.TryGetReferencedMemberSymbolFromLambda();
+        }
+
+        // Sometimes it might be a delegate creation or something else. Handle other patterns if needed.
+        return null;
+    }
+
+    /// <summary>
+    /// Checks if a property is the 'Result' property on <see cref="Task{TResult}"/>.
+    /// </summary>
     private static bool IsTaskResultProperty(IPropertySymbol propertySymbol, MoqKnownSymbols knownSymbols)
     {
         // Check if the property is named "Result"

--- a/src/Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/src/Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -50,7 +50,7 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
         }
 
         SymbolInfo memberAccessSymbolInfo = context.SemanticModel.GetSymbolInfo(memberAccessExpression, context.CancellationToken);
-        if (memberAccessSymbolInfo.Symbol is null || !context.SemanticModel.IsMoqSetupMethod(knownSymbols, memberAccessSymbolInfo.Symbol, context.CancellationToken))
+        if (memberAccessSymbolInfo.Symbol is null || !memberAccessSymbolInfo.Symbol.IsMoqSetupMethod(knownSymbols))
         {
             return;
         }

--- a/src/Analyzers/SquiggleCop.Baseline.yaml
+++ b/src/Analyzers/SquiggleCop.Baseline.yaml
@@ -755,7 +755,7 @@
 - {Id: RCS1138, Title: Add summary to documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RCS1139, Title: Add summary element to documentation comment, Category: Roslynator, DefaultSeverity: Warning, IsEnabledByDefault: true, EffectiveSeverities: [Error], IsEverSuppressed: false}
 - {Id: RCS1140, Title: Add exception to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
-- {Id: RCS1141, Title: Add 'param' element to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
+- {Id: RCS1141, Title: Add 'param' element to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: RCS1142, Title: Add 'typeparam' element to documentation comment, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: false}
 - {Id: RCS1143, Title: Simplify coalesce expression, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}
 - {Id: RCS1145, Title: Remove redundant 'as' operator, Category: Roslynator, DefaultSeverity: Note, IsEnabledByDefault: true, EffectiveSeverities: [Note], IsEverSuppressed: true}

--- a/src/Common/IOperationExtensions.cs
+++ b/src/Common/IOperationExtensions.cs
@@ -36,7 +36,7 @@ internal static class IOperationExtensions
         return operation;
     }
 
-    public static ISymbol? TryGetSymbolFromOperation(this IOperation? operation)
+    public static ISymbol? GetSymbolFromOperation(this IOperation? operation)
     {
         if (operation is IReturnOperation returnOp)
         {
@@ -51,15 +51,15 @@ internal static class IOperationExtensions
         };
     }
 
-    public static ISymbol? TryGetReferencedMemberSymbolFromLambda(this IOperation? bodyOperation)
+    public static ISymbol? GetReferencedMemberSymbolFromLambda(this IOperation? bodyOperation)
     {
         if (bodyOperation is IBlockOperation { Operations.Length: 1 } blockOperation)
         {
             // If it's a block lambda (example: => { return x.Property; })
-            return blockOperation.Operations[0].TryGetSymbolFromOperation();
+            return blockOperation.Operations[0].GetSymbolFromOperation();
         }
 
         // If it's an expression lambda (example: => x.Property or => x.Method(...))
-        return bodyOperation.TryGetSymbolFromOperation();
+        return bodyOperation.GetSymbolFromOperation();
     }
 }

--- a/src/Common/IOperationExtensions.cs
+++ b/src/Common/IOperationExtensions.cs
@@ -18,4 +18,43 @@ internal static class IOperationExtensions
 
         return operation;
     }
+
+    public static ISymbol? TryGetSymbolFromOperation(this IOperation? operation)
+    {
+        if (operation is IReturnOperation returnOp)
+        {
+            operation = returnOp.ReturnedValue;
+        }
+
+        return operation switch
+        {
+            IPropertyReferenceOperation propertyRef => propertyRef.Property,
+            IInvocationOperation methodOp => methodOp.TargetMethod,
+            _ => null,
+        };
+    }
+
+    public static ISymbol? TryGetReferencedMemberSymbolFromLambda(this IOperation? bodyOperation)
+    {
+        if (bodyOperation is IBlockOperation { Operations.Length: 1 } blockOperation)
+        {
+            // If it's a block lambda (example: => { return x.Property; })
+            return blockOperation.Operations[0].TryGetSymbolFromOperation();
+        }
+
+        // If it's an expression lambda (example: => x.Property or => x.Method(...))
+        return bodyOperation.TryGetSymbolFromOperation();
+    }
+
+    public static IOperation UnwrapConversion(this IOperation operation)
+    {
+        // Keep peeling off any IConversionOperation layers as long as the conversion is implicit or trivial.
+        // Typically, Moq expression lambdas are converted to Expression<Func<...>> or Func<...>.
+        while (operation is IConversionOperation { Conversion.IsImplicit: true, Operand: not null } conversion)
+        {
+            operation = conversion.Operand;
+        }
+
+        return operation;
+    }
 }

--- a/src/Common/IOperationExtensions.cs
+++ b/src/Common/IOperationExtensions.cs
@@ -22,7 +22,7 @@ internal static class IOperationExtensions
     /// <summary>
     /// Walks down consecutive implicit conversion operations until an operand is reached that isn't an implicit conversion operation.
     /// Unlike WalkDownConversion, this method only traverses through implicit conversions, which is particularly useful for
-    /// handling Moq expression lambdas that are typically converted to Expression<Func<...>> or Func<...>.
+    /// handling Moq expression lambdas that are typically converted to Expression&lt;Func&lt;...&gt;&gt; or Func&lt;...&gt;.
     /// </summary>
     /// <param name="operation">The starting operation.</param>
     /// <returns>The inner non-conversion operation or the starting operation if it wasn't an implicit conversion operation.</returns>

--- a/src/Common/IOperationExtensions.cs
+++ b/src/Common/IOperationExtensions.cs
@@ -64,15 +64,21 @@ internal static class IOperationExtensions
     /// <returns>The extracted symbol, or <see langword="null" /> if not found or if the <paramref name="operation"/> operation is <see langword="null" />.</returns>
     private static ISymbol? GetSymbolFromOperation(this IOperation? operation)
     {
-        if (operation is IReturnOperation returnOp)
+        switch (operation)
         {
-            operation = returnOp.ReturnedValue;
+            case null:
+                return null;
+            case IReturnOperation returnOp:
+                operation = returnOp.ReturnedValue;
+                break;
         }
 
         return operation switch
         {
             IPropertyReferenceOperation propertyRef => propertyRef.Property,
             IInvocationOperation methodOp => methodOp.TargetMethod,
+            IEventReferenceOperation eventRef => eventRef.Event,
+            IFieldReferenceOperation fieldRef => fieldRef.Field,
             _ => null,
         };
     }

--- a/src/Common/IOperationExtensions.cs
+++ b/src/Common/IOperationExtensions.cs
@@ -20,10 +20,12 @@ internal static class IOperationExtensions
     }
 
     /// <summary>
-    /// Walks down consecutive implicit conversion operations until an operand is reached that isn't a conversion operation.
+    /// Walks down consecutive implicit conversion operations until an operand is reached that isn't an implicit conversion operation.
+    /// Unlike WalkDownConversion, this method only traverses through implicit conversions, which is particularly useful for
+    /// handling Moq expression lambdas that are typically converted to Expression<Func<...>> or Func<...>.
     /// </summary>
     /// <param name="operation">The starting operation.</param>
-    /// <returns>The inner non conversion operation or the starting operation if it wasn't a conversion operation.</returns>
+    /// <returns>The inner non-conversion operation or the starting operation if it wasn't an implicit conversion operation.</returns>
     public static IOperation WalkDownImplicitConversion(this IOperation operation)
     {
         // Keep peeling off any IConversionOperation layers as long as the conversion is implicit or trivial.

--- a/src/Common/IOperationExtensions.cs
+++ b/src/Common/IOperationExtensions.cs
@@ -36,7 +36,19 @@ internal static class IOperationExtensions
         return operation;
     }
 
-    public static ISymbol? GetSymbolFromOperation(this IOperation? operation)
+    internal static ISymbol? GetReferencedMemberSymbolFromLambda(this IOperation? bodyOperation)
+    {
+        if (bodyOperation is IBlockOperation { Operations.Length: 1 } blockOperation)
+        {
+            // If it's a block lambda (example: => { return x.Property; })
+            return blockOperation.Operations[0].GetSymbolFromOperation();
+        }
+
+        // If it's an expression lambda (example: => x.Property or => x.Method(...))
+        return bodyOperation.GetSymbolFromOperation();
+    }
+
+    private static ISymbol? GetSymbolFromOperation(this IOperation? operation)
     {
         if (operation is IReturnOperation returnOp)
         {
@@ -49,17 +61,5 @@ internal static class IOperationExtensions
             IInvocationOperation methodOp => methodOp.TargetMethod,
             _ => null,
         };
-    }
-
-    public static ISymbol? GetReferencedMemberSymbolFromLambda(this IOperation? bodyOperation)
-    {
-        if (bodyOperation is IBlockOperation { Operations.Length: 1 } blockOperation)
-        {
-            // If it's a block lambda (example: => { return x.Property; })
-            return blockOperation.Operations[0].GetSymbolFromOperation();
-        }
-
-        // If it's an expression lambda (example: => x.Property or => x.Method(...))
-        return bodyOperation.GetSymbolFromOperation();
     }
 }

--- a/src/Common/IOperationExtensions.cs
+++ b/src/Common/IOperationExtensions.cs
@@ -38,6 +38,12 @@ internal static class IOperationExtensions
         return operation;
     }
 
+    /// <summary>
+    /// Extracts the referenced member symbol from a lambda operation, handling both block lambdas
+    /// (e.g., => { return x.Property; }) and expression lambdas (e.g., => x.Property).
+    /// </summary>
+    /// <param name="bodyOperation">The lambda body operation to analyze.</param>
+    /// <returns>The referenced member symbol, or <see langword="null" /> if not found or if the operation is <see langword="null" />.</returns>
     internal static ISymbol? GetReferencedMemberSymbolFromLambda(this IOperation? bodyOperation)
     {
         if (bodyOperation is IBlockOperation { Operations.Length: 1 } blockOperation)
@@ -50,6 +56,12 @@ internal static class IOperationExtensions
         return bodyOperation.GetSymbolFromOperation();
     }
 
+    /// <summary>
+    /// Extracts a <see cref="ISymbol"/> from an <see cref="IOperation"/>, handling return operations, property references,
+    /// method invocations, events, and fields.
+    /// </summary>
+    /// <param name="operation">The <see cref="IOperation"/> to analyze.</param>
+    /// <returns>The extracted symbol, or <see langword="null" /> if not found or if the <paramref name="operation"/> operation is <see langword="null" />.</returns>
     private static ISymbol? GetSymbolFromOperation(this IOperation? operation)
     {
         if (operation is IReturnOperation returnOp)

--- a/src/Common/ISymbolExtensions.cs
+++ b/src/Common/ISymbolExtensions.cs
@@ -114,7 +114,7 @@ internal static class ISymbolExtensions
             IMethodSymbol { IsStatic: true } or IPropertySymbol { IsStatic: true } => false,
             _ when symbol.ContainingType?.TypeKind == TypeKind.Interface => true,
             _ => !symbol.IsSealed &&
-                 (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false })
+                  (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false })
         };
     }
 }

--- a/src/Common/ISymbolExtensions.cs
+++ b/src/Common/ISymbolExtensions.cs
@@ -109,6 +109,12 @@ internal static class ISymbolExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsOverridable(this ISymbol symbol)
     {
-        return !symbol.IsSealed && (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false });
+        return symbol switch
+        {
+            IMethodSymbol { IsStatic: true } or IPropertySymbol { IsStatic: true } => false,
+            _ when symbol.ContainingType?.TypeKind == TypeKind.Interface => true,
+            _ => !symbol.IsSealed &&
+                 (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false })
+        };
     }
 }

--- a/src/Common/ISymbolExtensions.cs
+++ b/src/Common/ISymbolExtensions.cs
@@ -114,7 +114,7 @@ internal static class ISymbolExtensions
             IMethodSymbol { IsStatic: true } or IPropertySymbol { IsStatic: true } => false,
             _ when symbol.ContainingType?.TypeKind == TypeKind.Interface => true,
             _ => !symbol.IsSealed &&
-                  (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false })
+                  (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false }),
         };
     }
 }

--- a/src/Common/ISymbolExtensions.cs
+++ b/src/Common/ISymbolExtensions.cs
@@ -109,6 +109,6 @@ internal static class ISymbolExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static bool IsOverridable(this ISymbol symbol)
     {
-        return !symbol.IsSealed && (symbol.IsVirtual || symbol.IsAbstract || symbol.IsOverride);
+        return !symbol.IsSealed && (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false });
     }
 }

--- a/src/Common/ISymbolExtensions.cs
+++ b/src/Common/ISymbolExtensions.cs
@@ -117,4 +117,9 @@ internal static class ISymbolExtensions
                   (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false }),
         };
     }
+
+    internal static bool IsMoqSetupMethod(this ISymbol symbol, MoqKnownSymbols knownSymbols)
+    {
+        return symbol.IsInstanceOf(knownSymbols.Mock1Setup) && symbol is IMethodSymbol { IsGenericMethod: true };
+    }
 }

--- a/src/Common/SemanticModelExtensions.cs
+++ b/src/Common/SemanticModelExtensions.cs
@@ -21,7 +21,7 @@ internal static class SemanticModelExtensions
             return null;
         }
 
-        if (semanticModel.IsMoqSetupMethod(knownSymbols, symbolInfo.Symbol, cancellationToken))
+        if (symbolInfo.Symbol.IsMoqSetupMethod(knownSymbols))
         {
             return invocation;
         }
@@ -63,11 +63,6 @@ internal static class SemanticModelExtensions
             CandidateReason.None => IsCallbackOrReturnSymbol(symbolInfo.Symbol),
             _ => false,
         };
-    }
-
-    internal static bool IsMoqSetupMethod(this SemanticModel semanticModel, MoqKnownSymbols knownSymbols, ISymbol symbol, CancellationToken cancellationToken)
-    {
-        return symbol.IsInstanceOf(knownSymbols.Mock1Setup) && symbol is IMethodSymbol { IsGenericMethod: true };
     }
 
     private static List<T> GetAllMatchingSymbols<T>(this SemanticModel semanticModel, ExpressionSyntax expression)

--- a/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -8,9 +8,9 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests(ITestOutput
     {
         return new object[][]
         {
-            ["""new Mock<BaseSampleClass>().Setup(x => {|Moq1200:x.Calculate()|});"""],
-            ["""new Mock<SampleClass>().Setup(x => {|Moq1200:x.Property|});"""],
-            ["""new Mock<SampleClass>().Setup(x => {|Moq1200:x.Calculate(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>())|});"""],
+            ["""{|Moq1200:new Mock<BaseSampleClass>().Setup(x => x.Calculate())|};"""],
+            ["""{|Moq1200:new Mock<SampleClass>().Setup(x => x.Property)|};"""],
+            ["""{|Moq1200:new Mock<SampleClass>().Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>(), It.IsAny<int>()))|};"""],
             ["""new Mock<BaseSampleClass>().Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>()));"""],
             ["""new Mock<ISampleInterface>().Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>()));"""],
             ["""new Mock<ISampleInterface>().Setup(x => x.TestProperty);"""],

--- a/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -17,6 +17,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests(ITestOutput
             ["""new Mock<SampleClass>().Setup(x => x.Calculate(It.IsAny<int>(), It.IsAny<int>()));"""],
             ["""new Mock<SampleClass>().Setup(x => x.DoSth());"""],
             ["""new Mock<IParameterlessAsyncMethod>().Setup(x => x.DoSomethingAsync().Result).Returns(true);"""],
+            ["""new Mock<SampleClass>().Setup(x => x.Field);"""],
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 
@@ -51,6 +52,7 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests(ITestOutput
                                     public sealed override int Calculate(int a, int b, int c) => 0;
                                     public virtual int DoSth() => 0;
                                     public int Property { get; set; }
+                                    public int Field;
                                 }
 
                                 internal class UnitTest

--- a/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
@@ -29,7 +29,7 @@ public class SetupShouldNotIncludeAsyncResultAnalyzerTests(ITestOutputHelper out
               public class AsyncClient
               {
                   public virtual Task TaskAsync() => Task.CompletedTask;
-              
+
                   public virtual Task<string> GenericTaskAsync() => Task.FromResult(string.Empty);
               }
 


### PR DESCRIPTION
Updates `SetupShouldOnlyBeUsedForOverridableMembersAnalyzer` to use `IOperation` pattern found in explainer #118 

With the IOperation implementation, the symbol specificity is broader on the detected text span, so the test cases were updated to reflect that with a marker move to the beginning and end of the inserted symbol. 

Additional related updates include:

- Adding utility methods for handling code operations and symbol retrieval
- Updated symbol overridability detection logic

Fixes #339