### PR TITLE
fix: filter non-lambda-rooted members in Moq1302 to eliminate false positives

### DIFF
--- a/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
@@ -172,13 +172,8 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// expressions that have their own lambda parameters.
     /// </para>
     /// </remarks>
-    private static void AnalyzeMemberOperations(OperationAnalysisContext context, IAnonymousFunctionOperation lambdaOperation, IOperation? operation, MoqKnownSymbols knownSymbols)
+    private static void AnalyzeMemberOperations(OperationAnalysisContext context, IAnonymousFunctionOperation lambdaOperation, IOperation operation, MoqKnownSymbols knownSymbols)
     {
-        if (operation == null)
-        {
-            return;
-        }
-
         // Don't recursively analyze nested Mock.Of calls to avoid false positives
         if (operation is IInvocationOperation invocation && IsValidMockOfInvocation(invocation, knownSymbols))
         {

--- a/src/Common/IOperationExtensions.cs
+++ b/src/Common/IOperationExtensions.cs
@@ -90,18 +90,14 @@ internal static class IOperationExtensions
         IAnonymousFunctionOperation lambdaOperation)
     {
         IParameterSymbol? lambdaParameter = lambdaOperation.Symbol.Parameters.FirstOrDefault();
-        if (lambdaParameter == null)
-        {
-            return false;
-        }
-
-        IOperation current = operation;
-        while (current != null)
+        IOperation? current = operation;
+        while (true)
         {
             switch (current)
             {
                 case IParameterReferenceOperation paramRef:
-                    return SymbolEqualityComparer.Default.Equals(paramRef.Parameter, lambdaParameter);
+                    return lambdaParameter is not null &&
+                        SymbolEqualityComparer.Default.Equals(paramRef.Parameter, lambdaParameter);
 
                 case IMemberReferenceOperation memberRef:
                     if (memberRef.Instance == null)
@@ -125,16 +121,13 @@ internal static class IOperationExtensions
                     current = conversionOp.Operand;
                     break;
 
-                case IParenthesizedOperation parenOp:
-                    current = parenOp.Operand;
-                    break;
-
                 default:
+                    // IParenthesizedOperation is intentionally omitted. The C# compiler
+                    // never emits it in IOperation trees (VB.NET only), and this analyzer
+                    // targets C# exclusively via [DiagnosticAnalyzer(LanguageNames.CSharp)].
                     return false;
             }
         }
-
-        return false;
     }
 
     /// <summary>

--- a/tests/Moq.Analyzers.Test/LinqToMocksExpressionShouldBeValidAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/LinqToMocksExpressionShouldBeValidAnalyzerTests.cs
@@ -771,6 +771,94 @@ public class LinqToMocksExpressionShouldBeValidAnalyzerTests(ITestOutputHelper o
 
     [Theory]
     [MemberData(nameof(MoqReferenceAssemblyGroups))]
+    public async Task ShouldNotFlagNestedMockOfExpression(string referenceAssemblyGroup)
+    {
+        // Nested Mock.Of calls have their own lambda parameters and should not
+        // be recursively analyzed by the outer lambda's analysis.
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            using Moq;
+
+            public interface IInner
+            {
+                string Value { get; }
+            }
+
+            public interface IOuter
+            {
+                IInner Inner { get; }
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    var mock = Mock.Of<IOuter>(o => o.Inner == Mock.Of<IInner>(i => i.Value == "nested"));
+                }
+            }
+            """,
+            referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(MoqReferenceAssemblyGroups))]
+    public async Task ShouldNotFlagMemberAccessThroughExplicitCast(string referenceAssemblyGroup)
+    {
+        // Explicit cast on the lambda parameter inserts an IConversionOperation
+        // in the receiver chain. IsRootedInLambdaParameter must walk through it.
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            using Moq;
+
+            public interface IBase
+            {
+                string Name { get; }
+            }
+
+            public interface IDerived : IBase
+            {
+                string Extra { get; }
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    var mock = Mock.Of<IDerived>(d => ((IBase)d).Name == "test");
+                }
+            }
+            """,
+            referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(MoqReferenceAssemblyGroups))]
+    public async Task ShouldNotFlagVirtualInstanceMethodOnLambdaParameter(string referenceAssemblyGroup)
+    {
+        // Instance method call on the lambda parameter exercises the
+        // IInvocationOperation branch with non-null Instance in IsRootedInLambdaParameter.
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            using Moq;
+
+            public interface IFormatter
+            {
+                string Format(string input);
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    var mock = Mock.Of<IFormatter>(f => f.Format("x") == "formatted");
+                }
+            }
+            """,
+            referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(MoqReferenceAssemblyGroups))]
     public async Task ShouldNotAnalyzeNonMockOfInvocations(string referenceAssemblyGroup)
     {
         await Verifier.VerifyAnalyzerAsync(


### PR DESCRIPTION
## Summary

Fixes #1010. The Moq1302 analyzer (`LinqToMocksExpressionShouldBeValidAnalyzer`) produced false positives when `Mock.Of<T>()` expressions contained static members, constants, or enum values in binary comparisons (e.g., `r => r.Status == StatusCodes.Status200OK`).

**Root cause**: The analyzer walked both sides of binary expressions without checking whether the member access originated from the lambda parameter. Static members (`Instance == null`), constants, and external instance properties were incorrectly flagged as invalid mock members.

**Fix**:
- Add `IsRootedInLambdaParameter` extension method to `IOperationExtensions` that walks the receiver chain to verify a member access terminates in the lambda parameter
- Apply the guard in `AnalyzeMemberOperations` only to leaf member operations (`IMemberReferenceOperation`, `IInvocationOperation`), allowing composite operations (`IBinaryOperation` for chained `&&`/`||`/`==`) to pass through for decomposition
- Thread `MoqKnownSymbols` through the call chain to eliminate per-operation allocation
- Route the `default` branch child operations through the guarded path to prevent bypass
- Achieve 100% block code coverage on all changed lines

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature with breaking side effects)
- [ ] Documentation update

## Changes

| File | Change |
|------|--------|
| `src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs` | Add `IsRootedInLambdaParameter` guard (leaf ops only), thread `MoqKnownSymbols`, route default branch through guarded path, tighten `AnalyzeMemberOperations` parameter to non-nullable |
| `src/Common/IOperationExtensions.cs` | Add `IsRootedInLambdaParameter` extension method with `IMemberReferenceOperation` consolidated receiver chain walk, `while(true)` loop structure |
| `tests/.../LinqToMocksExpressionShouldBeValidAnalyzerTests.cs` | Add 16 boundary case tests, convert existing `[Fact]` to `[Theory]` with dual Moq version coverage |

## Test Plan

- [x] 16 new boundary case tests covering: static const, static property, enum value, reversed operands, chained `&&`, static method call, non-virtual member (true positive), field on lambda parameter (true positive), external instance property, ternary with static member, null-coalescing, conditional with mixed sources, chained property access, nested Mock.Of, explicit cast receiver chain, virtual instance method
- [x] All tests run against both Moq 4.8.2 and 4.18.4 via `[Theory]` with `MoqReferenceAssemblyGroups`
- [x] Existing `ShouldNotAnalyzeNonMockOfInvocations` converted from `[Fact]` to `[Theory]` for dual-version coverage
- [x] 100% block code coverage on all changed lines (verified via coverlet)
- [x] All tests pass locally

## Known Limitations

`IConditionalOperation` (ternary expressions) inside `Mock.Of` lambdas are not fully analyzed. Non-virtual members inside ternary branches are not flagged (false negative). This is a deliberate trade-off to prevent false positives. Documented in the `ShouldNotFlagConditionalWithMixedSources` test.

`IParenthesizedOperation` is intentionally omitted from `IsRootedInLambdaParameter`. The C# compiler never emits it in IOperation trees (VB.NET only), and this analyzer targets C# exclusively via `[DiagnosticAnalyzer(LanguageNames.CSharp)]`.

## Security Impact

None. Changes are limited to compile-time Roslyn analyzer logic with no runtime attack surface.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linq to Mocks expression validation to correctly handle comparisons, chained properties, and conditional expressions involving external members and static values.

* **Tests**
  * Expanded test coverage across multiple Moq versions with scenarios for ternaries, null-coalescing operators, nested comparisons, and complex expression patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->