### PR TITLE
fix: remove duplicate Net80 property and catalog entry

### DIFF
--- a/tests/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalog.cs
+++ b/tests/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalog.cs
@@ -36,11 +36,6 @@ public static class ReferenceAssemblyCatalog
     public static string Net80WithNewMoqAndLogging => nameof(Net80WithNewMoqAndLogging);
 
     /// <summary>
-    /// Gets the name of the reference assembly group for .NET 8.0 without Moq.
-    /// </summary>
-    public static string Net80 => nameof(Net80);
-
-    /// <summary>
     /// Gets the catalog of reference assemblies.
     /// </summary>
     /// <remarks>
@@ -69,8 +64,5 @@ public static class ReferenceAssemblyCatalog
                 new PackageIdentity("Microsoft.Extensions.Logging.Abstractions", "8.0.0"),
             ])
         },
-
-        // .NET 8.0 without Moq, used to verify analyzers bail out gracefully when Moq is not referenced.
-        { nameof(Net80), ReferenceAssemblies.Net.Net80 },
     };
 }


### PR DESCRIPTION
## Summary

Main is broken. PRs #955 and #958 each independently added a `Net80` property and dictionary entry to `ReferenceAssemblyCatalog`. The merge created duplicates, failing with `CS0102: The type 'ReferenceAssemblyCatalog' already contains a definition for 'Net80'`.

## Changes

Removed the duplicate property (lines 38-41) and duplicate dictionary entry (lines 73-74) from `ReferenceAssemblyCatalog.cs`. Kept the first copies which have the more descriptive doc comment.

## Test Plan

- [x] `dotnet build` passes
- [x] 2786 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Removed .NET 8.0 reference assembly support from test infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->