### PR TITLE
fix: correct access modifier inconsistencies on internal types

### DIFF
--- a/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
@@ -20,60 +20,7 @@ public abstract class MockBehaviorDiagnosticAnalyzerBase : DiagnosticAnalyzer
         context.RegisterCompilationStartAction(RegisterCompilationStartAction);
     }
 
-    internal abstract void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols);
-
-    /// <summary>
-    /// Attempts to report a diagnostic for a MockBehavior parameter issue.
-    /// </summary>
-    /// <param name="context">The operation analysis context.</param>
-    /// <param name="method">The method to check for MockBehavior parameter.</param>
-    /// <param name="knownSymbols">The known Moq symbols.</param>
-    /// <param name="rule">The diagnostic rule to report.</param>
-    /// <param name="editType">The type of edit for the code fix.</param>
-    /// <returns>True if a diagnostic was reported; otherwise, false.</returns>
-    internal bool TryReportMockBehaviorDiagnostic(
-        OperationAnalysisContext context,
-        IMethodSymbol method,
-        MoqKnownSymbols knownSymbols,
-        DiagnosticDescriptor rule,
-        DiagnosticEditProperties.EditType editType)
-    {
-        if (!method.TryGetParameterOfType(knownSymbols.MockBehavior!, out IParameterSymbol? parameterMatch, cancellationToken: context.CancellationToken))
-        {
-            return false;
-        }
-
-        ImmutableDictionary<string, string?> properties = new DiagnosticEditProperties
-        {
-            TypeOfEdit = editType,
-            EditPosition = parameterMatch.Ordinal,
-        }.ToImmutableDictionary();
-
-        context.ReportDiagnostic(context.Operation.CreateDiagnostic(rule, properties));
-        return true;
-    }
-
-    /// <summary>
-    /// Attempts to handle missing MockBehavior parameter by checking for overloads that accept it.
-    /// </summary>
-    /// <param name="context">The operation analysis context.</param>
-    /// <param name="mockParameter">The MockBehavior parameter (should be null to trigger overload check).</param>
-    /// <param name="target">The target method to check for overloads.</param>
-    /// <param name="knownSymbols">The known Moq symbols.</param>
-    /// <param name="rule">The diagnostic rule to report.</param>
-    /// <returns>True if a diagnostic was reported; otherwise, false.</returns>
-    internal bool TryHandleMissingMockBehaviorParameter(
-        OperationAnalysisContext context,
-        IParameterSymbol? mockParameter,
-        IMethodSymbol target,
-        MoqKnownSymbols knownSymbols,
-        DiagnosticDescriptor rule)
-    {
-        // If the target method doesn't have a MockBehavior parameter, check if there's an overload that does
-        return mockParameter is null
-            && target.TryGetOverloadWithParameterOfType(knownSymbols.MockBehavior!, out IMethodSymbol? methodMatch, out _, cancellationToken: context.CancellationToken)
-            && TryReportMockBehaviorDiagnostic(context, methodMatch, knownSymbols, rule, DiagnosticEditProperties.EditType.Insert);
-    }
+    private protected abstract void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols);
 
     private void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
     {

--- a/src/Analyzers/SetExplicitMockBehaviorAnalyzer.cs
+++ b/src/Analyzers/SetExplicitMockBehaviorAnalyzer.cs
@@ -28,7 +28,7 @@ public class SetExplicitMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBas
 
     /// <inheritdoc />
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Should be fixed. Ignoring for now to avoid additional churn as part of larger refactor.")]
-    internal override void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols)
+    private protected override void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols)
     {
         // Extract the type name for the diagnostic message
         string typeName = GetMockedTypeName(context, target);

--- a/src/Analyzers/SetStrictMockBehaviorAnalyzer.cs
+++ b/src/Analyzers/SetStrictMockBehaviorAnalyzer.cs
@@ -28,7 +28,7 @@ public class SetStrictMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBase
 
     /// <inheritdoc />
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Should be fixed. Ignoring for now to avoid additional churn as part of larger refactor.")]
-    internal override void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols)
+    private protected override void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols)
     {
         // Extract the mocked type name for the diagnostic message
         string mockedTypeName = GetMockedTypeName(context.Operation, target);

--- a/src/Common/DiagnosticExtensions.cs
+++ b/src/Common/DiagnosticExtensions.cs
@@ -4,18 +4,18 @@ namespace Moq.Analyzers.Common;
 
 internal static class DiagnosticExtensions
 {
-    public static Diagnostic CreateDiagnostic(
+    internal static Diagnostic CreateDiagnostic(
         this SyntaxNode node,
         DiagnosticDescriptor rule,
         params object?[]? messageArgs) => node.CreateDiagnostic(rule, properties: null, messageArgs);
 
-    public static Diagnostic CreateDiagnostic(
+    internal static Diagnostic CreateDiagnostic(
         this SyntaxNode node,
         DiagnosticDescriptor rule,
         ImmutableDictionary<string, string?>? properties,
         params object?[]? messageArgs) => node.CreateDiagnostic(rule, additionalLocations: null, properties, messageArgs);
 
-    public static Diagnostic CreateDiagnostic(
+    internal static Diagnostic CreateDiagnostic(
         this SyntaxNode node,
         DiagnosticDescriptor rule,
         IEnumerable<Location>? additionalLocations,
@@ -28,19 +28,19 @@ internal static class DiagnosticExtensions
                 properties: properties,
                 messageArgs: messageArgs);
 
-    public static Diagnostic CreateDiagnostic(
+    internal static Diagnostic CreateDiagnostic(
         this Location location,
         DiagnosticDescriptor rule,
         params object?[]? messageArgs) => location.CreateDiagnostic(rule, properties: null, messageArgs);
 
-    public static Diagnostic CreateDiagnostic(
+    internal static Diagnostic CreateDiagnostic(
         this Location location,
         DiagnosticDescriptor rule,
         ImmutableDictionary<string, string?>? properties,
         params object?[]? messageArgs) => location.CreateDiagnostic(rule, additionalLocations: null, properties, messageArgs);
 
     [SuppressMessage("ApiDesign", "RS0030:Do not use banned APIs", Justification = "This is the API that wraps the banned API, so it must be allowed to call banned APIs.")]
-    public static Diagnostic CreateDiagnostic(
+    internal static Diagnostic CreateDiagnostic(
         this Location location,
         DiagnosticDescriptor rule,
         IEnumerable<Location>? additionalLocations,
@@ -55,18 +55,18 @@ internal static class DiagnosticExtensions
         return Diagnostic.Create(rule, location, additionalLocations, properties, messageArgs);
     }
 
-    public static Diagnostic CreateDiagnostic(
+    internal static Diagnostic CreateDiagnostic(
         this IOperation operation,
         DiagnosticDescriptor rule,
         params object?[]? messageArgs) => operation.CreateDiagnostic(rule, properties: null, messageArgs);
 
-    public static Diagnostic CreateDiagnostic(
+    internal static Diagnostic CreateDiagnostic(
     this IOperation operation,
     DiagnosticDescriptor rule,
     ImmutableDictionary<string, string?>? properties,
     params object?[]? messageArgs) => operation.CreateDiagnostic(rule, additionalLocations: null, properties, messageArgs);
 
-    public static Diagnostic CreateDiagnostic(
+    internal static Diagnostic CreateDiagnostic(
         this IOperation operation,
         DiagnosticDescriptor rule,
         IEnumerable<Location>? additionalLocations,

--- a/src/Common/MockDetectionHelpers.cs
+++ b/src/Common/MockDetectionHelpers.cs
@@ -16,7 +16,7 @@ internal static class MockDetectionHelpers
     /// <param name="knownSymbols">The known Moq symbols.</param>
     /// <param name="mockedType">When successful, the mocked type; otherwise, null.</param>
     /// <returns>True if this is a valid <c>Mock{T}</c> creation; otherwise, false.</returns>
-    public static bool IsValidMockCreation(IObjectCreationOperation creation, MoqKnownSymbols knownSymbols, [NotNullWhen(true)] out ITypeSymbol? mockedType)
+    internal static bool IsValidMockCreation(IObjectCreationOperation creation, MoqKnownSymbols knownSymbols, [NotNullWhen(true)] out ITypeSymbol? mockedType)
     {
         mockedType = null;
 
@@ -35,7 +35,7 @@ internal static class MockDetectionHelpers
     /// <param name="knownSymbols">The known Moq symbols.</param>
     /// <param name="mockedType">When successful, the mocked type; otherwise, null.</param>
     /// <returns>True if this is a valid <c>Mock.Of{T}()</c> invocation; otherwise, false.</returns>
-    public static bool IsValidMockOfInvocation(IInvocationOperation invocation, MoqKnownSymbols knownSymbols, [NotNullWhen(true)] out ITypeSymbol? mockedType)
+    internal static bool IsValidMockOfInvocation(IInvocationOperation invocation, MoqKnownSymbols knownSymbols, [NotNullWhen(true)] out ITypeSymbol? mockedType)
     {
         mockedType = null;
 
@@ -61,7 +61,7 @@ internal static class MockDetectionHelpers
     /// <param name="knownSymbols">The known Moq symbols.</param>
     /// <param name="mockedType">When successful, the mocked type; otherwise, null.</param>
     /// <returns>True if this is a valid mock invocation; otherwise, false.</returns>
-    public static bool IsValidMockInvocation(IInvocationOperation invocation, MoqKnownSymbols knownSymbols, [NotNullWhen(true)] out ITypeSymbol? mockedType)
+    internal static bool IsValidMockInvocation(IInvocationOperation invocation, MoqKnownSymbols knownSymbols, [NotNullWhen(true)] out ITypeSymbol? mockedType)
     {
         mockedType = null;
 
@@ -90,7 +90,7 @@ internal static class MockDetectionHelpers
     /// <param name="targetMethod">The method symbol to check.</param>
     /// <param name="knownSymbols">The known Moq symbols.</param>
     /// <returns>True if the method is <c>Mock.Of{T}()</c>; otherwise, false.</returns>
-    public static bool IsValidMockOfMethod(IMethodSymbol? targetMethod, MoqKnownSymbols knownSymbols)
+    internal static bool IsValidMockOfMethod(IMethodSymbol? targetMethod, MoqKnownSymbols knownSymbols)
         => targetMethod is not null && targetMethod.IsInstanceOf(knownSymbols.MockOf);
 
     /// <summary>
@@ -99,7 +99,7 @@ internal static class MockDetectionHelpers
     /// <param name="type">The type symbol to extract from.</param>
     /// <param name="mockedType">When successful, the mocked type; otherwise, null.</param>
     /// <returns>True if the mocked type was extracted; otherwise, false.</returns>
-    public static bool TryGetMockedTypeFromGeneric(ITypeSymbol type, [NotNullWhen(true)] out ITypeSymbol? mockedType)
+    internal static bool TryGetMockedTypeFromGeneric(ITypeSymbol type, [NotNullWhen(true)] out ITypeSymbol? mockedType)
     {
         mockedType = null;
 
@@ -118,7 +118,7 @@ internal static class MockDetectionHelpers
     /// <param name="operation">The operation being analyzed.</param>
     /// <param name="fallbackSyntax">The fallback syntax node if type argument cannot be found.</param>
     /// <returns>The location for reporting the diagnostic.</returns>
-    public static Location GetDiagnosticLocation(IOperation operation, SyntaxNode fallbackSyntax)
+    internal static Location GetDiagnosticLocation(IOperation operation, SyntaxNode fallbackSyntax)
     {
         TypeSyntax? typeArgument = operation.Syntax
             .DescendantNodes()

--- a/src/Common/NamedTypeSymbolExtensions.cs
+++ b/src/Common/NamedTypeSymbolExtensions.cs
@@ -3,7 +3,7 @@ namespace Moq.Analyzers.Common;
 /// <summary>
 /// Provides extension methods for <see cref="INamedTypeSymbol"/> to assist with type analysis in analyzers.
 /// </summary>
-public static class NamedTypeSymbolExtensions
+internal static class NamedTypeSymbolExtensions
 {
     /// <summary>
     /// Determines if the given <paramref name="namedType"/> represents the generic <see cref="System.EventHandler{TEventArgs}"/> type.

--- a/src/Common/WellKnown/KnownSymbols.cs
+++ b/src/Common/WellKnown/KnownSymbols.cs
@@ -12,7 +12,7 @@ namespace Moq.Analyzers.Common.WellKnown;
 /// </summary>
 internal class KnownSymbols
 {
-    public KnownSymbols(WellKnownTypeProvider typeProvider)
+    internal KnownSymbols(WellKnownTypeProvider typeProvider)
     {
         if (typeProvider is null)
         {
@@ -22,7 +22,7 @@ internal class KnownSymbols
         TypeProvider = typeProvider;
     }
 
-    public KnownSymbols(Compilation compilation)
+    internal KnownSymbols(Compilation compilation)
         : this(WellKnownTypeProvider.GetOrCreate(compilation))
     {
     }
@@ -30,42 +30,42 @@ internal class KnownSymbols
     /// <summary>
     /// Gets the class <see cref="System.Threading.Tasks.Task"/>.
     /// </summary>
-    public INamedTypeSymbol? Task => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.Task");
+    internal INamedTypeSymbol? Task => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.Task");
 
     /// <summary>
     /// Gets the class <see cref="System.Threading.Tasks.Task{T}"/>.
     /// </summary>
-    public INamedTypeSymbol? Task1 => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.Task`1");
+    internal INamedTypeSymbol? Task1 => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.Task`1");
 
     /// <summary>
     /// Gets the class <see cref="System.Threading.Tasks.ValueTask"/>.
     /// </summary>
-    public INamedTypeSymbol? ValueTask => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.ValueTask");
+    internal INamedTypeSymbol? ValueTask => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.ValueTask");
 
     /// <summary>
     /// Gets the class <see cref="System.EventHandler{TEventArgs}"/>.
     /// </summary>
-    public INamedTypeSymbol? EventHandler1 => TypeProvider.GetOrCreateTypeByMetadataName("System.EventHandler`1");
+    internal INamedTypeSymbol? EventHandler1 => TypeProvider.GetOrCreateTypeByMetadataName("System.EventHandler`1");
 
     /// <summary>
     /// Gets the class <see cref="System.Threading.Tasks.ValueTask{T}"/>.
     /// </summary>
-    public INamedTypeSymbol? ValueTask1 => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
+    internal INamedTypeSymbol? ValueTask1 => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.ValueTask`1");
 
     /// <summary>
     /// Gets the class <see cref="System.Action"/>.
     /// </summary>
-    public INamedTypeSymbol? Action0 => TypeProvider.GetOrCreateTypeByMetadataName("System.Action");
+    internal INamedTypeSymbol? Action0 => TypeProvider.GetOrCreateTypeByMetadataName("System.Action");
 
     /// <summary>
     /// Gets the class <see cref="System.Action{T}"/>.
     /// </summary>
-    public INamedTypeSymbol? Action1 => TypeProvider.GetOrCreateTypeByMetadataName("System.Action`1");
+    internal INamedTypeSymbol? Action1 => TypeProvider.GetOrCreateTypeByMetadataName("System.Action`1");
 
     /// <summary>
     /// Gets the class <see cref="System.Runtime.CompilerServices.InternalsVisibleToAttribute"/>.
     /// </summary>
-    public INamedTypeSymbol? InternalsVisibleToAttribute => TypeProvider.GetOrCreateTypeByMetadataName("System.Runtime.CompilerServices.InternalsVisibleToAttribute");
+    internal INamedTypeSymbol? InternalsVisibleToAttribute => TypeProvider.GetOrCreateTypeByMetadataName("System.Runtime.CompilerServices.InternalsVisibleToAttribute");
 
     protected WellKnownTypeProvider TypeProvider { get; }
 }

--- a/src/Common/WellKnown/MoqKnownSymbolExtensions.cs
+++ b/src/Common/WellKnown/MoqKnownSymbolExtensions.cs
@@ -2,7 +2,7 @@
 
 internal static class MoqKnownSymbolExtensions
 {
-    public static bool IsMockReferenced(this MoqKnownSymbols mqs)
+    internal static bool IsMockReferenced(this MoqKnownSymbols mqs)
     {
         return mqs.Mock is not null || mqs.Mock1 is not null || mqs.MockRepository is not null;
     }


### PR DESCRIPTION
## Summary
- Change `public` members on `internal` types to `internal` across `KnownSymbols`, `MoqKnownSymbolExtensions`, `DiagnosticExtensions`, `MockDetectionHelpers`, and `NamedTypeSymbolExtensions`
- Change `MockBehaviorDiagnosticAnalyzerBase.AnalyzeCore` from `internal abstract` to `private protected abstract`, and update both subclass overrides to match
- Remove dead code (`TryReportMockBehaviorDiagnostic`, `TryHandleMissingMockBehaviorParameter`) from `MockBehaviorDiagnosticAnalyzerBase` that was never called by any subclass

## Test plan
- [x] Solution builds with zero warnings and zero errors
- [x] All 2901 existing tests pass
- [x] No behavioral changes; access modifiers only restrict visibility, never widen it
- [x] Verified no `InternalsVisibleTo` dependencies exist (Common is a shared-items project compiled directly into consuming assemblies)
- [x] Confirmed `AnalyzeCore` overrides in `SetExplicitMockBehaviorAnalyzer` and `SetStrictMockBehaviorAnalyzer` compile with `private protected override`

Closes #987

🤖 Generated with [Claude Code](https://claude.com/claude-code)