### PR TITLE
docs(serena): document shared-project coverage gotcha for src/Common

### DIFF
--- a/.serena/memories/coverage-shared-project-gotcha.md
+++ b/.serena/memories/coverage-shared-project-gotcha.md
@@ -1,0 +1,59 @@
+# Coverage gotcha: src/Common is a shared project (Common.projitems)
+
+## The fact
+
+`src/Common/Common.projitems` compiles `$(MSBuildThisFileDirectory)/**/*.cs`
+(SemanticModelExtensions, MoqKnownSymbols, DiagnosticEditProperties, all of
+`Moq.Analyzers.Common`) directly into **every** project that imports it:
+
+- `Moq.Analyzers.dll` (shipping)
+- `Moq.CodeFixes.dll` (shipping)
+- `Moq.Analyzers.Test.dll` (test project imports it at
+  `tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj:31`)
+
+Each assembly gets its **own compiled copy** of the Common code.
+
+## Why it bites coverage (the 5+ minute trap)
+
+`build/targets/tests/test.runsettings` uses the **Microsoft Code Coverage**
+collector and only instruments modules matching `.*Moq\.Analyzers\.dll$` and
+`.*Moq\.CodeFixes\.dll$`, with `IncludeTestAssembly=False`.
+
+A direct unit test like `SemanticModelExtensionsTests` calls
+`model.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(...)`. That
+call binds to the copy compiled into **Moq.Analyzers.Test.dll**, which is NOT
+instrumented. Result: the method shows **0 hits / 0% block coverage** in the
+cobertura report even though the test passes and clearly executes it.
+
+So: **direct unit tests of `src/Common` code do NOT move the shipping-binary
+coverage number.** They exercise a parallel, uninstrumented embedded copy.
+
+## What actually produces shipping coverage for Common code
+
+Only tests that load the real `Moq.Analyzers.dll` / `Moq.CodeFixes.dll` copy:
+the analyzer/code-fix verifier tests (`*.Verify*Async` through
+`Microsoft.CodeAnalysis.Testing`). To cover a guard inside a Common helper in
+the shipping binary, drive input through the analyzer/fixer that calls it, not
+through a direct unit test of the helper.
+
+## Tooling note
+
+Do NOT pass `--collect:"XPlat Code Coverage"` (coverlet). The runsettings
+already declares the Microsoft `Code Coverage` collector; adding `--collect`
+either errors ("Unable to find a datacollector with friendly name 'XPlat Code
+Coverage'") or produces a second, misleading report. Just run:
+`dotnet test <proj> --settings ./build/targets/tests/test.runsettings` and read
+the emitted `*.cobertura.xml`.
+
+## Interaction with defensive guards
+
+Some Common guards defend against malformed/incomplete syntax trees that only
+occur in the IDE while typing (e.g. `mock.Setup()` with zero arguments is
+`CS1501` and cannot appear in valid compilable code). Such branches are:
+
+1. unreachable by valid-code analyzer tests, and
+2. not counted by direct unit tests (shared-project copy, above).
+   For the 100% block-coverage bar, treat these as documented defensive
+   exclusions (comment + coverage-exclude) rather than trying to fake coverage
+   with compiler-error input, which the test contract
+   (`.github/instructions/csharp.instructions.md`) forbids.


### PR DESCRIPTION
## Summary

Adds a Serena memory documenting a non-obvious coverage trap discovered while validating the 100% block-coverage bar.

`src/Common/Common.projitems` globs `**/*.cs` and is imported by the analyzer, code-fix, **and test** projects, so each assembly gets its own compiled copy of the Common code. A direct unit test of a Common helper (e.g. `SemanticModelExtensionsTests`) binds to the copy inside `Moq.Analyzers.Test.dll`. The coverage collector in `build/targets/tests/test.runsettings` only instruments `Moq.Analyzers.dll` / `Moq.CodeFixes.dll` with `IncludeTestAssembly=False`, so those unit tests show **0% shipping coverage** even though they pass.

Shipping-binary coverage of Common code requires analyzer/code-fix verifier tests that load the real DLLs.

## Why

Prevents future contributors (human or agent) from adding direct `src/Common` unit tests and wrongly concluding shipping coverage improved. Directly supports the non-negotiable 100% block-coverage requirement.

## Validation

- `markdownlint-cli2 --config .markdownlint.json` on the file: 0 errors
- `prettier@3.8.4 --check`: formatted
- Docs-only change (`.serena/memories/`); no code, no tests affected.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new note explaining a coverage reporting caveat for shared code in the project.
  * Clarified why some tests can pass while showing 0% coverage for shared helpers.
  * Documented the recommended coverage setup and how to handle IDE-only defensive branches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->