### PR TITLE
Fix path casing for PerfDiff project in ComparePerfResults.ps1

### DIFF
--- a/build/scripts/perf/ComparePerfResults.ps1
+++ b/build/scripts/perf/ComparePerfResults.ps1
@@ -18,7 +18,7 @@ try {
     Write-Host " - results: '$resultsFolder' "
     
     $RepoRoot = Resolve-Path (Join-Path $PSScriptRoot '..\..\..')
-    $perfDiff = Join-Path $RepoRoot "src\Tools\PerfDiff\PerfDiff.csproj"
+    $perfDiff = Join-Path $RepoRoot "src\tools\PerfDiff\PerfDiff.csproj"
     & dotnet build $perfDiff -c Release
     & dotnet run -c Release --project $perfDiff -- --baseline $baselineFolder --results $resultsFolder --failOnRegression --verbosity diag
     $host.SetShouldExit($LASTEXITCODE)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated internal script paths for performance comparison tools to improve consistency. No changes to user-facing features or functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->