### PR TITLE
build: configure version with semver2 height-based prerelease

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,9 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "0.5.0-alpha",
+  "version": "0.5.0-alpha.{height}",
+  "nugetPackageVersion": {
+    "semVer": 2
+  },
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/v\\d+(?:\\.\\d+)?$",


### PR DESCRIPTION
## Summary
- Add `{height}` to prerelease tag for auto-incrementing alpha versions (`0.5.0-alpha.1`, `0.5.0-alpha.2`, ...)
- Add `nugetPackageVersion.semVer=2` for dotted format (`alpha.N`) instead of zero-padded (`alpha-000N`)

Mirrors the same change applied to `release/v0.4.1` in commit 3d66e79.

## Test plan
- [ ] Verify `dotnet nbgv get-version` shows `NuGetPackageVersion: 0.5.0-alpha.N` on main after merge
- [ ] Verify CI produces correctly versioned NuGet package

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated version string format to include build height as a dynamic placeholder
  * Enabled semantic versioning 2.0 for NuGet package management

<!-- end of auto-generated comment: release notes by coderabbit.ai -->