### PR TITLE
fix: correct YAML indentation in Serena project config

### DIFF
--- a/.serena/project.yml
+++ b/.serena/project.yml
@@ -4,10 +4,10 @@
 # Languages for which language servers are started.
 # csharp requires the presence of a .sln file in the project folder.
 languages:
-- csharp
-- markdown
-- yaml
-- bash
+  - csharp
+  - markdown
+  - yaml
+  - bash
 
 # the encoding used by text files in the project
 # For a list of possible encodings, see https://docs.python.org/3.11/library/codecs.html#standard-encodings
@@ -18,12 +18,12 @@ ignore_all_files_in_gitignore: true
 
 # list of additional paths to ignore
 ignored_paths:
-- "**/bin/**"
-- "**/obj/**"
-- "**/artifacts/**"
-- "**/.vs/**"
-- "**/BenchmarkDotNet.Artifacts/**"
-- "**/TestResults/**"
+  - "**/bin/**"
+  - "**/obj/**"
+  - "**/artifacts/**"
+  - "**/.vs/**"
+  - "**/BenchmarkDotNet.Artifacts/**"
+  - "**/TestResults/**"
 
 # whether the project is in read-only mode
 # If set to true, all editing tools will be disabled and attempts to use them will result in an error


### PR DESCRIPTION
## Summary

- Fix YAML sequence indentation in `.serena/project.yml` (lines 7 and 21)
- The `languages` and `ignored_paths` list items were not indented under their parent keys, violating yamllint's default indentation rules
- This was causing super-linter YAML validation failures on all open PRs (e.g., #949)

## Test plan

- [ ] Super-linter YAML check passes on this PR
- [ ] After merge, Renovate PRs (e.g., #949) can be rebased and pass lint


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project configuration file formatting and structure for consistency.
  * Added encoding and read-only configuration settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->