### PR TITLE
fix(test): update Verify snapshots for THIRD-PARTY-NOTICES.TXT

### DIFF
--- a/tests/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
+++ b/tests/Moq.Analyzers.Test/PackageTests.Baseline#contents.verified.txt
@@ -1,6 +1,7 @@
 ﻿/
 |-- Moq.Analyzers.nuspec
 |-- README.md
+|-- THIRD-PARTY-NOTICES.TXT
 |-- analyzers
 |   |-- dotnet
 |   |   |-- cs

--- a/tests/Moq.Analyzers.Test/PackageTests.Baseline_main#contents.verified.txt
+++ b/tests/Moq.Analyzers.Test/PackageTests.Baseline_main#contents.verified.txt
@@ -1,6 +1,7 @@
 ﻿/
 |-- Moq.Analyzers.nuspec
 |-- README.md
+|-- THIRD-PARTY-NOTICES.TXT
 |-- analyzers
 |   |-- dotnet
 |   |   |-- cs

--- a/tests/Moq.Analyzers.Test/PackageTests.Baseline_symbols#contents.verified.txt
+++ b/tests/Moq.Analyzers.Test/PackageTests.Baseline_symbols#contents.verified.txt
@@ -1,6 +1,7 @@
 ﻿/
 |-- Moq.Analyzers.nuspec
 |-- README.md
+|-- THIRD-PARTY-NOTICES.TXT
 |-- analyzers
 |   |-- dotnet
 |   |   |-- cs


### PR DESCRIPTION
## Summary
- Update Verify snapshot baselines to include `THIRD-PARTY-NOTICES.TXT` added by PR #1053
- This file was added to the NuGet package via csproj but the test baselines were not updated
- All open PRs are currently blocked by this regression

## Root Cause
PR #1053 added `THIRD-PARTY-NOTICES.TXT` to the package contents. The test workflow only runs on PRs (not push to main), so the snapshot mismatch was not caught before merge.

## Test plan
- [ ] PackageTests.Baseline passes locally
- [ ] CI test matrix passes (ubuntu-arm, windows)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added third-party notices documentation to the package contents for improved transparency regarding included third-party dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->