### PR TITLE
perf: replace recursive iterator with Roslyn Descendants() API

### DIFF
--- a/src/Analyzers/MockRepositoryVerifyAnalyzer.cs
+++ b/src/Analyzers/MockRepositoryVerifyAnalyzer.cs
@@ -118,7 +118,7 @@ public class MockRepositoryVerifyAnalyzer : DiagnosticAnalyzer
     /// </summary>
     private static bool HasCreateCallsForRepository(ILocalSymbol repositorySymbol, IOperation memberOperation, MoqKnownSymbols knownSymbols)
     {
-        foreach (IOperation operation in GetAllChildOperations(memberOperation))
+        foreach (IOperation operation in memberOperation.Descendants())
         {
             if (operation is IInvocationOperation invocation &&
                 IsValidMockRepositoryCreateCall(invocation, knownSymbols) &&
@@ -136,7 +136,7 @@ public class MockRepositoryVerifyAnalyzer : DiagnosticAnalyzer
     /// </summary>
     private static bool HasVerifyCallsForRepository(ILocalSymbol repositorySymbol, IOperation memberOperation, MoqKnownSymbols knownSymbols)
     {
-        foreach (IOperation operation in GetAllChildOperations(memberOperation))
+        foreach (IOperation operation in memberOperation.Descendants())
         {
             if (operation is IInvocationOperation invocation &&
                 IsValidMockRepositoryVerifyCall(invocation, knownSymbols) &&
@@ -147,22 +147,6 @@ public class MockRepositoryVerifyAnalyzer : DiagnosticAnalyzer
         }
 
         return false;
-    }
-
-    /// <summary>
-    /// Gets all child operations recursively.
-    /// </summary>
-    private static IEnumerable<IOperation> GetAllChildOperations(IOperation operation)
-    {
-        foreach (IOperation child in operation.ChildOperations)
-        {
-            yield return child;
-
-            foreach (IOperation grandchild in GetAllChildOperations(child))
-            {
-                yield return grandchild;
-            }
-        }
     }
 
     /// <summary>


### PR DESCRIPTION
## Summary
- Replace hand-rolled recursive `GetAllChildOperations` with Roslyn's built-in `Descendants()` API
- Uses `Descendants()` (not `DescendantsAndSelf()`) to preserve existing behavior of excluding the root operation
- Removes 16 lines of custom traversal code

Closes #984

## Changes
- `MockRepositoryVerifyAnalyzer.cs`: Replace 2 call sites, delete `GetAllChildOperations` method
- Net: 2 insertions, 18 deletions

## Review iterations
- Reviewed for correctness (Descendants vs DescendantsAndSelf), import presence, dead code removal
- PASS: No issues found

## Test plan
- [x] 2801 tests pass (14 MockRepositoryVerify-specific tests)
- [x] Build succeeds with 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified operation tree traversal logic by consolidating traversal patterns and removing redundant helper code, reducing overall complexity while maintaining existing verification behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->