### PR TITLE
chore: add GitHub issue templates for bugs and feature requests

### DIFF
--- a/.github/ISSUE_TEMPLATE/01_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/01_bug_report.yml
@@ -1,0 +1,97 @@
+name: Bug Report
+description: Report a false positive, false negative, or incorrect analyzer behavior
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for reporting a bug! Please provide as much detail as possible so we can reproduce and fix the issue.
+        See our [contribution guidelines](https://github.com/rjmurillo/moq.analyzers/blob/main/CONTRIBUTING.md) for more information.
+  - type: input
+    id: rule-id
+    attributes:
+      label: Rule ID
+      description: Which analyzer rule is affected (e.g., Moq1000, Moq1100)?
+      placeholder: "Moq1000"
+    validations:
+      required: false
+  - type: dropdown
+    id: bug-type
+    attributes:
+      label: Bug Type
+      description: What kind of issue are you experiencing?
+      options:
+        - False positive (diagnostic reported incorrectly)
+        - False negative (diagnostic not reported when it should be)
+        - Incorrect code fix
+        - Crash or exception
+        - Performance issue
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear and concise description of the problem.
+      placeholder: Describe the bug
+    validations:
+      required: true
+  - type: textarea
+    id: repro-code
+    attributes:
+      label: Code to Reproduce
+      description: |
+        Please provide a minimal code snippet that demonstrates the issue.
+        Include all relevant `using` statements and class definitions.
+      placeholder: |
+        using Moq;
+
+        var mock = new Mock<IMyService>();
+        mock.Setup(x => x.MyMethod());
+      render: csharp
+    validations:
+      required: true
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: Expected Behavior
+      description: What did you expect to happen?
+      placeholder: Expected behavior
+    validations:
+      required: true
+  - type: textarea
+    id: actual-behavior
+    attributes:
+      label: Actual Behavior
+      description: What actually happened? Include any error messages or diagnostic output.
+      placeholder: Actual behavior
+    validations:
+      required: true
+  - type: textarea
+    id: configuration
+    attributes:
+      label: Environment
+      description: |
+        Please provide your environment details:
+        - Moq.Analyzers version:
+        - Moq version (e.g., 4.18.4, 4.8.2):
+        - .NET SDK version:
+        - IDE (e.g., Visual Studio 2022, Rider, VS Code):
+        - OS:
+      placeholder: |
+        - Moq.Analyzers version: 0.4.0
+        - Moq version: 4.18.4
+        - .NET SDK version: 8.0.100
+        - IDE: Visual Studio 2022
+        - OS: Windows 11
+    validations:
+      required: false
+  - type: textarea
+    id: workarounds
+    attributes:
+      label: Known Workarounds
+      description: Any workarounds you have found.
+      placeholder: Known workarounds
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/02_feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/02_feature_request.yml
@@ -1,0 +1,62 @@
+name: Feature Request
+description: Suggest a new analyzer rule, code fix, or improvement
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thank you for suggesting a feature! Please describe the problem you are trying to solve and how your proposed feature would help.
+  - type: dropdown
+    id: feature-type
+    attributes:
+      label: Feature Type
+      description: What type of feature are you requesting?
+      options:
+        - New analyzer rule
+        - New code fix
+        - Improvement to existing rule
+        - Performance improvement
+        - Documentation improvement
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem Statement
+      description: |
+        What problem does this feature solve? Describe the Moq usage pattern that should be detected or improved.
+      placeholder: "I frequently write code like ... and the analyzer doesn't catch ..."
+    validations:
+      required: true
+  - type: textarea
+    id: proposed-solution
+    attributes:
+      label: Proposed Solution
+      description: |
+        Describe how you would like the feature to work. For new rules, include example code that should trigger a diagnostic and the expected message.
+      placeholder: |
+        The analyzer should report a diagnostic when:
+        ```csharp
+        // This code should trigger a warning
+        ```
+
+        The expected diagnostic message: "..."
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives Considered
+      description: Any alternative solutions or features you have considered.
+      placeholder: Alternatives considered
+    validations:
+      required: false
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: Additional Context
+      description: Any other context, screenshots, or references (e.g., links to Moq documentation or related analyzer projects).
+      placeholder: Additional context
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: Moq Documentation
+    url: https://github.com/devlooped/moq/wiki
+    about: For questions about the Moq framework itself, consult the Moq wiki.
+  - name: Discussions
+    url: https://github.com/rjmurillo/moq.analyzers/discussions
+    about: Ask questions and share ideas in GitHub Discussions.


### PR DESCRIPTION
## Summary

Add structured GitHub issue templates to the `.github/ISSUE_TEMPLATE/` directory, modeled after [dotnet/runtime](https://github.com/dotnet/runtime/tree/main/.github/ISSUE_TEMPLATE).

## Changes

### Bug Report Template (`01_bug_report.yml`)
- **Rule ID** input field for specifying the affected analyzer rule
- **Bug Type** dropdown (false positive, false negative, incorrect code fix, crash, performance, other)
- **Code to Reproduce** textarea with C# syntax highlighting
- **Environment** section for Moq.Analyzers version, Moq version, .NET SDK, IDE, and OS
- Required fields: Description, Code to Reproduce, Expected/Actual Behavior

### Feature Request Template (`02_feature_request.yml`)
- **Feature Type** dropdown (new rule, new code fix, improvement, performance, docs, other)
- **Problem Statement** and **Proposed Solution** fields
- Optional fields for alternatives and additional context

### Template Config (`config.yml`)
- Blank issues remain enabled
- Contact links to Moq wiki and GitHub Discussions

## Why
Structured issue templates guide reporters to provide the information needed for effective triage (rule IDs, reproduction code, Moq version). This helps both human maintainers and AI agents create well-structured issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Chores
* Added standardized GitHub issue templates for bug reports and feature requests with structured forms, including required fields and helpful guidance to improve clarity and consistency in issue submissions.
* Configured GitHub issue template settings to enable blank issues and provide helpful contact links to documentation and community discussion resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->