### PR TITLE
feat: add large file detection to pre-commit hook

### DIFF
--- a/.githooks/hooks/Invoke-PreCommit.ps1
+++ b/.githooks/hooks/Invoke-PreCommit.ps1
@@ -9,6 +9,9 @@ if ($LASTEXITCODE -ne 0 -or -not $repoRoot) {
 . "$PSScriptRoot/../lib/LintHelpers.ps1"
 
 try {
+    # Large file detection (file size and line count)
+    Test-LargeFiles
+
     # C# formatting (auto-fix + re-stage)
     $csFiles = Get-StagedFiles -Extensions @('.cs')
     if ($csFiles.Count -gt 0) {

--- a/.githooks/lib/LintHelpers.ps1
+++ b/.githooks/lib/LintHelpers.ps1
@@ -97,3 +97,62 @@ function Set-HookFailed {
     Write-Host "FAIL: $Check" -ForegroundColor Red
     $script:HookExitCode = 1
 }
+
+function Test-LargeFiles {
+    <#
+    .SYNOPSIS
+        Checks staged files against size and line-count thresholds.
+    .DESCRIPTION
+        Prevents accidentally committing oversized files or source files
+        that have grown beyond a maintainable line count. Binary and
+        generated files are excluded from the line-count check.
+    .PARAMETER MaxFileSizeKB
+        Maximum file size in kilobytes. Default 500 KB.
+    .PARAMETER MaxLineCount
+        Maximum number of lines for source files. Default 1000 lines.
+    .PARAMETER SourceExtensions
+        File extensions treated as source code for line-count checks.
+    #>
+    [CmdletBinding()]
+    param(
+        [int]$MaxFileSizeKB = 500,
+        [int]$MaxLineCount = 1000,
+        [string[]]$SourceExtensions = @('.cs', '.ps1', '.sh', '.yaml', '.yml', '.json', '.xml', '.md')
+    )
+
+    $repoRoot = git rev-parse --show-toplevel
+    $stagedFiles = git diff --cached --name-only --diff-filter=d
+    if ($LASTEXITCODE -ne 0 -or -not $stagedFiles) {
+        return
+    }
+
+    $maxBytes = $MaxFileSizeKB * 1024
+    $violations = @()
+
+    foreach ($file in $stagedFiles) {
+        $fullPath = Join-Path $repoRoot $file
+        if (-not (Test-Path $fullPath)) {
+            continue
+        }
+
+        $fileInfo = Get-Item $fullPath
+        if ($fileInfo.Length -gt $maxBytes) {
+            $sizeKB = [math]::Round($fileInfo.Length / 1024, 1)
+            $violations += "  $file ($($sizeKB) KB exceeds $($MaxFileSizeKB) KB limit)"
+        }
+
+        $ext = [System.IO.Path]::GetExtension($file)
+        if ($ext -and $SourceExtensions -contains $ext) {
+            $lineCount = (Get-Content $fullPath | Measure-Object -Line).Lines
+            if ($lineCount -gt $MaxLineCount) {
+                $violations += "  $file ($lineCount lines exceeds $MaxLineCount line limit)"
+            }
+        }
+    }
+
+    if ($violations.Count -gt 0) {
+        Write-Host "Large file(s) detected:" -ForegroundColor Yellow
+        $violations | ForEach-Object { Write-Host $_ -ForegroundColor Yellow }
+        Set-HookFailed -Check "large-file-detection"
+    }
+}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -57,6 +57,7 @@ This project adheres to the [Contributor Covenant Code of Conduct](CODE-OF-CONDU
 
    | Hook | Check | Mode | Tool |
    | ------ | ------- | ------ | ------ |
+   | pre-commit | Large file detection | Fail on error | Built-in (500 KB / 1000 lines) |
    | pre-commit | C# formatting | Auto-fix + re-stage | `dotnet format` |
    | pre-commit | Markdown lint | Auto-fix + re-stage | `markdownlint-cli2` |
    | pre-commit | YAML lint | Lint only | `yamllint` |


### PR DESCRIPTION
## Summary

Adds a `Test-LargeFiles` function to the pre-commit hook infrastructure that prevents committing oversized files.

## What it does

- **File size check**: Flags any staged file exceeding 500 KB (prevents accidental binary/data commits)
- **Line count check**: Flags source files (.cs, .ps1, .sh, .yaml, .yml, .json, .xml, .md) exceeding 1,000 lines (encourages modular code)
- Both thresholds are configurable via function parameters

## Changes

| File | Change |
|------|--------|
| `.githooks/lib/LintHelpers.ps1` | Added `Test-LargeFiles` function with configurable thresholds and PowerShell doc comments |
| `.githooks/hooks/Invoke-PreCommit.ps1` | Calls `Test-LargeFiles` as the first check in the pre-commit flow |
| `CONTRIBUTING.md` | Documents the new hook check in the hooks table |

## Why

Closes the "Large File Detection" agent readiness gap. The check integrates naturally into the existing PowerShell-based git hook system and runs before formatting/linting so oversized files are caught early.

## Testing

- Verified the function loads and runs without errors via `pwsh`
- Confirmed existing files (e.g., CONTRIBUTING.md at 963 lines, 50.9 KB) are below thresholds
- Bypass available via `git commit --no-verify` for exceptional cases

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added large file detection to pre-commit hooks to prevent oversized files (500 KB limit) and source files with excessive line counts (1000-line limit) from being committed.
  * Updated contributing documentation to reflect new pre-commit validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->