### PR TITLE
fix(ci): document DevSkim Docker container x64 runner requirement

### DIFF
--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -16,7 +16,9 @@ on:
 jobs:
   lint:
     name: DevSkim
-    # DevSkim requires x64 runner
+    # DevSkim-Action is a Docker container action, which GitHub Actions
+    # only supports on Linux x64 runners; do not use ARM64 runners.
+    # https://docs.github.com/en/actions/creating-actions/about-custom-actions#docker-container-actions
     runs-on: ubuntu-latest
     permissions:
       actions: read


### PR DESCRIPTION
## Summary
- Update inline comment on `devskim.yml` to document why ARM64 runners cannot be used
- DevSkim-Action is a Docker container action (`using: 'docker'`), which GitHub Actions only supports on Linux x64 runners
- Links to [GitHub docs](https://docs.github.com/en/actions/creating-actions/about-custom-actions#docker-container-actions) as upstream reference
- Addresses unresolved review feedback from PR #1041

## Test plan
- [ ] CI passes (no functional change, comment-only update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)