### PR TITLE
refactor: Update AsShouldBeUsedOnlyForInterfaceAnalyzer description and category

### DIFF
--- a/.codacy/codacy.yaml
+++ b/.codacy/codacy.yaml
@@ -1,15 +1,6 @@
 runtimes:
-    - dart@3.7.2
-    - go@1.22.3
-    - java@17.0.10
-    - node@22.2.0
     - python@3.11.11
 tools:
-    - dartanalyzer@3.7.2
-    - eslint@8.57.0
     - lizard@1.17.19
-    - pmd@7.11.0
-    - pylint@3.3.6
-    - revive@1.7.0
     - semgrep@1.78.0
     - trivy@0.59.1

--- a/.cursor/rules/codacy.mdc
+++ b/.cursor/rules/codacy.mdc
@@ -8,13 +8,6 @@ alwaysApply: false
 # Codacy Rules
 Configuration for AI behavior when interacting with Codacy's MCP Server
 
-## using any tool that accepts the arguments: `provider`, `organization`, or `repository`
-- ALWAYS use:
- - provider: gh
- - organization: rjmurillo
- - repository: moq.analyzers
-- Avoid calling `git remote -v` unless really necessary
-
 ## After ANY successful `edit_file` or `reapply` operation
 - YOU MUST IMMEDIATELY run the `codacy_cli_analyze` tool from Codacy's MCP Server for each file that was edited, with:
  - `rootPath`: set to the workspace path

--- a/.cursor/rules/generate-tasks.md
+++ b/.cursor/rules/generate-tasks.md
@@ -33,16 +33,16 @@ The generated task list _must_ follow this structure. The example below is gener
 - The parent task list should be created as a GitHub issue (the parent issue), with each high-level task represented as a checklist item that links to a corresponding sub-task issue.
 - Each sub-task should be created as its own GitHub issue, with a reference back to the parent issue (e.g., "Parent: #123").
 - The parent issue should include a checklist like:
-  - [ ] [Sub-task Title 1](https://github.com/org/repo/issues/456)
-  - [ ] [Sub-task Title 2](https://github.com/org/repo/issues/457)
+  - [ ] #456
+  - [ ] #457
 - Each sub-task issue should include a link to the parent issue at the top, and may include its own detailed checklist if needed.
 
 #### Example Parent Issue Checklist
 
 ```markdown
-- [ ] [Implement Core Analyzer Logic](https://github.com/org/repo/issues/456)
-- [ ] [Add Test Coverage](https://github.com/org/repo/issues/457)
-- [ ] [Update Documentation](https://github.com/org/repo/issues/458)
+- [ ] #456
+- [ ] #457
+- [ ] #458
 ```
 
 #### Example Sub-task Issue Header
@@ -69,9 +69,9 @@ When editing files, follow the guidance at `.github/instructions/README.md` to d
 
 ## Tasks
 
-- [ ] [Implement Core Analyzer Logic](https://github.com/org/repo/issues/456)
-- [ ] [Add Test Coverage](https://github.com/org/repo/issues/457)
-- [ ] [Update Documentation](https://github.com/org/repo/issues/458)
+- [ ] #456
+- [ ] #457
+- [ ] #458
 ```
 
 ## Interaction Model

--- a/.cursor/rules/process-task-list.md
+++ b/.cursor/rules/process-task-list.md
@@ -5,6 +5,7 @@ Guidelines for managing task lists in GitHub issue Markdown files to track progr
 ## Task Implementation
 
 - **One sub-task at a time:** Do **NOT** start the next sub‑task until you ask the user for permission and they say "yes" or "y"
+- **Load in the appropriate rules:** Before beginning any work, load `./.github/copilot-instructions.md` and `./.github/instructions/README.md`
 - **Completion protocol:**
   1. When you finish a **sub‑task**, immediately mark it as completed by changing `[ ]` to `[x]`.
   2. If **all** subtasks underneath a parent task are now `[x]`, follow this sequence:

--- a/.cursor/rules/process-task-list.md
+++ b/.cursor/rules/process-task-list.md
@@ -6,6 +6,7 @@ Guidelines for managing task lists in GitHub issue Markdown files to track progr
 
 - **One sub-task at a time:** Do **NOT** start the next sub‑task until you ask the user for permission and they say "yes" or "y"
 - **Load in the appropriate rules:** Before beginning any work, load `./.github/copilot-instructions.md` and `./.github/instructions/README.md`
+- **Build and Test Failures are STOP conditions**: If at any point a `dotnet build` or `dotnet test` command fails, you MUST stop. Do not proceed with the task list. Your immediate and only priority is to diagnose and fix the failure. Never apply a workaround to simply make a build pass. Investigate the root cause, and if you are unsure, you MUST ask for guidance.
 - **Completion protocol:**
   1. When you finish a **sub‑task**, immediately mark it as completed by changing `[ ]` to `[x]`.
   2. If **all** subtasks underneath a parent task are now `[x]`, follow this sequence:

--- a/.cursor/rules/process-task-list.md
+++ b/.cursor/rules/process-task-list.md
@@ -21,10 +21,15 @@ Guidelines for managing task lists in GitHub issue Markdown files to track progr
       - **Formats the message as a single-line command using `-m` flags**, e.g.:
 
         ```text
-        git commit -m "feat: add payment validation logic" -m "- Validates card type and expiry" -m "- Adds unit tests for edge cases" -m "Related to #123 in Explainer"
+        git commit -m "feat: add payment validation logic" -m "- Validates card type and expiry" -m "- Adds unit tests for edge cases" -m "Related to #123 in Explainer" -m "Fixes sub-task #456"
         ```
 
-  3. Once all the subtasks are marked completed and changes have been committed, mark the **parent task** as completed.
+  3. Once all the subtasks are marked completed and changes have been committed, verify with the user the task is completed.
+  4. Once the user has indicated the work is verified, push the branch and open a pull request.
+    - **Title**: Uses convention commit format
+    - **Body**: Be descriptive
+      - **Explain**: all changes made, why they were made, and all validation performed
+      - **Reference the Task** Use language to indicate the issue is resolved at the end of the description (e.g., `Fixes #456`, `Closes #123`, `Resolves #789` etc. )
 - Stop after each sub‑task and wait for the user's go‑ahead.
 
 ## Task List Maintenance

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -380,6 +380,7 @@ If you encounter:
 
 - Place new analyzers in `src/Analyzers/`, code fixes in `src/CodeFixes/`, and shared logic in `src/Common/`.
 - Update `src/Analyzers/AnalyzerReleases.Unshipped.md` and add or update documentation in `docs/rules/` for each diagnostic.
+- **CRITICAL: Do not modify `AnalyzerReleases.Shipped.md`**. This file is an immutable record of past releases. All changes, including category or severity updates to existing rules, **MUST** be documented in `AnalyzerReleases.Unshipped.md`.
 - Add or update unit tests in `tests/Moq.Analyzers.Test/` for every analyzer or code fix change.
 - After any file edit, immediately run Codacy analysis for the edited file and resolve all reported issues before proceeding.
 - After any dependency change, run Codacy analysis with `tool: trivy` and resolve vulnerabilities before continuing.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -347,6 +347,12 @@ If you have passed the expertise declaration, you must now answer the following 
   - Never guess which Roslyn API to use. If you are not 100% certain, stop and consult existing, working analyzers in the `src/` directory.
   - Never "fix" a failing test by slightly adjusting the code and re-running. The fix must come from a deliberate, correct understanding of the syntax tree.
 
+- **Handle Build Failures Correctly:** If a `dotnet build` command fails, you **MUST** treat it as a critical stop condition.
+  - **Analyze the error:** Do not guess. Read the build output carefully to understand the exact cause.
+  - **Do not apply workarounds:** Never change the code to simply make an error go away (e.g., changing a required value to a different, incorrect one that happens to exist).
+  - **Investigate the root cause:** If a type or member is "missing", find its definition. If a configuration is wrong, find the configuration file.
+  - **Escalate if unsure:** If you cannot determine the root cause after investigation, you **MUST STOP** and ask for guidance. A wrong "fix" is worse than no action.
+
 ---
 
 ## AI Agent Troubleshooting

--- a/docs/rules/Moq1300.md
+++ b/docs/rules/Moq1300.md
@@ -2,9 +2,10 @@
 
 | Item     | Value |
 | -------- | ----- |
+| Category | Usage |
 | Enabled  | True  |
 | Severity | Error |
-| CodeFix  | False |
+| CodeFix  | No    |
 ---
 
 The `.As()` method is used when a mocked object must implement multiple interfaces. It cannot be used with abstract or

--- a/src/Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Analyzers/AnalyzerReleases.Shipped.md
@@ -50,7 +50,7 @@ Moq1200 | Moq | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer, [Doc
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-Moq1300 | Usage | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1300.md)
+Moq1300 | Moq | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1300.md)
 
 ## Release 0.0.9
 

--- a/src/Analyzers/AnalyzerReleases.Shipped.md
+++ b/src/Analyzers/AnalyzerReleases.Shipped.md
@@ -50,7 +50,7 @@ Moq1200 | Moq | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer, [Doc
 
 Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
-Moq1300 | Moq | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1300.md)
+Moq1300 | Usage | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer, [Documentation](https://github.com/rjmurillo/moq.analyzers/blob/main/docs/rules/Moq1300.md)
 
 ## Release 0.0.9
 

--- a/src/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/AnalyzerReleases.Unshipped.md
@@ -11,12 +11,8 @@ Moq1205 | Moq | Warning | EventSetupHandlerShouldMatchEventTypeAnalyzer
 Moq1206 | Moq | Warning | ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer
 Moq1207 | Moq | Error | SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer
 Moq1210 | Moq | Error | VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer
+Moq1300 | Usage | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer, [Documentation](../../docs/rules/Moq1300.md)
 Moq1301 | Moq | Warning | Mock.Get() should not take literals
 Moq1302 | Moq | Warning | LINQ to Mocks expression should be valid (flags non-virtual members including fields, events, nested and chained accesses)
 Moq1420 | Moq | Info | RedundantTimesSpecificationAnalyzer
 Moq1500 | Moq | Warning | MockRepository.Verify() should be called
-
-### Changed Rules
-Rule ID | New Category | New Severity | Notes
---------|--------------|--------------|-------
-Moq1300 | Usage | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer

--- a/src/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/AnalyzerReleases.Unshipped.md
@@ -15,3 +15,8 @@ Moq1301 | Moq | Warning | Mock.Get() should not take literals
 Moq1302 | Moq | Warning | LINQ to Mocks expression should be valid (flags non-virtual members including fields, events, nested and chained accesses)
 Moq1420 | Moq | Info | RedundantTimesSpecificationAnalyzer
 Moq1500 | Moq | Warning | MockRepository.Verify() should be called
+
+### Changed Rules
+Rule ID | New Category | New Severity | Notes
+--------|--------------|--------------|-------
+Moq1300 | Usage | Error | AsShouldBeUsedOnlyForInterfaceAnalyzer

--- a/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -17,7 +17,7 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
         DiagnosticIds.AsShouldOnlyBeUsedForInterfacesRuleId,
         Title,
         Message,
-        DiagnosticCategory.Moq,
+        DiagnosticCategory.Usage,
         DiagnosticSeverity.Error,
         isEnabledByDefault: true,
         description: Description,

--- a/src/Common/DiagnosticCategory.cs
+++ b/src/Common/DiagnosticCategory.cs
@@ -5,4 +5,5 @@
 internal static class DiagnosticCategory
 {
     internal const string Moq = nameof(Moq);
+    internal const string Usage = nameof(Usage);
 }


### PR DESCRIPTION
Update `src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs` to use proper messaging and category

Fixes #648 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated task management and analyzer rule documentation with clearer instructions, stricter protocols, and improved formatting.
  * Enhanced rule Moq1300 documentation to include a new "Category" field and updated "CodeFix" information.

* **New Features**
  * Added a new "Usage" diagnostic category for analyzers.

* **Bug Fixes**
  * Improved diagnostic messages for interface usage errors, now displaying the specific non-interface type name.

* **Chores**
  * Simplified and streamlined configuration files by removing unused runtimes and analysis tools.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->