### PR TITLE
fix(analyzers): Moq1100 false positive on scoped ref / ref readonly lambda params

### DIFF
--- a/docs/rules/Moq1100.md
+++ b/docs/rules/Moq1100.md
@@ -92,6 +92,10 @@ mock.Setup(x => x.ProcessData(ref It.Ref<string>.IsAny))
     .Callback(new ProcessDataCallback((ref string data) => data = "processed"));
 ```
 
+The analyzer compares each lambda parameter's ref kind using the resolved
+parameter symbol, so multi-token modifier lists such as `scoped ref` and
+`ref readonly` are matched correctly and do not produce a false positive.
+
 ### Complex Multi-Parameter Scenarios
 
 ```csharp

--- a/src/Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/src/Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -221,14 +221,14 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
         ParameterSyntax lambdaParameter,
         CancellationToken cancellationToken)
     {
-        // Use semantic model to resolve the parameter type, handling both
+        // Use semantic model to resolve the parameter symbol, handling both
         // explicitly typed and implicitly typed lambda parameters.
         IParameterSymbol? parameterSymbol = semanticModel.GetDeclaredSymbol(lambdaParameter, cancellationToken);
         ITypeSymbol? lambdaParameterTypeSymbol = parameterSymbol?.Type;
 
-        if (lambdaParameterTypeSymbol is null || lambdaParameterTypeSymbol.TypeKind == TypeKind.Error)
+        if (parameterSymbol is null || lambdaParameterTypeSymbol is null || lambdaParameterTypeSymbol.TypeKind == TypeKind.Error)
         {
-            return false; // Type could not be resolved; treat as mismatch to avoid suppressing Moq1100
+            return false; // Symbol/type could not be resolved; treat as mismatch to avoid suppressing Moq1100
         }
 
         ITypeSymbol mockedParameterType = mockedParameter.Type;
@@ -238,23 +238,10 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
             return false;
         }
 
-        return mockedParameter.RefKind == GetRefKind(lambdaParameter);
-    }
-
-    private static RefKind GetRefKind(ParameterSyntax parameter)
-    {
-        if (parameter.Modifiers.Count == 0)
-        {
-            return RefKind.None;
-        }
-
-        return parameter.Modifiers[0].ValueText switch
-        {
-            "ref" => RefKind.Ref,
-            "out" => RefKind.Out,
-            "in" => RefKind.In,
-            _ => RefKind.None,
-        };
+        // Use the resolved symbol's RefKind, which is authoritative for every modifier
+        // combination and ordering (e.g. `scoped ref`, `ref readonly`). Re-deriving the
+        // ref kind from the first syntax token misreads multi-token modifier lists.
+        return mockedParameter.RefKind == parameterSymbol.RefKind;
     }
 
     private static string GetMethodName(InvocationExpressionSyntax mockedMethodInvocation)

--- a/tests/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodAnalyzerTests.cs
@@ -53,6 +53,11 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzerTests(ITestOutputHe
             // modifier token, but the parameter's RefKind is still Ref, so this matches DoRef.
             ["""new Mock<IFoo>().Setup(m => m.DoRef(ref It.Ref<string>.IsAny)).Callback((scoped ref string data) => { });"""],
 
+            // ref readonly parameter with correct signature (issue #1262): the resolved RefKind is
+            // RefReadOnlyParameter (a distinct enum value), so a ref readonly lambda matches the
+            // ref readonly mocked method without a false positive.
+            ["""new Mock<IFoo>().Setup(m => m.DoRefReadonly(ref It.Ref<DateTime>.IsAny)).Callback((ref readonly DateTime timestamp) => { });"""],
+
             // Implicitly typed lambda with correct parameter type via generic Callback overload
             ["""new Mock<IFoo>().Setup(x => x.DoWork("test")).Callback<string>((x) => { });"""],
 
@@ -91,6 +96,11 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzerTests(ITestOutputHe
             // matches but the RefKind differs (Ref vs In), so a diagnostic is still expected. This
             // guards against the modifier-list read suppressing a genuine ref-kind mismatch.
             ["""new Mock<IFoo>().Setup(m => m.DoIn(in It.Ref<DateTime>.IsAny)).Callback(({|Moq1100:scoped ref DateTime timestamp|}) => { });"""],
+
+            // ref readonly lambda parameter against an `in` mocked parameter (issue #1262): the type
+            // matches but the RefKind differs (RefReadOnlyParameter vs In), so a diagnostic is still
+            // expected. Confirms the analyzer compares ref kinds exactly, not loosely.
+            ["""new Mock<IFoo>().Setup(m => m.DoIn(in It.Ref<DateTime>.IsAny)).Callback(({|Moq1100:ref readonly DateTime timestamp|}) => { });"""],
 
             // Parenthesized Setup with wrong callback type
             ["""(new Mock<IFoo>().Setup(x => x.DoWork("test"))).Callback(({|Moq1100:int wrongParam|}) => { });"""],
@@ -136,6 +146,7 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzerTests(ITestOutputHe
                 int DoRef(ref string data);
                 bool DoOut(out int result);
                 string DoIn(in DateTime timestamp);
+                void DoRefReadonly(ref readonly DateTime timestamp);
                 T ProcessGeneric<T>(T input);
             }
 

--- a/tests/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodAnalyzerTests.cs
@@ -49,6 +49,10 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzerTests(ITestOutputHe
             // In parameter with correct signature
             ["""new Mock<IFoo>().Setup(m => m.DoIn(in It.Ref<DateTime>.IsAny)).Callback((in DateTime timestamp) => { });"""],
 
+            // scoped ref parameter with correct signature (issue #1262): `scoped` is the first
+            // modifier token, but the parameter's RefKind is still Ref, so this matches DoRef.
+            ["""new Mock<IFoo>().Setup(m => m.DoRef(ref It.Ref<string>.IsAny)).Callback((scoped ref string data) => { });"""],
+
             // Implicitly typed lambda with correct parameter type via generic Callback overload
             ["""new Mock<IFoo>().Setup(x => x.DoWork("test")).Callback<string>((x) => { });"""],
 
@@ -82,6 +86,11 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzerTests(ITestOutputHe
 
             // In parameter mismatch (missing in modifier)
             ["""new Mock<IFoo>().Setup(m => m.DoIn(in It.Ref<DateTime>.IsAny)).Callback(({|Moq1100:DateTime timestamp|}) => { });"""],
+
+            // scoped ref lambda parameter against an `in` mocked parameter (issue #1262): the type
+            // matches but the RefKind differs (Ref vs In), so a diagnostic is still expected. This
+            // guards against the modifier-list read suppressing a genuine ref-kind mismatch.
+            ["""new Mock<IFoo>().Setup(m => m.DoIn(in It.Ref<DateTime>.IsAny)).Callback(({|Moq1100:scoped ref DateTime timestamp|}) => { });"""],
 
             // Parenthesized Setup with wrong callback type
             ["""(new Mock<IFoo>().Setup(x => x.DoWork("test"))).Callback(({|Moq1100:int wrongParam|}) => { });"""],

--- a/tests/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/CallbackSignatureShouldMatchMockedMethodAnalyzerTests.cs
@@ -53,6 +53,11 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzerTests(ITestOutputHe
             // modifier token, but the parameter's RefKind is still Ref, so this matches DoRef.
             ["""new Mock<IFoo>().Setup(m => m.DoRef(ref It.Ref<string>.IsAny)).Callback((scoped ref string data) => { });"""],
 
+            // scoped in parameter with correct signature (issue #1262): same bug class as scoped
+            // ref. `scoped` leads the modifier list, but the resolved RefKind is In, so this
+            // matches DoIn without a false positive.
+            ["""new Mock<IFoo>().Setup(m => m.DoIn(in It.Ref<DateTime>.IsAny)).Callback((scoped in DateTime timestamp) => { });"""],
+
             // ref readonly parameter with correct signature (issue #1262): the resolved RefKind is
             // RefReadOnlyParameter (a distinct enum value), so a ref readonly lambda matches the
             // ref readonly mocked method without a false positive.


### PR DESCRIPTION
Closes #1262

## Problem

`Moq1100` (callback signature should match mocked method) raised a false positive when a callback lambda parameter used a multi-token ref modifier list such as `scoped ref` or `ref readonly`. The private `GetRefKind` helper inspected only `parameter.Modifiers[0]`, so `scoped ref string` resolved to `scoped` -> `RefKind.None`, which no longer matched the mocked method's `RefKind.Ref`.

## Fix

Use the already-resolved `parameterSymbol.RefKind` (the authoritative semantic ref kind) instead of re-deriving it from the first syntax token. Removed the now-dead `GetRefKind` helper. Symbol-to-symbol `RefKind` comparison needs no mapping and handles every modifier combination (`ref`, `in`, `out`, `ref readonly`, `scoped ref`).

## Tests

Added to `CallbackSignatureShouldMatchMockedMethodAnalyzerTests`:

- Positive: `(scoped ref string data) => {}` against `DoRef(ref string)` -> no diagnostic.
- Negative: `(scoped ref DateTime timestamp) => {}` against `DoIn(in DateTime)` -> still `Moq1100` (ref != in).

Covers positive, negative, and the boundary modifier-token case.

## Validation

- `dotnet build tests/Moq.Analyzers.Test` -> 0 warnings.
- Moq1100 callback test suite (281 cases) passes.
- 100% block coverage of `ParameterTypesMatch`; the two defensive null sub-conditions are unreachable by valid compilable C# (kept as a combined guard so the single early-return block is fully covered).
- `lizard` complexity: 0 warnings, `ParameterTypesMatch` CCN=8 (<=10).
- `markdownlint-cli2` + `prettier@3.8.4` clean on `docs/rules/Moq1100.md`.

No `AnalyzerReleases` change: behavior bug fix only, no category/severity change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved callback signature checking to match `ref`, `ref readonly`, and `scoped ref` parameters more reliably.
  * Reduced false positives by correctly interpreting multi-token ref modifiers.
  * Maintains accurate diagnostics when ref-kind expectations differ (e.g., `in` vs `scoped ref`).
* **Documentation**
  * Updated the Moq1100 rule documentation to clarify how callback ref-kind matching works, including multi-token modifier lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->