### PR TITLE
test(Moq1100): regression test for empty-argument Setup guard (#1242)

### DIFF
--- a/docs/rules/Moq1300.md
+++ b/docs/rules/Moq1300.md
@@ -119,4 +119,3 @@ because `Mock.As<T>()` requires a reference type.
 > [issue #1251](https://github.com/rjmurillo/moq.analyzers/issues/1251), the analyzer no longer
 > reports interface-constrained or unconstrained type parameters, which removes the previous false
 > positives for those patterns.
-

--- a/tests/Moq.Analyzers.Test/Common/SemanticModelExtensionsTests.cs
+++ b/tests/Moq.Analyzers.Test/Common/SemanticModelExtensionsTests.cs
@@ -560,6 +560,36 @@ public class C
     }
 
     [Fact]
+    public async Task GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation_SetupWithoutArguments_ReturnsEmpty()
+    {
+        // The helper must not assume ArgumentList.Arguments[0] exists: a zero-argument
+        // invocation (which is what FindSetupMethodFromCallbackInvocation can return for
+        // mid-edit `Setup()` code via candidate symbols) must yield an empty result, not
+        // throw ArgumentOutOfRangeException. A valid zero-argument invocation (VerifyAll)
+        // exercises the same empty-argument-list guard using only compilable C#.
+        const string code = @"
+using Moq;
+public interface IFoo { int Bar(string s); }
+public class C
+{
+    public void M()
+    {
+        var mock = new Mock<IFoo>();
+        mock.VerifyAll();
+    }
+}";
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(code);
+        SyntaxNode root = await tree.GetRootAsync();
+        InvocationExpressionSyntax zeroArgInvocation = root
+            .DescendantNodes().OfType<InvocationExpressionSyntax>()
+            .First(i => i.ArgumentList.Arguments.Count == 0);
+
+        IEnumerable<IMethodSymbol> symbols = model.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(zeroArgInvocation);
+
+        Assert.Empty(symbols);
+    }
+
+    [Fact]
     public async Task IsCallbackOrReturnInvocation_CallbackInvocation_ReturnsTrue()
     {
         const string code = @"


### PR DESCRIPTION
## Context

#1288 fixed the #1242 crash by guarding `GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation` against an empty argument list (returns `[]` instead of indexing `Arguments[0]`). It shipped **without** the regression test #1242's acceptance criteria call for. This PR adds that coverage.

## Change
One test in `SemanticModelExtensionsTests`: `GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation_SetupWithoutArguments_ReturnsEmpty`. It feeds a valid zero-argument invocation (`mock.VerifyAll()`) to the helper and asserts an empty result. The pre-guard code threw `ArgumentOutOfRangeException` on `Arguments[0]` for a zero-argument invocation, so this is a true regression test.

## Test-contract note
#1242 also proposed a fixer-level and an analyzer-level test. Both intrinsically require mid-edit `mock.Setup().Callback(...)` source, where `Setup()` with no arguments is a **compiler error** (CS1501). `.github/instructions/csharp.instructions.md:13` forbids compiler-error input in analyzer/code-fix tests (non-negotiable), so those two are intentionally omitted. The guard is fully covered at the helper level by the added test.

## Validation
- `dotnet build`: 0 warnings, 0 errors.
- `SemanticModelExtensions` tests: 38 passed, 0 failed.
- Moq versions: helper is Moq-version-agnostic; unaffected by 4.8.2 vs 4.18.4.

Closes #1242.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added coverage for a zero-argument invocation scenario, helping ensure argumentless setup/verification calls are handled safely and consistently.
* **Documentation**
  * Updated the Moq1300 rule documentation to accurately reflect the analyzer’s current behavior for generic type parameter scenarios, removing previously incorrect guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->