### PR TITLE
perf: hoist MoqKnownSymbols to per-compilation in 9 analyzers

### DIFF
--- a/src/Analyzers/EventSetupHandlerShouldMatchEventTypeAnalyzer.cs
+++ b/src/Analyzers/EventSetupHandlerShouldMatchEventTypeAnalyzer.cs
@@ -28,12 +28,25 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
     }
 
-    private static void Analyze(SyntaxNodeAnalysisContext context)
+    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
     {
-        MoqKnownSymbols knownSymbols = new(context.SemanticModel.Compilation);
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
+
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
+        context.RegisterSyntaxNodeAction(
+            syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
+            SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols)
+    {
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
         // Check if this is a SetupAdd or SetupRemove method call on a Mock<T>

--- a/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
@@ -30,23 +30,29 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
     {
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
         context.EnableConcurrentExecution();
-        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
     }
 
-    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
+    {
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
+
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
+        context.RegisterOperationAction(
+            operationContext => AnalyzeInvocation(operationContext, knownSymbols),
+            OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
         if (context.Operation is not IInvocationOperation invocationOperation)
         {
             return;
         }
-
-        SemanticModel? semanticModel = invocationOperation.SemanticModel;
-        if (semanticModel == null)
-        {
-            return;
-        }
-
-        MoqKnownSymbols knownSymbols = new(semanticModel.Compilation);
 
         // Check if this is a Mock.Of invocation
         if (!IsValidMockOfInvocation(invocationOperation, knownSymbols))

--- a/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -45,13 +45,26 @@ public class RaisesEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticA
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
     }
 
-    private static void Analyze(SyntaxNodeAnalysisContext context)
+    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
+    {
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
+
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
+        context.RegisterSyntaxNodeAction(
+            syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
+            SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
-        MoqKnownSymbols knownSymbols = new(context.SemanticModel.Compilation);
 
         // Check if this is a Raises method call using symbol-based detection
         if (!context.SemanticModel.IsRaisesInvocation(invocation, knownSymbols) && !invocation.IsRaisesMethodCall(context.SemanticModel, knownSymbols))

--- a/src/Analyzers/RedundantTimesSpecificationAnalyzer.cs
+++ b/src/Analyzers/RedundantTimesSpecificationAnalyzer.cs
@@ -31,23 +31,30 @@ public class RedundantTimesSpecificationAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
     }
 
-    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
+    {
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
+
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
+        context.RegisterOperationAction(
+            operationContext => AnalyzeInvocation(operationContext, knownSymbols),
+            OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
         if (context.Operation is not IInvocationOperation invocationOperation)
         {
             return;
         }
 
-        SemanticModel? semanticModel = invocationOperation.SemanticModel;
-        if (semanticModel == null)
-        {
-            return;
-        }
-
-        MoqKnownSymbols knownSymbols = new(semanticModel.Compilation);
         IMethodSymbol targetMethod = invocationOperation.TargetMethod;
 
         if (!ShouldAnalyzeMethod(targetMethod, knownSymbols))

--- a/src/Analyzers/ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer.cs
+++ b/src/Analyzers/ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer.cs
@@ -28,13 +28,25 @@ public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer : DiagnosticAnalyze
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
     }
 
-    private static void Analyze(SyntaxNodeAnalysisContext context)
+    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
     {
-        MoqKnownSymbols knownSymbols = new(context.SemanticModel.Compilation);
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
 
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
+        context.RegisterSyntaxNodeAction(
+            syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
+            SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols)
+    {
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
         // Check if this is a Returns method call with async lambda

--- a/src/Analyzers/ReturnsDelegateShouldReturnTaskAnalyzer.cs
+++ b/src/Analyzers/ReturnsDelegateShouldReturnTaskAnalyzer.cs
@@ -30,13 +30,25 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
     }
 
-    private static void Analyze(SyntaxNodeAnalysisContext context)
+    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
     {
-        MoqKnownSymbols knownSymbols = new(context.SemanticModel.Compilation);
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
 
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
+        context.RegisterSyntaxNodeAction(
+            syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
+            SyntaxKind.InvocationExpression);
+    }
+
+    private static void Analyze(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols)
+    {
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
         if (!IsReturnsMethodCallWithSyncDelegate(invocation, context.SemanticModel, knownSymbols, out MemberAccessExpressionSyntax? memberAccess, out InvocationExpressionSyntax? setupInvocation))

--- a/src/Analyzers/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -31,25 +31,31 @@ public class SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer : Diagno
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
+    }
+
+    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
+    {
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
+
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
+        context.RegisterOperationAction(
+            operationContext => AnalyzeInvocation(operationContext, knownSymbols),
+            OperationKind.Invocation);
     }
 
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Should be fixed. Ignoring for now to avoid additional churn as part of larger refactor.")]
-    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void AnalyzeInvocation(OperationAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
         if (context.Operation is not IInvocationOperation invocationOperation)
         {
             return;
         }
 
-        SemanticModel? semanticModel = invocationOperation.SemanticModel;
-
-        if (semanticModel == null)
-        {
-            return;
-        }
-
-        MoqKnownSymbols knownSymbols = new(semanticModel.Compilation);
         IMethodSymbol targetMethod = invocationOperation.TargetMethod;
 
         // 1. Check if the invoked method is a Moq SetupSequence method

--- a/src/Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/src/Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -28,11 +28,18 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterSyntaxNodeAction(Analyze, SyntaxKind.InvocationExpression);
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
     }
 
-    private static void Analyze(SyntaxNodeAnalysisContext context)
+    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
     {
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
+
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
         // Check Moq version and skip analysis if the version is 4.16.0 or later
         AssemblyIdentity? moqAssembly = context.Compilation.ReferencedAssemblyNames.FirstOrDefault(a => a.Name.Equals("Moq", StringComparison.OrdinalIgnoreCase));
 
@@ -42,8 +49,13 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        MoqKnownSymbols knownSymbols = new(context.SemanticModel.Compilation);
+        context.RegisterSyntaxNodeAction(
+            syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
+            SyntaxKind.InvocationExpression);
+    }
 
+    private static void Analyze(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols)
+    {
         InvocationExpressionSyntax setupInvocation = (InvocationExpressionSyntax)context.Node;
 
         if (setupInvocation.Expression is not MemberAccessExpressionSyntax memberAccessExpression)

--- a/src/Analyzers/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -30,23 +30,30 @@ public class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAna
     {
         context.EnableConcurrentExecution();
         context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterOperationAction(AnalyzeInvocation, OperationKind.Invocation);
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
     }
 
-    private static void AnalyzeInvocation(OperationAnalysisContext context)
+    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
+    {
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
+
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
+        context.RegisterOperationAction(
+            operationContext => AnalyzeInvocation(operationContext, knownSymbols),
+            OperationKind.Invocation);
+    }
+
+    private static void AnalyzeInvocation(OperationAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
         if (context.Operation is not IInvocationOperation invocationOperation)
         {
             return;
         }
 
-        SemanticModel? semanticModel = invocationOperation.SemanticModel;
-        if (semanticModel == null)
-        {
-            return;
-        }
-
-        MoqKnownSymbols knownSymbols = new(semanticModel.Compilation);
         IMethodSymbol targetMethod = invocationOperation.TargetMethod;
 
         if (!ShouldAnalyzeMethod(targetMethod, knownSymbols))


### PR DESCRIPTION
## Summary
- Moved `MoqKnownSymbols` construction from per-operation/per-node callbacks into `RegisterCompilationStartAction` for 9 analyzers that were creating a new instance on every invocation
- Each analyzer now creates `MoqKnownSymbols` once per compilation, guards with `IsMockReferenced()`, and captures the instance via closure
- For `SetupShouldNotIncludeAsyncResultAnalyzer`, also hoisted the Moq version check to per-compilation scope

### Analyzers modified
1. `RedundantTimesSpecificationAnalyzer` (RegisterOperationAction)
2. `VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer` (RegisterOperationAction)
3. `SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer` (RegisterOperationAction)
4. `LinqToMocksExpressionShouldBeValidAnalyzer` (RegisterOperationAction)
5. `SetupShouldNotIncludeAsyncResultAnalyzer` (RegisterSyntaxNodeAction)
6. `ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer` (RegisterSyntaxNodeAction)
7. `ReturnsDelegateShouldReturnTaskAnalyzer` (RegisterSyntaxNodeAction)
8. `EventSetupHandlerShouldMatchEventTypeAnalyzer` (RegisterSyntaxNodeAction)
9. `RaisesEventArgumentsShouldMatchEventSignatureAnalyzer` (RegisterSyntaxNodeAction)

## Test plan
- [x] `dotnet build Moq.Analyzers.sln` passes with 0 warnings, 0 errors
- [x] `dotnet test Moq.Analyzers.sln` passes all 2901 tests with 0 failures
- [x] Each modified analyzer follows the same pattern as existing correct analyzers (e.g., `NoSealedClassMocksAnalyzer`, `MockBehaviorDiagnosticAnalyzerBase`)
- [x] No behavioral changes: only the lifetime of `MoqKnownSymbols` instances changed from per-operation to per-compilation

Closes #972

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Refactored nine Moq analyzers to defer analysis registration until compilation start with conditional processing when Moq is referenced. No changes to diagnostic output or behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->