### PR TITLE
fix: pin NBGV schema URL to v3.9.50 tag

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
+  "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/v3.9.50/src/NerdBank.GitVersioning/version.schema.json",
   "version": "0.5.0-alpha.{height}",
   "nugetPackageVersion": {
     "semVer": 2


### PR DESCRIPTION
## Summary
- Pin the `$schema` URL in `version.json` from the mutable `main` branch reference to the immutable `v3.9.50` tag
- This matches the NBGV version already declared in `Directory.Packages.props`, preventing silent schema drift

## Test plan
- [x] `dotnet build Moq.Analyzers.sln` succeeds with 0 warnings, 0 errors
- [x] `dotnet test Moq.Analyzers.sln` passes all 2901 tests
- [x] Verify NBGV version resolution still works correctly in CI

Closes #993

🤖 Generated with [Claude Code](https://claude.com/claude-code)