### PR TITLE
fix: pass ContinuousIntegrationBuild to dotnet restore in CI

### DIFF
--- a/.github/actions/setup-restore-build/action.yml
+++ b/.github/actions/setup-restore-build/action.yml
@@ -25,7 +25,7 @@ runs:
 
     - name: NuGet Restore
       shell: pwsh
-      run: dotnet restore
+      run: dotnet restore /p:ContinuousIntegrationBuild=true
 
     - name: Build
       shell: pwsh

--- a/src/tools/PerfDiff/PerfDiff.csproj
+++ b/src/tools/PerfDiff/PerfDiff.csproj
@@ -5,7 +5,6 @@
     <TargetFramework>net8.0</TargetFramework>
     <NonShipping>true</NonShipping>
     <ExcludeFromSourceBuild>true</ExcludeFromSourceBuild>
-
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- Pass `/p:ContinuousIntegrationBuild=true` to `dotnet restore` in the shared CI setup action
- Previously only `dotnet build` received this property, so NuGet warnings during restore were never promoted to errors

## Root Cause
`CodeAnalysis.targets` already configures `TreatWarningsAsErrors` via `PedanticMode`, which derives from `ContinuousIntegrationBuild`. But `setup-restore-build/action.yml` only passed that property to `dotnet build --no-restore`, not to `dotnet restore`. NuGet warnings like NU1608 (dependency version outside constraint) are emitted during restore, not build. They were invisible to the error promotion.

This is why PR #968 (Perfolizer 0.6.1 -> 0.7.1) passed CI despite BenchmarkDotNet requiring exactly `[0.6.1]`.

## What This Fixes
All NuGet warnings (NU*) are now promoted to errors in CI, not just compiler warnings. This catches:
- NU1608: package version outside dependency constraint
- NU1603: dependency version lower than constraint
- NU1701: package restored with fallback framework
- Any other NuGet warning that indicates a potential runtime issue

## Test plan
- [x] Verified `dotnet restore /p:ContinuousIntegrationBuild=true` passes with current compatible versions
- [ ] CI build/test should pass (no NuGet warnings on main)
- [ ] Verify that updating Perfolizer to 0.7.1 would now fail at restore time, not silently pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized build configuration for enhanced continuous integration reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->