### PR TITLE
fix(analyzers): Moq1300 false positive on open type parameters / unresolved types (#1251)

### DIFF
--- a/docs/rules/Moq1300.md
+++ b/docs/rules/Moq1300.md
@@ -73,51 +73,39 @@ For more information, see
 
 ### Advanced Scenarios: Generic Type Parameters
 
-Moq1300 fires for generic type parameters constrained to interfaces, even though the constraint ensures interface compatibility at the call site:
+Whether Moq1300 fires on a generic type parameter depends on its constraints, because the
+constraints determine whether `T` could ever be an interface at a call site.
+
+Moq1300 does **not** fire when `T` could still be substituted with an interface:
 
 ```csharp
-void SetupMyMock<T>(Mock<IFoo> mock, Action<Mock<T>> setupStuff) 
+void SetupMyMock<T>(Mock<IFoo> mock, Action<Mock<T>> setupStuff)
     where T : IFoo
 {
-    // Moq1300 fires here, even though T is constrained to IFoo
+    // No Moq1300: T is constrained to the interface IFoo, so T may be an interface.
     setupStuff(mock.As<T>());
 }
 ```
 
-#### Why This Happens
+This also applies to unconstrained type parameters and those constrained with `where T : class`,
+since an interface is a reference type.
 
-C# generic constraints cannot enforce "interface-only" requirements. While `where T : IFoo` ensures `T` implements the interface `IFoo`, it doesn't prevent `T` from being a class (e.g., `class Foo : IFoo {}`), which would cause `Mock.As<T>()` to fail at runtime.
-
-Because `Mock.As<T>()` only works with interfaces, the analyzer **errs on the side of safety** and reports this as an error to prevent potential runtime failures.
-
-#### When Suppression is Appropriate
-
-- You control all call sites and can verify `T` is always an interface
-- Your helper method is internal to your test project with limited usage
-- You have integration tests validating the generic patterns
-
-#### When to Avoid Suppression
-
-- The helper is in a public library
-- Call sites are outside your control
-- Runtime failures would be difficult to diagnose
-
-##### Suppression Example
+Moq1300 **does** fire when the constraints make an interface substitution impossible, because
+`Mock.As<T>()` can then never bind to an interface:
 
 ```csharp
-void SetupMyMock<T>(Mock<IFoo> mock, Action<Mock<T>> setupStuff) 
-    where T : IFoo
+void SetupMyMock<T>(Mock<T> mock)
+    where T : SampleClass // base-class constraint: T can never be an interface
 {
-    #pragma warning disable Moq1300 // Helper method used in test where call sites are under our control
-    setupStuff(mock.As<T>());
-    #pragma warning restore Moq1300
+    mock.As<T>(); // Moq1300: Mock.As() should take interfaces only
 }
 ```
 
-> **Note:** Per [issue #756](https://github.com/rjmurillo/moq.analyzers/issues/756), this guidance may be reconsidered if:
->
->1. multiple independent users report the scenario,
->2. official Moq documentation includes this pattern,
->3. C# adds interface-only constraints,
->4. significant community validation, or
->5. the pattern appears in other major OSS projects
+A value-type constraint (`where T : struct` or `where T : unmanaged`) is likewise reported,
+though such code also fails to compile because `Mock.As<T>()` requires a reference type.
+
+> **Note:** Per [issue #756](https://github.com/rjmurillo/moq.analyzers/issues/756) and
+> [issue #1251](https://github.com/rjmurillo/moq.analyzers/issues/1251), the analyzer no longer
+> reports interface-constrained or unconstrained type parameters, which removes the previous false
+> positives for those patterns.
+

--- a/docs/rules/Moq1300.md
+++ b/docs/rules/Moq1300.md
@@ -80,7 +80,7 @@ Moq1300 does **not** fire when `T` could still be substituted with an interface:
 
 ```csharp
 void SetupMyMock<T>(Mock<IFoo> mock, Action<Mock<T>> setupStuff)
-    where T : IFoo
+    where T : class, IFoo
 {
     // No Moq1300: T is constrained to the interface IFoo, so T may be an interface.
     setupStuff(mock.As<T>());
@@ -101,8 +101,19 @@ void SetupMyMock<T>(Mock<T> mock)
 }
 ```
 
-A value-type constraint (`where T : struct` or `where T : unmanaged`) is likewise reported,
-though such code also fails to compile because `Mock.As<T>()` requires a reference type.
+A `new()` constraint is likewise reported, because an interface has no constructor and can never
+satisfy it:
+
+```csharp
+void SetupMyMock<T>(Mock<T> mock)
+    where T : class, new() // T needs a constructor, so it can never be an interface
+{
+    mock.As<T>(); // Moq1300: Mock.As() should take interfaces only
+}
+```
+
+A value-type constraint (`where T : struct` or `where T : unmanaged`) does not compile at all,
+because `Mock.As<T>()` requires a reference type.
 
 > **Note:** Per [issue #756](https://github.com/rjmurillo/moq.analyzers/issues/756) and
 > [issue #1251](https://github.com/rjmurillo/moq.analyzers/issues/1251), the analyzer no longer

--- a/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -83,7 +83,14 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        if (typeArguments[0] is ITypeSymbol { TypeKind: not TypeKind.Interface } typeSymbol)
+        // Exclude type kinds we cannot classify as "not an interface":
+        //   - TypeParameter: an open generic (for example As<T>() in a generic method) may be
+        //     constrained to, or substituted with, an interface at the call site. Reporting here
+        //     is a false positive (issue #1251).
+        //   - Error: the type failed to bind, so the code already has a compiler error; adding
+        //     Moq1300 on top is noise.
+        if (typeArguments[0] is ITypeSymbol { TypeKind: not TypeKind.Interface } typeSymbol
+            && typeSymbol.TypeKind is not (TypeKind.TypeParameter or TypeKind.Error))
         {
             // Find the first As<T> generic type argument and report the diagnostic on it
             GenericNameSyntax? asGeneric = invocationOperation.Syntax

--- a/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -83,24 +83,62 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Exclude type kinds we cannot classify as "not an interface":
-        //   - TypeParameter: an open generic (for example As<T>() in a generic method) may be
-        //     constrained to, or substituted with, an interface at the call site. Reporting here
-        //     is a false positive (issue #1251).
-        //   - Error: the type failed to bind, so the code already has a compiler error; adding
-        //     Moq1300 on top is noise.
-        if (typeArguments[0] is ITypeSymbol { TypeKind: not TypeKind.Interface } typeSymbol
-            && typeSymbol.TypeKind is not (TypeKind.TypeParameter or TypeKind.Error))
-        {
-            // Find the first As<T> generic type argument and report the diagnostic on it
-            GenericNameSyntax? asGeneric = invocationOperation.Syntax
-                .DescendantNodes()
-                .OfType<GenericNameSyntax>()
-                .FirstOrDefault(x => string.Equals(x.Identifier.ValueText, "As", StringComparison.Ordinal));
+        ITypeSymbol typeSymbol = typeArguments[0];
 
-            TypeSyntax? typeArg = asGeneric?.TypeArgumentList.Arguments.FirstOrDefault();
-            Location location = typeArg?.GetLocation() ?? invocationOperation.Syntax.GetLocation();
-            context.ReportDiagnostic(location.CreateDiagnostic(Rule, typeSymbol.ToDisplayString()));
+        // Interface: this is the valid, intended use of As<T>, so never report.
+        // Error: the type failed to bind, so the code already has a compiler error; adding
+        // Moq1300 on top is noise (issue #1251).
+        if (typeSymbol.TypeKind is TypeKind.Interface or TypeKind.Error)
+        {
+            return;
         }
+
+        // Open generic type parameter: at the call site T may be substituted with an interface,
+        // so reporting is a false positive (issue #1251) UNLESS its constraints make an interface
+        // substitution impossible (a value-type or base-class constraint). In that case As<T> can
+        // never bind to an interface, so the diagnostic is correct.
+        if (typeSymbol is ITypeParameterSymbol typeParameter && CanBeSubstitutedWithInterface(typeParameter))
+        {
+            return;
+        }
+
+        // Find the first As<T> generic type argument and report the diagnostic on it
+        GenericNameSyntax? asGeneric = invocationOperation.Syntax
+            .DescendantNodes()
+            .OfType<GenericNameSyntax>()
+            .FirstOrDefault(x => string.Equals(x.Identifier.ValueText, "As", StringComparison.Ordinal));
+
+        TypeSyntax? typeArg = asGeneric?.TypeArgumentList.Arguments.FirstOrDefault();
+        Location location = typeArg?.GetLocation() ?? invocationOperation.Syntax.GetLocation();
+        context.ReportDiagnostic(location.CreateDiagnostic(Rule, typeSymbol.ToDisplayString()));
+    }
+
+    /// <summary>
+    /// Determines whether an open generic type parameter could be substituted with an interface
+    /// at a call site, given its declared constraints.
+    /// </summary>
+    /// <param name="typeParameter">The open generic type parameter used as the <c>As&lt;T&gt;</c> argument.</param>
+    /// <returns>
+    /// <see langword="false" /> when a value-type constraint (<c>struct</c>/<c>unmanaged</c>) or a
+    /// base-class constraint forbids an interface substitution; otherwise <see langword="true" />.
+    /// </returns>
+    private static bool CanBeSubstitutedWithInterface(ITypeParameterSymbol typeParameter)
+    {
+        // A value type can never be an interface.
+        if (typeParameter.HasValueTypeConstraint || typeParameter.HasUnmanagedTypeConstraint)
+        {
+            return false;
+        }
+
+        // A base-class constraint forces T to derive from a class, so it cannot be an interface.
+        foreach (ITypeSymbol constraintType in typeParameter.ConstraintTypes)
+        {
+            if (constraintType.TypeKind == TypeKind.Class)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -119,13 +119,18 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
     /// </summary>
     /// <param name="typeParameter">The open generic type parameter used as the <c>As&lt;T&gt;</c> argument.</param>
     /// <returns>
-    /// <see langword="false" /> when a value-type constraint (<c>struct</c>/<c>unmanaged</c>) or a
-    /// base-class constraint forbids an interface substitution; otherwise <see langword="true" />.
+    /// <see langword="false" /> when a value-type constraint (<c>struct</c>/<c>unmanaged</c>), a
+    /// constructor constraint (<c>new()</c>), or a base-class constraint forbids an interface
+    /// substitution; otherwise <see langword="true" />.
     /// </returns>
     private static bool CanBeSubstitutedWithInterface(ITypeParameterSymbol typeParameter)
     {
-        // A value type can never be an interface.
-        if (typeParameter.HasValueTypeConstraint || typeParameter.HasUnmanagedTypeConstraint)
+        // A value type can never be an interface. A `new()` constraint requires a public
+        // parameterless constructor, which no interface can satisfy, so it also rules out
+        // an interface substitution.
+        if (typeParameter.HasValueTypeConstraint
+            || typeParameter.HasUnmanagedTypeConstraint
+            || typeParameter.HasConstructorConstraint)
         {
             return false;
         }

--- a/tests/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
@@ -1,5 +1,3 @@
-using Microsoft.CodeAnalysis.Testing;
-
 using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.AsShouldBeUsedOnlyForInterfaceAnalyzer>;
 
 namespace Moq.Analyzers.Test;
@@ -116,10 +114,10 @@ public class AsAcceptOnlyInterfaceAnalyzerTests(ITestOutputHelper output)
     }
 
     [Fact]
-    public async Task ShouldNotReportForUnresolvedType()
+    public async Task ShouldReportForConstructorConstrainedTypeParameter()
     {
-        // An unresolved type argument already produces a compiler error; piling Moq1300 on top
-        // is noise, so the analyzer must skip TypeKind.Error. See issue #1251.
+        // A new() constraint requires a parameterless constructor, which no interface can
+        // satisfy, so T can never be an interface and Moq1300 must still fire. See issue #1251.
         await Verifier.VerifyAnalyzerAsync(
             """
             public class SampleClass
@@ -129,13 +127,13 @@ public class AsAcceptOnlyInterfaceAnalyzerTests(ITestOutputHelper output)
 
             internal class UnitTest
             {
-                private void Test()
+                private void Test<T>()
+                    where T : class, new()
                 {
-                    _ = new Mock<SampleClass>().As<DoesNotExist>();
+                    _ = new Mock<SampleClass>().As<{|Moq1300:T|}>();
                 }
             }
             """,
-            ReferenceAssemblyCatalog.Net80WithNewMoq,
-            CompilerDiagnostics.None);
+            ReferenceAssemblyCatalog.Net80WithNewMoq);
     }
 }

--- a/tests/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis.Testing;
+
 using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.AsShouldBeUsedOnlyForInterfaceAnalyzer>;
 
 namespace Moq.Analyzers.Test;
@@ -87,5 +89,53 @@ public class AsAcceptOnlyInterfaceAnalyzerTests(ITestOutputHelper output)
             }
             """,
             ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
+    [Fact]
+    public async Task ShouldReportForClassConstrainedTypeParameter()
+    {
+        // A base-class constraint means T can never be substituted with an interface, so
+        // As<T> can never bind to an interface and Moq1300 must still fire. See issue #1251.
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            public abstract class BaseSampleClass
+            {
+                public int Calculate() => 0;
+            }
+
+            internal class UnitTest
+            {
+                private void Test<T>()
+                    where T : BaseSampleClass
+                {
+                    _ = new Mock<BaseSampleClass>().As<{|Moq1300:T|}>();
+                }
+            }
+            """,
+            ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportForUnresolvedType()
+    {
+        // An unresolved type argument already produces a compiler error; piling Moq1300 on top
+        // is noise, so the analyzer must skip TypeKind.Error. See issue #1251.
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            public class SampleClass
+            {
+                public int Calculate() => 0;
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    _ = new Mock<SampleClass>().As<DoesNotExist>();
+                }
+            }
+            """,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CompilerDiagnostics.None);
     }
 }

--- a/tests/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/AsAcceptOnlyInterfaceAnalyzerTests.cs
@@ -64,4 +64,28 @@ public class AsAcceptOnlyInterfaceAnalyzerTests(ITestOutputHelper output)
             DoppelgangerTestHelper.CreateTestCode(mockCode),
             ReferenceAssemblyCatalog.Net80WithNewMoq);
     }
+
+    [Fact]
+    public async Task ShouldNotReportForOpenTypeParameter()
+    {
+        // Moq1300 must not fire on an open type parameter: at the call site T may be
+        // constrained to (or substituted with) an interface. See issue #1251.
+        await Verifier.VerifyAnalyzerAsync(
+            """
+            public class SampleClass
+            {
+                public int Calculate() => 0;
+            }
+
+            internal class UnitTest
+            {
+                private void Test<T>()
+                    where T : class
+                {
+                    _ = new Mock<SampleClass>().As<T>();
+                }
+            }
+            """,
+            ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
 }


### PR DESCRIPTION
Fixes #1251.

## Problem
`AsShouldBeUsedOnlyForInterfaceAnalyzer` reported Moq1300 for any non-interface `TypeKind`, including open generic type parameters. That produced false positives for `As<T>()` in generic helpers where `T` may be substituted with an interface at the call site.

## Fix (constraint-aware)
Moq1300 now decides based on whether the type argument *could* be an interface:

- **Interface** type argument: never reported (valid use).
- **Unresolved (`TypeKind.Error`)**: skipped; the code already has a compiler error, so piling on is noise.
- **Open generic type parameter**: reported **only** when its constraints make an interface substitution impossible:
  - value-type constraint (`struct`/`unmanaged`) — value types are not interfaces,
  - `new()` constraint — interfaces have no constructor,
  - base-class constraint (`where T : SomeClass`) — cannot also be an interface.
  Otherwise (unconstrained, `where T : class`, or interface-constrained) it is exempt, since `T` may be an interface.

This refines the original "skip all type parameters" idea: a blanket exemption would miss cases where `T` provably cannot be an interface (raised in review by Codex).

## Tests
- `ShouldNotReportForOpenTypeParameter` (`where T : class`) — no diagnostic.
- `ShouldReportForClassConstrainedTypeParameter` (`where T : BaseSampleClass`) — reports.
- `ShouldReportForConstructorConstrainedTypeParameter` (`where T : class, new()`) — reports.

All test inputs are valid, compilable C# per `csharp.instructions.md` (no compiler-error samples).

## Docs
`docs/rules/Moq1300.md` "Advanced Scenarios: Generic Type Parameters" rewritten to describe the constraint-aware behavior with compilable examples.

## Validation
- `dotnet build`: 0 warnings, 0 errors.
- As-analyzer tests: 35 passed, 0 failed.
- Moq version: behavior identical for Moq 4.8.2 and 4.18.4 (analyzer is Moq-version-agnostic here).
