### PR TITLE
docs: add missing Moq1003/Moq1004 rules, fix stale SDK version, correct Moq1400 CodeFix flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,8 @@ something is wrong with your Moq configuration.
 | [Moq1000](docs/rules/Moq1000.md) | Usage         | Sealed classes cannot be mocked                                                         |
 | [Moq1001](docs/rules/Moq1001.md) | Usage         | Mocked interfaces cannot have constructor parameters                                    |
 | [Moq1002](docs/rules/Moq1002.md) | Usage         | Parameters provided into mock do not match any existing constructors                    |
+| [Moq1003](docs/rules/Moq1003.md) | Usage         | Internal type requires InternalsVisibleTo for DynamicProxy                              |
+| [Moq1004](docs/rules/Moq1004.md) | Usage         | ILogger should not be mocked                                                            |
 | [Moq1100](docs/rules/Moq1100.md) | Correctness   | Callback signature must match the signature of the mocked method                        |
 | [Moq1101](docs/rules/Moq1101.md) | Usage         | SetupGet/SetupSet/SetupProperty should be used for properties, not for methods          |
 | [Moq1200](docs/rules/Moq1200.md) | Correctness   | Setup should be used only for overridable members                                       |
@@ -49,7 +51,7 @@ dotnet add package Moq.Analyzers
 ```
 
 > NOTE: You must use a [supported version](https://dotnet.microsoft.com/en-us/platform/support/policy/dotnet-core) of
-> the .NET SDK (i.e. 8.0 or later).
+> the .NET SDK.
 
 ### Configuring rules
 

--- a/docs/rules/Moq1400.md
+++ b/docs/rules/Moq1400.md
@@ -4,7 +4,7 @@
 | -------- | ------- |
 | Enabled  | True    |
 | Severity | Warning |
-| CodeFix  | False   |
+| CodeFix  | True    |
 
 ---
 


### PR DESCRIPTION
## Summary
- Add Moq1003 and Moq1004 rows to the root `README.md` rules table (they were skipped between Moq1002 and Moq1100)
- Remove stale `.NET SDK (i.e. 8.0 or later)` parenthetical from `README.md` since `global.json` pins SDK 10.0.103
- Correct `CodeFix: False` to `CodeFix: True` in `docs/rules/Moq1400.md` to reflect the existing `SetExplicitMockBehaviorFixer.cs`

## Test plan
- [ ] Verify `README.md` rules table lists Moq1003 and Moq1004 between Moq1002 and Moq1100
- [ ] Verify `README.md` SDK note no longer references a specific version number
- [ ] Verify `docs/rules/Moq1400.md` metadata shows `CodeFix: True`
- [ ] Verify solution builds with zero warnings and zero errors

Closes #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added documentation for two new analyzer rules: Moq1003 (Internal type requires InternalsVisibleTo for DynamicProxy) and Moq1004 (ILogger should not be mocked).
  * Simplified the Getting Started guide.
  * Updated Moq1400 rule documentation to show a code fix is now available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->