### PR TITLE
fix: use GetMembers(".ctor") to pre-filter constructor search

### DIFF
--- a/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -455,7 +455,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         ArgumentSyntax[] arguments)
     {
         IMethodSymbol[] constructors = mockedClass
-            .GetMembers(".ctor")
+            .GetMembers(WellKnownMemberNames.InstanceConstructorName)
             .OfType<IMethodSymbol>()
             .Where(methodSymbol => methodSymbol.IsConstructor())
             .ToArray();


### PR DESCRIPTION
## Summary
- Replace `GetMembers()` with `GetMembers(".ctor")` in `ConstructorArgumentsShouldMatchAnalyzer` to let Roslyn pre-filter members at the API level
- Avoids unnecessary iteration over all type members when only constructors are needed
- The `IsConstructor()` filter is retained to exclude private and static constructors

## Test plan
- [x] Verified build succeeds with `dotnet build src/Analyzers/Moq.Analyzers.csproj`
- [ ] Existing unit tests pass (test runner requires .NET 8.0 SDK not available in local env)

Fixes #451

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved constructor detection to target instance constructors only, resulting in more accurate analyzer behavior and modest performance gains.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->