### PR TITLE
Fix analyzer crash on C# 13 params collections

### DIFF
--- a/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -414,7 +414,30 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
             return arrayType.ElementType;
         }
 
-        if (paramsType is INamedTypeSymbol { IsGenericType: true } namedType && namedType.TypeArguments.Length == 1)
+        if (paramsType is not INamedTypeSymbol namedType)
+        {
+            return null;
+        }
+
+        // The element type of a non-span params collection is the T of the IEnumerable<T> it
+        // is or implements — not its own type argument, which a custom collection type
+        // (e.g. MyCollection<TTag> : IEnumerable<string>) may use for something unrelated.
+        if (namedType.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)
+        {
+            return namedType.TypeArguments[0];
+        }
+
+        foreach (INamedTypeSymbol implementedInterface in namedType.AllInterfaces)
+        {
+            if (implementedInterface.OriginalDefinition.SpecialType == SpecialType.System_Collections_Generic_IEnumerable_T)
+            {
+                return implementedInterface.TypeArguments[0];
+            }
+        }
+
+        // Span<T> and ReadOnlySpan<T> are valid params collections but do not implement IEnumerable<T>.
+        if (namedType is { Name: "Span" or "ReadOnlySpan", TypeArguments.Length: 1 }
+            && namedType.ContainingNamespace is { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true })
         {
             return namedType.TypeArguments[0];
         }

--- a/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -249,6 +249,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
     /// <param name="constructors">The constructors.</param>
     /// <param name="arguments">The arguments.</param>
     /// <param name="context">The context.</param>
+    /// <param name="knownSymbols">The known Moq and BCL symbols for the current compilation.</param>
     /// <returns>
     /// <see langword="true" /> if a suitable constructor was found; otherwise <see langword="false" />.
     /// If the construction method is a parenthesized lambda expression, <see langword="null" /> is returned.
@@ -257,11 +258,12 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
     private static bool? AnyConstructorsFound(
         IMethodSymbol[] constructors,
         FilteredArgumentList arguments,
-        SyntaxNodeAnalysisContext context)
+        SyntaxNodeAnalysisContext context,
+        MoqKnownSymbols knownSymbols)
     {
         for (int constructorIndex = 0; constructorIndex < constructors.Length; constructorIndex++)
         {
-            if (IsConstructorMatch(constructors[constructorIndex], arguments, context))
+            if (IsConstructorMatch(constructors[constructorIndex], arguments, context, knownSymbols))
             {
                 return true;
             }
@@ -284,12 +286,14 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
     /// <param name="constructor">The constructor to check.</param>
     /// <param name="arguments">The filtered arguments provided at the call site.</param>
     /// <param name="context">The syntax node analysis context.</param>
+    /// <param name="knownSymbols">The known Moq and BCL symbols for the current compilation.</param>
     /// <returns><see langword="true"/> if the constructor matches the arguments; otherwise, <see langword="false"/>.</returns>
     /// <remarks>Handles <see langword="params"/> and optional parameters.</remarks>
     private static bool IsConstructorMatch(
         IMethodSymbol constructor,
         FilteredArgumentList arguments,
-        SyntaxNodeAnalysisContext context)
+        SyntaxNodeAnalysisContext context,
+        MoqKnownSymbols knownSymbols)
     {
         bool hasParams = constructor.Parameters.Length > 0 && constructor.Parameters[^1].IsParams;
         int fixedParametersCount = hasParams ? constructor.Parameters.Length - 1 : constructor.Parameters.Length;
@@ -313,7 +317,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        if (hasParams && !AllParamsArgumentsMatch(constructor, arguments, fixedParametersCount, context))
+        if (hasParams && !AllParamsArgumentsMatch(constructor, arguments, fixedParametersCount, context, knownSymbols))
         {
             return false;
         }
@@ -377,10 +381,11 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         IMethodSymbol constructor,
         FilteredArgumentList arguments,
         int fixedParametersCount,
-        SyntaxNodeAnalysisContext context)
+        SyntaxNodeAnalysisContext context,
+        MoqKnownSymbols knownSymbols)
     {
         IParameterSymbol paramsParameter = constructor.Parameters[^1];
-        ITypeSymbol? paramsElementType = GetParamsElementType(paramsParameter.Type);
+        ITypeSymbol? paramsElementType = GetParamsElementType(paramsParameter.Type, knownSymbols);
 
         if (paramsElementType is null)
         {
@@ -407,7 +412,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
     /// (<c>params T[]</c>) or a C# 13+ params collection (e.g. <c>params List&lt;T&gt;</c>,
     /// <c>params ReadOnlySpan&lt;T&gt;</c>) which is not an <see cref="IArrayTypeSymbol"/>.
     /// </summary>
-    private static ITypeSymbol? GetParamsElementType(ITypeSymbol paramsType)
+    private static ITypeSymbol? GetParamsElementType(ITypeSymbol paramsType, MoqKnownSymbols knownSymbols)
     {
         if (paramsType is IArrayTypeSymbol arrayType)
         {
@@ -436,8 +441,9 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         }
 
         // Span<T> and ReadOnlySpan<T> are valid params collections but do not implement IEnumerable<T>.
-        if (namedType is { Name: "Span" or "ReadOnlySpan", TypeArguments.Length: 1 }
-            && namedType.ContainingNamespace is { Name: nameof(System), ContainingNamespace.IsGlobalNamespace: true })
+        if (namedType.TypeArguments.Length == 1
+            && (SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, knownSymbols.Span1)
+                || SymbolEqualityComparer.Default.Equals(namedType.OriginalDefinition, knownSymbols.ReadOnlySpan1)))
         {
             return namedType.TypeArguments[0];
         }
@@ -498,7 +504,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 
             case TypeKind.Class:
                 // Now we're interested in the ctors for the mocked class
-                VerifyClassMockAttempt(context, mockedClass, argumentList, arguments);
+                VerifyClassMockAttempt(context, knownSymbols, mockedClass, argumentList, arguments);
 
                 break;
         }
@@ -506,6 +512,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 
     private static void VerifyClassMockAttempt(
         SyntaxNodeAnalysisContext context,
+        MoqKnownSymbols knownSymbols,
         ITypeSymbol mockedClass,
         ArgumentListSyntax? argumentList,
         FilteredArgumentList arguments)
@@ -529,7 +536,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 
         // We have constructors, now we need to check if the arguments match any of them
         // If the value is null it means we want to ignore and not create a diagnostic
-        bool? matchingCtorFound = AnyConstructorsFound(constructors, arguments, context);
+        bool? matchingCtorFound = AnyConstructorsFound(constructors, arguments, context, knownSymbols);
         if (matchingCtorFound.HasValue && !matchingCtorFound.Value)
         {
             Diagnostic diagnostic = constructorIsEmpty.Location.CreateDiagnostic(ClassMustHaveMatchingConstructor, mockedClass.ToDisplayString(), argumentsString);

--- a/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -380,7 +380,14 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         SyntaxNodeAnalysisContext context)
     {
         IParameterSymbol paramsParameter = constructor.Parameters[^1];
-        ITypeSymbol paramsElementType = ((IArrayTypeSymbol)paramsParameter.Type).ElementType;
+        ITypeSymbol? paramsElementType = GetParamsElementType(paramsParameter.Type);
+
+        if (paramsElementType is null)
+        {
+            // The element type could not be determined for this params collection shape,
+            // so avoid reporting a false positive.
+            return true;
+        }
 
         for (int parameterIndex = fixedParametersCount; parameterIndex < arguments.Count; parameterIndex++)
         {
@@ -393,6 +400,26 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         }
 
         return true;
+    }
+
+    /// <summary>
+    /// Gets the element type of a params parameter's type, whether it is a classic array
+    /// (<c>params T[]</c>) or a C# 13+ params collection (e.g. <c>params List&lt;T&gt;</c>,
+    /// <c>params ReadOnlySpan&lt;T&gt;</c>) which is not an <see cref="IArrayTypeSymbol"/>.
+    /// </summary>
+    private static ITypeSymbol? GetParamsElementType(ITypeSymbol paramsType)
+    {
+        if (paramsType is IArrayTypeSymbol arrayType)
+        {
+            return arrayType.ElementType;
+        }
+
+        if (paramsType is INamedTypeSymbol { IsGenericType: true } namedType && namedType.TypeArguments.Length == 1)
+        {
+            return namedType.TypeArguments[0];
+        }
+
+        return null;
     }
 
     private static (bool IsEmpty, Location Location) ConstructorIsEmpty(

--- a/src/Common/WellKnown/MoqKnownSymbols.cs
+++ b/src/Common/WellKnown/MoqKnownSymbols.cs
@@ -605,6 +605,16 @@ internal class MoqKnownSymbols : KnownSymbols
     internal INamedTypeSymbol? ILogger1 => TypeProvider.GetOrCreateTypeByMetadataName("Microsoft.Extensions.Logging.ILogger`1");
 
     /// <summary>
+    /// Gets the struct <c>System.Span{T}</c>.
+    /// </summary>
+    internal INamedTypeSymbol? Span1 => TypeProvider.GetOrCreateTypeByMetadataName("System.Span`1");
+
+    /// <summary>
+    /// Gets the struct <c>System.ReadOnlySpan{T}</c>.
+    /// </summary>
+    internal INamedTypeSymbol? ReadOnlySpan1 => TypeProvider.GetOrCreateTypeByMetadataName("System.ReadOnlySpan`1");
+
+    /// <summary>
     /// Creates a <see cref="Lazy{T}"/> that resolves all methods with <paramref name="memberName"/> declared directly on <paramref name="type"/>.
     /// </summary>
     /// <remarks>

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -160,6 +160,55 @@ public partial class ConstructorArgumentsShouldMatchAnalyzerTests
                 ReferenceAssemblyCatalog.Net80WithNewMoq);
     }
 
+    // A custom params collection type resolves its element type from the IEnumerable<T> it
+    // implements — including a non-generic collection (MyIntCollection : IEnumerable<int>) and a
+    // generic wrapper whose own type argument is unrelated to the element type
+    // (MyTaggedCollection<TTag> : IEnumerable<string>).
+    [Theory]
+    [InlineData("MyIntCollection", """new Mock<ClassWithCustomParams>(1, 2, 3);""")]
+    [InlineData("MyIntCollection", """new Mock<ClassWithCustomParams>{|Moq1002:("a", "b")|};""")]
+    [InlineData("MyTaggedCollection<int>", """new Mock<ClassWithCustomParams>("a", "b");""")]
+    [InlineData("MyTaggedCollection<int>", """new Mock<ClassWithCustomParams>{|Moq1002:(1, 2)|};""")]
+    public async Task ShouldAnalyzeCustomParamsCollectionConstructorArguments(string collectionType, string mock)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+                $$"""
+                using System.Collections;
+                using System.Collections.Generic;
+                using Moq;
+
+                internal class MyIntCollection : IEnumerable<int>
+                {
+                    private readonly List<int> _items = new();
+                    public void Add(int item) => _items.Add(item);
+                    public IEnumerator<int> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                }
+
+                internal class MyTaggedCollection<TTag> : IEnumerable<string>
+                {
+                    private readonly List<string> _items = new();
+                    public void Add(string item) => _items.Add(item);
+                    public IEnumerator<string> GetEnumerator() => _items.GetEnumerator();
+                    IEnumerator IEnumerable.GetEnumerator() => _items.GetEnumerator();
+                }
+
+                internal class ClassWithCustomParams
+                {
+                    public ClassWithCustomParams(params {{collectionType}} items) { }
+                }
+
+                internal class UnitTest
+                {
+                    private void Test()
+                    {
+                        {{mock}}
+                    }
+                }
+                """,
+                ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
     [Theory]
     [MemberData(nameof(TestData))]
     public async Task ShouldAnalyzeConstructorArguments(string referenceAssemblyGroup, string @namespace, string mock)

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -85,6 +85,81 @@ public partial class ConstructorArgumentsShouldMatchAnalyzerTests
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 
+    [System.Diagnostics.CodeAnalysis.SuppressMessage("Design", "MA0051:Method is too long", Justification = "All test cases")]
+    public static IEnumerable<object[]> ParamsCollectionTestData()
+    {
+        return new object[][]
+        {
+            ["List<int>", """new Mock<ClassWithCollectionParams>(1, 2, 3);"""],
+            ["List<int>", """new Mock<ClassWithCollectionParams>{|Moq1002:("a", "b")|};"""],
+            ["List<int>", """new Mock<ClassWithCollectionParams>();"""],
+
+            ["IEnumerable<int>", """new Mock<ClassWithCollectionParams>(1, 2, 3);"""],
+            ["IEnumerable<int>", """new Mock<ClassWithCollectionParams>{|Moq1002:("a", "b")|};"""],
+
+            ["IReadOnlyList<int>", """new Mock<ClassWithCollectionParams>(1, 2, 3);"""],
+            ["IReadOnlyList<int>", """new Mock<ClassWithCollectionParams>{|Moq1002:("a", "b")|};"""],
+
+            ["Span<int>", """new Mock<ClassWithCollectionParams>(1, 2, 3);"""],
+            ["Span<int>", """new Mock<ClassWithCollectionParams>{|Moq1002:("a", "b")|};"""],
+        }.WithNamespaces();
+    }
+
+    // A constructor whose params parameter is a C# 13 params collection (e.g. `params ReadOnlySpan<T>`)
+    // must not crash the analyzer (AD0001/InvalidCastException) and must still correctly validate
+    // argument types against the collection's element type.
+    [Fact]
+    public async Task ShouldNotCrashOnParamsReadOnlySpanConstructor()
+    {
+        await Verifier.VerifyAnalyzerAsync(
+                """
+                using System;
+                using Moq;
+
+                internal class ClassWithReadOnlySpanParams
+                {
+                    public ClassWithReadOnlySpanParams(params ReadOnlySpan<string> values) { }
+                }
+
+                internal class UnitTest
+                {
+                    private void Test()
+                    {
+                        var mockOk = new Mock<ClassWithReadOnlySpanParams>("a", "b");
+                        var mockBad = new Mock<ClassWithReadOnlySpanParams>{|Moq1002:(1, 2)|};
+                    }
+                }
+                """,
+                ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
+    // A constructor whose params parameter uses any of the C# 13 params collection types
+    // (List<T>, IEnumerable<T>, IReadOnlyList<T>, Span<T>) must be analyzed the same way as a
+    // `params T[]` constructor: matching argument types are accepted, mismatched ones raise Moq1002.
+    [Theory]
+    [MemberData(nameof(ParamsCollectionTestData))]
+    public async Task ShouldAnalyzeParamsCollectionConstructorArguments(string @namespace, string collectionType, string mock)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+                $$"""
+                {{@namespace}}
+
+                internal class ClassWithCollectionParams
+                {
+                    public ClassWithCollectionParams(params {{collectionType}} items) { }
+                }
+
+                internal class UnitTest
+                {
+                    private void Test()
+                    {
+                        {{mock}}
+                    }
+                }
+                """,
+                ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
     [Theory]
     [MemberData(nameof(TestData))]
     public async Task ShouldAnalyzeConstructorArguments(string referenceAssemblyGroup, string @namespace, string mock)

--- a/tests/Moq.Analyzers.Test/Helpers/Test.cs
+++ b/tests/Moq.Analyzers.Test/Helpers/Test.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.CodeAnalysis.CodeFixes;
+﻿using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Testing;
 
@@ -27,5 +29,13 @@ internal class Test<TAnalyzer, TCodeFixProvider> : CSharpCodeFixTest<TAnalyzer, 
 
         TestState.Sources.Add(globalUsings);
         FixedState.Sources.Add(globalUsings);
+
+        // Compile test snippets with the latest language version so C# 13 features (e.g. params
+        // collections) can be exercised. The analyzer itself still targets its minimum-supported Roslyn.
+        SolutionTransforms.Add((solution, projectId) =>
+        {
+            CSharpParseOptions parseOptions = (CSharpParseOptions)solution.GetProject(projectId)!.ParseOptions!;
+            return solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.Latest));
+        });
     }
 }

--- a/tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
+++ b/tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj
@@ -19,8 +19,15 @@
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
+    <!-- Tests are compiled against a newer Roslyn than the analyzer's minimum-supported 4.8 so that
+         C# 13 params-collection syntax can be exercised. This does not change the analyzer's runtime
+         requirement; it only governs the compiler used to build test snippets. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.Common" VersionOverride="4.14.0" />
     <PackageReference Include="Microsoft.CodeAnalysis.AnalyzerUtilities" />
+    <!-- Required transitively by Roslyn 4.14; overrides the centrally pinned 8.0.0 for the test project only. -->
+    <PackageReference Include="System.Collections.Immutable" VersionOverride="10.0.5" />
     <PackageReference Include="Verify.Nupkg" />
   </ItemGroup>
 


### PR DESCRIPTION
## Problem

`ConstructorArgumentsShouldMatchAnalyzer` casts a params parameter's type directly to `IArrayTypeSymbol`:

```csharp
ITypeSymbol paramsElementType = ((IArrayTypeSymbol)paramsParameter.Type).ElementType;
```

With a **C# 13 params collection** (`params List<T>`, `params ReadOnlySpan<T>`, `params IEnumerable<T>`, etc.) the parameter type is an `INamedTypeSymbol`, not an array. The cast throws and the analyzer crashes:

```
AD0001: Analyzer 'Moq.Analyzers.ConstructorArgumentsShouldMatchAnalyzer' threw an exception
of type 'System.InvalidCastException' with message 'Unable to cast object of type
'...NonErrorNamedTypeSymbol' to type 'Microsoft.CodeAnalysis.IArrayTypeSymbol'.'
```

Any `Mock<T>` whose target constructor uses a params collection triggers it.

## Fix

Resolve the params element type for both classic arrays and single-type-argument collections, and return early (no diagnostic) when it can't be determined, so no false positive is reported.

## Tests

Adds regression coverage for `List<T>`, `IEnumerable<T>`, `IReadOnlyList<T>`, `Span<T>`, and `ReadOnlySpan<T>` params shapes — verifying both that the analyzer no longer crashes and that argument-type mismatches still raise `Moq1002`.

Because these tests use C# 13 syntax, the **test project** is compiled against Roslyn 4.14 (`VersionOverride`) with `LanguageVersion.Latest`. This is scoped to the test project only — the analyzer's minimum-supported Roslyn is unchanged.

Full suite: 3376 passing, 0 failing. The new tests fail against the pre-fix analyzer (RED) and pass with the fix (GREEN).

Draft pending maintainer feedback on the test-project Roslyn bump — happy to adjust the approach if you'd prefer a different way to exercise C# 13 in the test harness.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved constructor argument validation for `params` to be type-aware across C# 13 collection-based `params` forms and custom `IEnumerable<T>`-backed shapes.
  * Added support for `params Span<T>` / `params ReadOnlySpan<T>` without crashing.
  * Reduced false positives when the `params` element type can’t be determined.
* **Tests**
  * Expanded analyzer test coverage for additional `params` shapes, including `List<T>`, `IEnumerable<T>`, `IReadOnlyList<T>`, `Span<T>`, and custom enumerable types.
  * Updated the test harness to recompile snippets using the latest C# language version.
* **Chores**
  * Pinned newer Roslyn-related package versions for the test suite.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->