### PR TITLE
fix(ci): stop Release Drafter from creating releases on PRs

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -36,8 +36,6 @@ jobs:
       pull-requests: write
     steps:
       - name: Apply release-drafter labels
-        uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
-        with:
-          disable-releaser: true
+        uses: release-drafter/release-drafter/autolabeler@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -37,5 +37,7 @@ jobs:
     steps:
       - name: Apply release-drafter labels
         uses: release-drafter/release-drafter@4d75298e00d9e34c483e5ff8c68d0ea1c1940c1e # v7.5.1
+        with:
+          disable-releaser: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Problem

The `label_pull_request` job in `.github/workflows/release-drafter.yml` runs the release-drafter action with the releaser enabled. On `pull_request_target` events the action tries to create a GitHub release, but the job only grants `contents: read`. Every PR fails the non-required **Label pull request** check with:

```
##[error]Resource not accessible by integration - https://docs.github.com/rest/releases/releases#create-a-release
```

This makes nearly every open PR show `mergeStateStatus: UNSTABLE` (pure noise, since the check is not required).

## Fix

release-drafter v7.5.1 removed the `disable-releaser` input (verified against the pinned SHA `4d75298`, tag v7.5.1: it is absent from the action's `action.yml`). Passing it was a silent no-op, so the label job still ran the drafter.

Point the `label_pull_request` job at the dedicated `release-drafter/release-drafter/autolabeler@v7.5.1` sub-action, which only applies labels and never drafts or publishes a release. This is the usage the action's own `autolabeler/README.md` documents as correct; it warns that the root `release-drafter/release-drafter@...` reference "runs drafter". The `update_release_draft` job (push to `main`, `contents: write`) is unchanged and still drafts releases.

Because `pull_request_target` runs the workflow from the base branch, merging this repairs the check for all open PRs on their next run.

## Validation

- `python3 -c "import yaml; yaml.safe_load(...)"` -> YAML OK.
- Verified `autolabeler/action.yml` exists at the pinned SHA and its inputs (`token`, `config-name`, `dry-run`) cover this use.
- The fix cannot self-validate on this PR: `pull_request_target` runs the base-branch (main) workflow, which still has the broken `disable-releaser` no-op. The **Label pull request** check therefore fails here on main's version; it is non-required. Merging repairs it for subsequent PR runs.

## Moq compatibility

No analyzer or test changes. Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the release automation workflow to use the release-drafter autolabeler component for pull request labeling.
  * This changes how pull requests are categorized within release drafts during pull request processing, keeping release notes more organized and up to date. Release drafts will reflect the updated labeling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
