### PR TITLE
Add ValueTask detection tests

### DIFF
--- a/src/Common/ISymbolExtensions.cs
+++ b/src/Common/ISymbolExtensions.cs
@@ -100,7 +100,7 @@ internal static class ISymbolExtensions
     {
         string type = methodSymbol.ToDisplayString();
         return string.Equals(type, "System.Threading.Tasks.Task", StringComparison.Ordinal)
-               || string.Equals(type, "System.Threading.ValueTask", StringComparison.Ordinal)
+               || string.Equals(type, "System.Threading.Tasks.ValueTask", StringComparison.Ordinal)
                || type.StartsWith("System.Threading.Tasks.Task<", StringComparison.Ordinal)
                || (type.StartsWith("System.Threading.Tasks.ValueTask<", StringComparison.Ordinal)
                    && type.EndsWith(".Result", StringComparison.Ordinal));

--- a/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
@@ -13,8 +13,14 @@ public class SetupShouldNotIncludeAsyncResultAnalyzerTests(ITestOutputHelper out
             // Prior to Moq 4.16, the setup helper ReturnsAsync(), ThrowsAsync() are preferred
             ["""new Mock<AsyncClient>().Setup(c => c.GenericTaskAsync()).ReturnsAsync(string.Empty);"""],
 
+            ["""new Mock<AsyncClient>().Setup(c => c.ValueTaskAsync());"""],
+
+            ["""new Mock<AsyncClient>().Setup(c => c.GenericValueTaskAsync()).Returns(ValueTask.FromResult(string.Empty));"""],
+
             // Starting with Moq 4.16, you can simply .Setup the returned tasks's .Result property
             ["""new Mock<AsyncClient>().Setup(c => {|Moq1201:c.GenericTaskAsync().Result|});"""],
+
+            ["""new Mock<AsyncClient>().Setup(c => {|Moq1201:c.GenericValueTaskAsync().Result|});"""],
         }.WithNamespaces().WithOldMoqReferenceAssemblyGroups();
     }
 
@@ -31,6 +37,10 @@ public class SetupShouldNotIncludeAsyncResultAnalyzerTests(ITestOutputHelper out
                   public virtual Task TaskAsync() => Task.CompletedTask;
 
                   public virtual Task<string> GenericTaskAsync() => Task.FromResult(string.Empty);
+
+                  public virtual ValueTask ValueTaskAsync() => ValueTask.CompletedTask;
+
+                  public virtual ValueTask<string> GenericValueTaskAsync() => ValueTask.FromResult(string.Empty);
               }
 
               internal class UnitTest


### PR DESCRIPTION
- fix `ValueTask` string comparison for task-return detection
- add regression tests for `ValueTask` setup analysis


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Tests**
  - Added new test cases to verify analyzer behavior with ValueTask-based asynchronous methods.
  - Extended the test client with methods returning ValueTask and ValueTask<string> to support these scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->