### PR TITLE
ci: skip expensive jobs for docs-only PRs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,15 +43,7 @@ jobs:
       # For non-PR events, always run full pipeline; for PRs use paths-filter result.
       # When paths-filter is skipped, outputs are '' (empty), which is not 'true',
       # so the fallback 'true' is needed for non-PR events.
-      code-changed: >-
-        ${{
-          (github.event_name == 'push' && 'true')
-          || (github.event_name == 'merge_group' && 'true')
-          || (github.event_name == 'schedule' && 'true')
-          || (github.event_name == 'workflow_dispatch' && 'true')
-          || (github.event_name == 'workflow_call' && 'true')
-          || steps.filter.outputs.code
-        }}
+      code-changed: ${{ github.event_name != 'pull_request' || steps.filter.outputs.code }}
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 


### PR DESCRIPTION
## Summary

Closes #900.

- Adds a `check-paths` job using `dorny/paths-filter` to detect whether changed files require the full CI pipeline
- Downstream jobs (build, test, analyzer-load-test, perf) still run to satisfy all 16 required status checks, but skip their expensive steps when only docs/non-code files changed
- Non-PR events (push, merge_group, schedule, workflow_dispatch, workflow_call) always run the full pipeline
- Pins all action references to SHA for supply-chain security
- Adds a skip-notice step to each job for log clarity

### How it works

The `check-paths` job outputs `code-changed: 'true'` or the paths-filter result. Every step in downstream jobs is gated on `needs.check-paths.outputs.code-changed == 'true'`. Jobs themselves always run (no job-level `if:`), so required status checks still report a status.

### Known risks

| Risk | Severity | Action |
|------|----------|--------|
| Codacy Coverage Variation stays pending on docs-only PRs | High | Observe on first docs-only PR. File follow-up issue if it blocks. |
| 9 analyzer-load-test runners spin up to emit skip notice | Low | Unavoidable with per-matrix required checks. Each finishes in seconds. |

## Test plan

- [ ] **Docs-only PR:** Change only a `.md` file. Verify all 16 checks pass, jobs show "Skipped" in logs, wall-clock < 1 min per job
- [ ] **Code PR:** Change a file in `src/`. Verify full pipeline runs identically to today
- [ ] **Mixed PR:** Change both `README.md` and `src/` file. Verify full pipeline runs
- [ ] **workflow_dispatch:** Trigger manually. Verify full pipeline runs
- [ ] **Release:** Next release via `release.yml` triggers full pipeline via `workflow_call`
- [ ] Validated locally with `gh act push` (check-paths succeeds, step gating works, compound `if:` conditions evaluate correctly)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized CI/CD pipeline to skip expensive operations when only non-code files are changed, improving feedback speed for documentation and configuration updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->