### PR TITLE
fix: add release workflow safety guards

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,7 +39,13 @@ jobs:
             exit 1
           }
           foreach ($pkg in $packages) {
-            $nupkgVersion = [System.IO.Path]::GetFileNameWithoutExtension($pkg.Name) -replace '^.*?(\d+\..*)$', '$1'
+            $stem = [System.IO.Path]::GetFileNameWithoutExtension($pkg.Name)
+            if ($stem -match '(\d+\.\d+\.\d+.*)$') {
+              $nupkgVersion = $Matches[1]
+            } else {
+              Write-Error "Could not parse version from package filename '$($pkg.Name)'"
+              exit 1
+            }
             if ($nupkgVersion -ne $tag) {
               Write-Error "Package version '$nupkgVersion' does not match release tag '$tag'"
               exit 1
@@ -58,5 +64,15 @@ jobs:
           }
           foreach ($file in $files) {
             Write-Host "NuGet publish for file: '$file'"
-            dotnet nuget push $file --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+            $maxAttempts = 3
+            for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+              dotnet nuget push $file --api-key $env:NUGET_API_KEY --source https://api.nuget.org/v3/index.json --skip-duplicate
+              if ($LASTEXITCODE -eq 0) { break }
+              if ($attempt -eq $maxAttempts) {
+                Write-Error "NuGet push failed for '$file' after $maxAttempts attempts"
+                exit 1
+              }
+              Write-Warning "Attempt $attempt failed (exit code $LASTEXITCODE). Retrying in $($attempt * 5)s..."
+              Start-Sleep -Seconds ($attempt * 5)
+            }
           }


### PR DESCRIPTION
## Summary
- Restrict release triggers to `published` only (removes duplicate `released`/`edited`/`prereleased`)
- Add `timeout-minutes: 15` to publish job
- Add fail-fast guard when no .nupkg files found
- Add version verification step comparing release tag to package filenames
- Skip version check on `workflow_dispatch` (no tag available)
- Pass `NUGET_API_KEY` via env variable instead of inline expression
- Use exact version comparison instead of substring regex match

Closes #976

## Review iterations
- Initial implementation: 4 safety guards
- Review found 5 issues (duplicate trigger, broken workflow_dispatch, empty package false-pass, loose version match, secret interpolation)
- All 5 fixed and re-reviewed to PASS

## Test plan
- [x] YAML syntax verified
- [x] PowerShell variable scoping correct
- [x] Version extraction handles `Moq.Analyzers.X.Y.Z` naming

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Streamlined release automation and tightened release triggers.
  * Added a 15-minute timeout for the publish job to prevent hung runs.
  * Added package version verification to ensure published packages match release tags.
  * Improved NuGet publishing reliability with authentication, retries, backoff and detailed publish logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->