### PR TITLE
fix: use SymbolEqualityComparer for symbol comparisons

### DIFF
--- a/src/Analyzers/EventSetupHandlerShouldMatchEventTypeAnalyzer.cs
+++ b/src/Analyzers/EventSetupHandlerShouldMatchEventTypeAnalyzer.cs
@@ -161,7 +161,7 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
             // Use semantic model to check if this is actually It.IsAny
             SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess);
             if (symbolInfo.Symbol is IMethodSymbol methodSymbol &&
-                knownSymbols.ItIsAny.Contains(methodSymbol))
+                methodSymbol.IsInstanceOf(knownSymbols.ItIsAny))
             {
                 // NOTE: This code path extracts the generic type argument T from It.IsAny<T>() expressions.
                 // It's difficult to test directly because most type mismatches that would exercise this

--- a/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -138,6 +138,6 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticAn
             return false;
         }
 
-        return knownSymbols.Mock1Raise.Contains(methodSymbol.OriginalDefinition);
+        return methodSymbol.IsInstanceOf(knownSymbols.Mock1Raise);
     }
 }


### PR DESCRIPTION
## Summary
- Replace `ImmutableArray<IMethodSymbol>.Contains()` with `IsInstanceOf()` in 2 analyzers
- `Contains()` uses reference equality; `IsInstanceOf()` uses `SymbolEqualityComparer.Default`
- Fixes false negatives in `RaiseEventArgumentsShouldMatchEventSignatureAnalyzer` and `EventSetupHandlerShouldMatchEventTypeAnalyzer`

Closes #973

## Changes
- `RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs`: Replace `knownSymbols.Mock1Raise.Contains(methodSymbol.OriginalDefinition)` with `methodSymbol.IsInstanceOf(knownSymbols.Mock1Raise)`
- `EventSetupHandlerShouldMatchEventTypeAnalyzer.cs`: Replace `knownSymbols.ItIsAny.Contains(methodSymbol)` with `methodSymbol.IsInstanceOf(knownSymbols.ItIsAny)`

## Test plan
- [x] Full test suite passes (2801 tests)
- [x] Build succeeds with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the detection mechanism in event handler analyzers to more accurately identify specific method invocations using refined symbol-checking logic.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->