### PR TITLE
fix: align pre-push hook build flags with CI

### DIFF
--- a/.githooks/hooks/Invoke-PrePush.ps1
+++ b/.githooks/hooks/Invoke-PrePush.ps1
@@ -28,7 +28,22 @@ try {
 
     $slnPath = Join-Path $repoRoot "Moq.Analyzers.sln"
 
-    $output = dotnet build $slnPath /p:PedanticMode=true --verbosity quiet 2>&1
+    # Mirror CI build flags from .github/actions/setup-restore-build/action.yml
+    # to prevent issues from escaping the local environment.
+    $buildArgs = @(
+        $slnPath
+        "--configuration", "Release"
+        "--verbosity", "quiet"
+        "/p:PedanticMode=true"
+        "/p:Deterministic=true"
+        "/p:ContinuousIntegrationBuild=true"
+        "/p:UseSharedCompilation=false"
+        "/p:BuildInParallel=false"
+        "/nodeReuse:false"
+    )
+
+    Write-Host "Building (Release, CI-parity flags)..." -ForegroundColor Cyan
+    $output = dotnet build @buildArgs 2>&1
     $buildExitCode = $LASTEXITCODE
     $output = $output | Out-String
 
@@ -39,7 +54,7 @@ try {
     }
     else {
         $runSettings = Join-Path $repoRoot "build/targets/tests/test.runsettings"
-        $output = dotnet test $slnPath --no-build --settings $runSettings --verbosity quiet 2>&1
+        $output = dotnet test $slnPath --no-build --configuration Release --settings $runSettings --verbosity quiet 2>&1
         $testExitCode = $LASTEXITCODE
         $output = $output | Out-String
         if ($testExitCode -ne 0) {


### PR DESCRIPTION
## Summary

- Aligns pre-push hook build flags with CI (`setup-restore-build/action.yml`) to prevent issues from escaping the local environment
- Adds `--configuration Release`, `/p:Deterministic=true`, `/p:ContinuousIntegrationBuild=true`, `/p:UseSharedCompilation=false`, `/p:BuildInParallel=false`, `/nodeReuse:false`
- Passes `--configuration Release` to `dotnet test` so tests run against Release output

## Motivation

The pre-push hook was building in Debug while CI builds in Release with stricter MSBuild properties. This allowed build failures like [this one](https://github.com/rjmurillo/moq.analyzers/actions/runs/22832705128/job/66223915166?pr=1042#step:3:87) to escape local validation and waste CI runs and reviewer time.

## Test plan

- [ ] Verify pre-push hook runs `dotnet build` with Release configuration
- [ ] Verify pre-push hook runs `dotnet test` with `--configuration Release`
- [ ] Confirm a build that passes locally also passes in CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Improved build process configuration and reliability for development workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->