### PR TITLE
fix(Moq1302): bound recursion depth to prevent stack overflow (#1261)

### DIFF
--- a/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
@@ -8,6 +8,18 @@ namespace Moq.Analyzers;
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
 {
+    /// <summary>
+    /// Maximum recursion depth for lambda body analysis. Hand-written LINQ-to-Mocks predicates
+    /// nest well under 10 levels; 64 comfortably covers generated-but-plausible expressions while
+    /// bounding the walk to a trivial number of stack frames (two frames per level via the
+    /// AnalyzeLambdaBody/AnalyzeMemberOperations mutual recursion, so at most ~128 frames).
+    /// Mirrors the pathological-tree guard in InvocationExpressionSyntaxExtensions.FindSetupInvocation
+    /// (src/Common/InvocationExpressionSyntaxExtensions.cs, cap of 10), sized larger because
+    /// operation trees for boolean predicates legitimately nest deeper than fluent chains.
+    /// Operations beyond the cap are skipped: no crash, no diagnostic (accepted false negative).
+    /// </summary>
+    private static readonly int MaxAnalysisDepth = 64;
+
     private static readonly LocalizableString Title = "Moq: Invalid LINQ to Mocks expression";
     private static readonly LocalizableString Message = "Invalid member '{0}' in LINQ to Mocks expression";
     private static readonly LocalizableString Description = "LINQ to Mocks expression contains non-virtual member that cannot be mocked.";
@@ -90,14 +102,45 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
 
     private static void AnalyzeLambdaExpression(OperationAnalysisContext context, IAnonymousFunctionOperation lambdaOperation, MoqKnownSymbols knownSymbols)
     {
+        // Only report diagnostics if the lambda is semantically valid. Binding failures inside
+        // the lambda materialize as IInvalidOperation nodes; scanning the already-built operation
+        // tree replaces the previous SemanticModel.GetDiagnostics(span) call, which forced a full
+        // re-bind of the span for every member-reference candidate.
+        if (ContainsInvalidOperation(lambdaOperation))
+        {
+            return;
+        }
+
         // For LINQ to Mocks, we need to handle more complex expressions like: x => x.Property == "value"
         // The lambda body is often a binary expression where the left operand is the member we want to check
-        AnalyzeLambdaBody(context, lambdaOperation, lambdaOperation.Body, knownSymbols);
+        AnalyzeLambdaBody(context, lambdaOperation, lambdaOperation.Body, knownSymbols, depth: 0);
     }
 
-    private static void AnalyzeLambdaBody(OperationAnalysisContext context, IAnonymousFunctionOperation lambdaOperation, IOperation? body, MoqKnownSymbols knownSymbols)
+    private static bool ContainsInvalidOperation(IOperation root)
+    {
+        foreach (IOperation descendant in root.DescendantsAndSelf())
+        {
+            if (descendant.Kind == OperationKind.Invalid)
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static void AnalyzeLambdaBody(OperationAnalysisContext context, IAnonymousFunctionOperation lambdaOperation, IOperation? body, MoqKnownSymbols knownSymbols, int depth)
     {
         if (body == null)
+        {
+            return;
+        }
+
+        // Bound the AnalyzeLambdaBody <-> AnalyzeMemberOperations mutual recursion so
+        // machine-generated expressions with thousands of clauses cannot overflow the stack.
+        // A StackOverflowException here is uncatchable and would kill the host compiler/IDE
+        // process, so operations beyond the cap are skipped: no crash, no diagnostic.
+        if (depth > MaxAnalysisDepth)
         {
             return;
         }
@@ -106,20 +149,20 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
         {
             case IBlockOperation blockOp when blockOp.Operations.Length == 1:
                 // Handle block lambdas with return statements
-                AnalyzeLambdaBody(context, lambdaOperation, blockOp.Operations[0], knownSymbols);
+                AnalyzeLambdaBody(context, lambdaOperation, blockOp.Operations[0], knownSymbols, depth + 1);
                 break;
 
             case IReturnOperation returnOp:
                 // Handle return statements
-                AnalyzeLambdaBody(context, lambdaOperation, returnOp.ReturnedValue, knownSymbols);
+                AnalyzeLambdaBody(context, lambdaOperation, returnOp.ReturnedValue, knownSymbols, depth + 1);
                 break;
 
             case IBinaryOperation binaryOp:
                 // Analyze each operand independently. The IsRootedInLambdaParameter guard
                 // in AnalyzeMemberOperations filters out operands not rooted in the lambda
                 // parameter (e.g., static constants, enum values).
-                AnalyzeMemberOperations(context, lambdaOperation, binaryOp.LeftOperand, knownSymbols);
-                AnalyzeMemberOperations(context, lambdaOperation, binaryOp.RightOperand, knownSymbols);
+                AnalyzeMemberOperations(context, lambdaOperation, binaryOp.LeftOperand, knownSymbols, depth + 1);
+                AnalyzeMemberOperations(context, lambdaOperation, binaryOp.RightOperand, knownSymbols, depth + 1);
                 break;
 
             case IPropertyReferenceOperation propertyRef:
@@ -142,12 +185,16 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
                 // IsRootedInLambdaParameter guard. Calling AnalyzeLambdaBody directly would
                 // bypass the guard for operation kinds not enumerated above (e.g.,
                 // IConditionalOperation, ICoalesceOperation).
-                foreach (IOperation childOperation in body.ChildOperations)
-                {
-                    AnalyzeMemberOperations(context, lambdaOperation, childOperation, knownSymbols);
-                }
-
+                AnalyzeChildOperations(context, lambdaOperation, body, knownSymbols, depth + 1);
                 break;
+        }
+    }
+
+    private static void AnalyzeChildOperations(OperationAnalysisContext context, IAnonymousFunctionOperation lambdaOperation, IOperation body, MoqKnownSymbols knownSymbols, int depth)
+    {
+        foreach (IOperation childOperation in body.ChildOperations)
+        {
+            AnalyzeMemberOperations(context, lambdaOperation, childOperation, knownSymbols, depth);
         }
     }
 
@@ -171,7 +218,7 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// expressions that have their own lambda parameters.
     /// </para>
     /// </remarks>
-    private static void AnalyzeMemberOperations(OperationAnalysisContext context, IAnonymousFunctionOperation lambdaOperation, IOperation operation, MoqKnownSymbols knownSymbols)
+    private static void AnalyzeMemberOperations(OperationAnalysisContext context, IAnonymousFunctionOperation lambdaOperation, IOperation operation, MoqKnownSymbols knownSymbols, int depth)
     {
         // Don't recursively analyze nested Mock.Of calls to avoid false positives
         if (operation is IInvocationOperation invocation && IsValidMockOfInvocation(invocation, knownSymbols))
@@ -190,8 +237,9 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Recursively analyze the operation to find member references
-        AnalyzeLambdaBody(context, lambdaOperation, operation, knownSymbols);
+        // Recursively analyze the operation to find member references. The caller already
+        // incremented depth; AnalyzeLambdaBody is the single choke point that enforces the cap.
+        AnalyzeLambdaBody(context, lambdaOperation, operation, knownSymbols, depth);
     }
 
     private static void AnalyzeMemberSymbol(OperationAnalysisContext context, ISymbol memberSymbol, IAnonymousFunctionOperation lambdaOperation)
@@ -202,20 +250,19 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        // Only report diagnostics if the lambda is semantically valid (no compiler errors in the member access span)
-        Location? memberLocation = GetMemberReferenceLocation(lambdaOperation, memberSymbol, context.Operation.SemanticModel);
-        if (memberLocation == null)
+        // Don't flag members whose containing type failed to resolve (mid-edit code).
+        // Binding failures inside the lambda are already handled once, up front, by the
+        // ContainsInvalidOperation scan in AnalyzeLambdaExpression; this guard covers the
+        // narrower case of an unresolved containing type on the member symbol itself.
+        if (memberSymbol.ContainingType?.TypeKind == TypeKind.Error)
         {
             return;
         }
 
-        if (context.Operation.SemanticModel is not null)
+        Location? memberLocation = GetMemberReferenceLocation(lambdaOperation, memberSymbol, context.Operation.SemanticModel);
+        if (memberLocation == null)
         {
-            ImmutableArray<Diagnostic> diagnostics = context.Operation.SemanticModel.GetDiagnostics(memberLocation.SourceSpan, context.CancellationToken);
-            if (diagnostics.Any(d => d.Severity == DiagnosticSeverity.Error))
-            {
-                return;
-            }
+            return;
         }
 
         // Only report diagnostics for non-virtual, non-abstract, non-override members

--- a/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
@@ -145,6 +145,11 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
             return;
         }
 
+        DispatchLambdaBodyOperation(context, lambdaOperation, body, knownSymbols, depth);
+    }
+
+    private static void DispatchLambdaBodyOperation(OperationAnalysisContext context, IAnonymousFunctionOperation lambdaOperation, IOperation body, MoqKnownSymbols knownSymbols, int depth)
+    {
         switch (body)
         {
             case IBlockOperation blockOp when blockOp.Operations.Length == 1:

--- a/tests/Moq.Analyzers.Test/LinqToMocksExpressionShouldBeValidAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/LinqToMocksExpressionShouldBeValidAnalyzerTests.cs
@@ -1231,6 +1231,91 @@ public class LinqToMocksExpressionShouldBeValidAnalyzerTests(ITestOutputHelper o
     }
 
     [Fact]
+    public async Task ShouldReportAtExactDepthCap()
+    {
+        // Exact-boundary case for https://github.com/rjmurillo/moq.analyzers/issues/1261.
+        // A left-associative `||` chain nests the leftmost clause deepest (one level per `||`);
+        // expression lambdas add a synthesized block+return wrapper, so the deepest member of an
+        // N-clause chain lands at depth N+2. With 62 clauses that is exactly MaxAnalysisDepth (64);
+        // the guard is `depth > cap`, so depth 64 is still analyzed and the non-virtual member MUST
+        // be flagged. Verified empirically: the deepest clause is the last one reported at N=62 and
+        // is suppressed at N=63. A `>=` regression would suppress N=62 and fail this test.
+        // Only the leftmost clause references a non-virtual member, so its diagnostic location is
+        // unambiguous (the analyzer resolves member locations by symbol and returns the first match).
+        string[] clauses = new string[62];
+        clauses[0] = "{|Moq1302:c.NonVirtualProperty|} == \"v0\"";
+        for (int i = 1; i < clauses.Length; i++)
+        {
+            clauses[i] = "c.VirtualProperty == \"v" + i + "\"";
+        }
+
+        string expression = string.Join(" || ", clauses);
+
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+              using Moq;
+
+              public class ConcreteClass
+              {
+                  public virtual string VirtualProperty { get; set; }
+                  public string NonVirtualProperty { get; set; }
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      var mock = Mock.Of<ConcreteClass>(c => {{expression}});
+                  }
+              }
+              """,
+            ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
+    [Fact]
+    public async Task ShouldSuppressJustBeyondDepthCapButStillReportShallowMembers()
+    {
+        // Just-over-boundary case for https://github.com/rjmurillo/moq.analyzers/issues/1261.
+        // With 63 clauses the leftmost (deepest) member sits one past the cap, so it is suppressed
+        // (no markup on `NonVirtualDeep`). The rightmost clause is shallow and its non-virtual member
+        // (`NonVirtualShallow`) MUST still be flagged. This proves the cap suppresses only deep
+        // members, not the whole expression, and would fail if the guard regressed to `>=`.
+        // The deep and shallow members use distinct names so their diagnostic locations do not
+        // collide (the analyzer resolves member locations by symbol and returns the first match).
+        string[] clauses = new string[63];
+        clauses[0] = "c.NonVirtualDeep == \"v0\"";
+        for (int i = 1; i < clauses.Length - 1; i++)
+        {
+            clauses[i] = "c.VirtualProperty == \"v" + i + "\"";
+        }
+
+        clauses[clauses.Length - 1] = "{|Moq1302:c.NonVirtualShallow|} == \"v62\"";
+
+        string expression = string.Join(" || ", clauses);
+
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+              using Moq;
+
+              public class ConcreteClass
+              {
+                  public virtual string VirtualProperty { get; set; }
+                  public string NonVirtualDeep { get; set; }
+                  public string NonVirtualShallow { get; set; }
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      var mock = Mock.Of<ConcreteClass>(c => {{expression}});
+                  }
+              }
+              """,
+            ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
+    [Fact]
     public async Task ShouldBailSilentlyBeyondDepthCapWithoutCrashing()
     {
         // Regression for the stack-overflow crash in https://github.com/rjmurillo/moq.analyzers/issues/1261.

--- a/tests/Moq.Analyzers.Test/LinqToMocksExpressionShouldBeValidAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/LinqToMocksExpressionShouldBeValidAnalyzerTests.cs
@@ -1191,4 +1191,81 @@ public class LinqToMocksExpressionShouldBeValidAnalyzerTests(ITestOutputHelper o
             """,
             referenceAssemblyGroup);
     }
+
+    [Fact]
+    public async Task ShouldAnalyzeDeepButUnderCapExpression()
+    {
+        // Boundary case for https://github.com/rjmurillo/moq.analyzers/issues/1261.
+        // A left-associative `||` chain nests the leftmost clause deepest in the operation tree
+        // (one level per `||`). With 39 clauses the deepest clause sits well under
+        // MaxAnalysisDepth (64), so its non-virtual member must still be flagged. All shallower
+        // clauses reference a virtual member and must NOT be flagged.
+        string[] clauses = new string[39];
+        clauses[0] = "{|Moq1302:c.NonVirtualProperty|} == \"v0\"";
+        for (int i = 1; i < clauses.Length; i++)
+        {
+            clauses[i] = "c.VirtualProperty == \"v" + i + "\"";
+        }
+
+        string expression = string.Join(" || ", clauses);
+
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+              using Moq;
+
+              public class ConcreteClass
+              {
+                  public virtual string VirtualProperty { get; set; }
+                  public string NonVirtualProperty { get; set; }
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      var mock = Mock.Of<ConcreteClass>(c => {{expression}});
+                  }
+              }
+              """,
+            ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
+    [Fact]
+    public async Task ShouldBailSilentlyBeyondDepthCapWithoutCrashing()
+    {
+        // Regression for the stack-overflow crash in https://github.com/rjmurillo/moq.analyzers/issues/1261.
+        // A 499-clause `||` chain nests the leftmost clause ~499 levels deep, far beyond
+        // MaxAnalysisDepth (64). The depth guard stops the walk before reaching that clause, so the
+        // non-virtual member there produces NO diagnostic (accepted false negative) and, critically,
+        // the analyzer does not overflow the stack. Every clause the walk DOES reach is virtual, so
+        // the expected diagnostic count is zero.
+        string[] clauses = new string[499];
+        clauses[0] = "c.NonVirtualProperty == \"v0\"";
+        for (int i = 1; i < clauses.Length; i++)
+        {
+            clauses[i] = "c.VirtualProperty == \"v" + i + "\"";
+        }
+
+        string expression = string.Join(" || ", clauses);
+
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+              using Moq;
+
+              public class ConcreteClass
+              {
+                  public virtual string VirtualProperty { get; set; }
+                  public string NonVirtualProperty { get; set; }
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      var mock = Mock.Of<ConcreteClass>(c => {{expression}});
+                  }
+              }
+              """,
+            ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
 }

--- a/tests/Moq.Analyzers.Test/LinqToMocksExpressionShouldBeValidAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/LinqToMocksExpressionShouldBeValidAnalyzerTests.cs
@@ -1196,8 +1196,8 @@ public class LinqToMocksExpressionShouldBeValidAnalyzerTests(ITestOutputHelper o
     public async Task ShouldAnalyzeDeepButUnderCapExpression()
     {
         // Boundary case for https://github.com/rjmurillo/moq.analyzers/issues/1261.
-        // A left-associative `||` chain nests the leftmost clause deepest in the operation tree
-        // (one level per `||`). With 39 clauses the deepest clause sits well under
+        // A left-associative chain of boolean-or clauses nests the leftmost clause deepest in the
+        // operation tree, one level per operator. With 39 clauses the deepest clause sits well under
         // MaxAnalysisDepth (64), so its non-virtual member must still be flagged. All shallower
         // clauses reference a virtual member and must NOT be flagged.
         string[] clauses = new string[39];
@@ -1234,14 +1234,15 @@ public class LinqToMocksExpressionShouldBeValidAnalyzerTests(ITestOutputHelper o
     public async Task ShouldReportAtExactDepthCap()
     {
         // Exact-boundary case for https://github.com/rjmurillo/moq.analyzers/issues/1261.
-        // A left-associative `||` chain nests the leftmost clause deepest (one level per `||`);
-        // expression lambdas add a synthesized block+return wrapper, so the deepest member of an
-        // N-clause chain lands at depth N+2. With 62 clauses that is exactly MaxAnalysisDepth (64);
-        // the guard is `depth > cap`, so depth 64 is still analyzed and the non-virtual member MUST
-        // be flagged. Verified empirically: the deepest clause is the last one reported at N=62 and
-        // is suppressed at N=63. A `>=` regression would suppress N=62 and fail this test.
+        // In a left-associative chain of boolean-or clauses, the leftmost clause nests deepest,
+        // one level per operator. Expression lambdas also add a synthesized block-and-return
+        // wrapper worth two more levels, so with 62 clauses the deepest member lands at exactly
+        // MaxAnalysisDepth of 64. The guard skips operations strictly deeper than the cap, so a
+        // member sitting at the cap is still analyzed and its non-virtual member must be flagged.
+        // Verified empirically: the deepest clause is the last one reported at 62 clauses and is
+        // suppressed at 63. Tightening the guard to also skip the exact cap would break this test.
         // Only the leftmost clause references a non-virtual member, so its diagnostic location is
-        // unambiguous (the analyzer resolves member locations by symbol and returns the first match).
+        // unambiguous. The analyzer resolves member locations by symbol and returns the first match.
         string[] clauses = new string[62];
         clauses[0] = "{|Moq1302:c.NonVirtualProperty|} == \"v0\"";
         for (int i = 1; i < clauses.Length; i++)
@@ -1276,12 +1277,12 @@ public class LinqToMocksExpressionShouldBeValidAnalyzerTests(ITestOutputHelper o
     public async Task ShouldSuppressJustBeyondDepthCapButStillReportShallowMembers()
     {
         // Just-over-boundary case for https://github.com/rjmurillo/moq.analyzers/issues/1261.
-        // With 63 clauses the leftmost (deepest) member sits one past the cap, so it is suppressed
-        // (no markup on `NonVirtualDeep`). The rightmost clause is shallow and its non-virtual member
-        // (`NonVirtualShallow`) MUST still be flagged. This proves the cap suppresses only deep
-        // members, not the whole expression, and would fail if the guard regressed to `>=`.
+        // With 63 clauses the leftmost (deepest) member sits one level past the cap, so it is
+        // suppressed and the deep member carries no markup. The rightmost clause is shallow and its
+        // non-virtual member must still be flagged. This proves the cap suppresses only deep members,
+        // not the whole expression, and would fail if the guard also skipped members at the exact cap.
         // The deep and shallow members use distinct names so their diagnostic locations do not
-        // collide (the analyzer resolves member locations by symbol and returns the first match).
+        // collide. The analyzer resolves member locations by symbol and returns the first match.
         string[] clauses = new string[63];
         clauses[0] = "c.NonVirtualDeep == \"v0\"";
         for (int i = 1; i < clauses.Length - 1; i++)
@@ -1319,7 +1320,7 @@ public class LinqToMocksExpressionShouldBeValidAnalyzerTests(ITestOutputHelper o
     public async Task ShouldBailSilentlyBeyondDepthCapWithoutCrashing()
     {
         // Regression for the stack-overflow crash in https://github.com/rjmurillo/moq.analyzers/issues/1261.
-        // A 499-clause `||` chain nests the leftmost clause ~499 levels deep, far beyond
+        // A 499-clause boolean-or chain nests the leftmost clause about 499 levels deep, far beyond
         // MaxAnalysisDepth (64). The depth guard stops the walk before reaching that clause, so the
         // non-virtual member there produces NO diagnostic (accepted false negative) and, critically,
         // the analyzer does not overflow the stack. Every clause the walk DOES reach is virtual, so


### PR DESCRIPTION
## Summary

Fixes #1261. `LinqToMocksExpressionShouldBeValidAnalyzer` (Moq1302) walked the lambda operation tree with an unbounded `AnalyzeLambdaBody` <-> `AnalyzeMemberOperations` mutual recursion. A machine-generated `Mock.Of` predicate with thousands of chained clauses (`c.P == "a" || c.P == "b" || ...`) overflowed the stack. A `StackOverflowException` is uncatchable and kills the host compiler/IDE process.

## Changes

- **Depth cap.** Added `MaxAnalysisDepth = 64` and threaded a `depth` counter through the recursion. `AnalyzeLambdaBody` is the single choke point: past the cap it returns (no crash, no diagnostic; accepted false negative for pathological inputs). Mirrors the existing cap-of-10 guard in `InvocationExpressionSyntaxExtensions.FindSetupInvocation`, sized larger because boolean-predicate operation trees legitimately nest deeper than fluent chains.
- **Error suppression rework.** Replaced the per-candidate `SemanticModel.GetDiagnostics(span)` call (a full re-bind for every member-reference candidate) with one up-front `ContainsInvalidOperation` scan (`OperationKind.Invalid`) in `AnalyzeLambdaExpression`, plus a member-level `ContainingType.TypeKind == TypeKind.Error` guard.
  - **Behavior delta:** error suppression moves from **span-scoped** to **lambda-wide**. If any part of the lambda fails to bind, the analyzer now suppresses diagnostics for the whole lambda rather than just the erroring span. This is strictly more conservative (fewer false positives on mid-edit code) and removes repeated re-binding on the hot path.
- **Refactor.** Extracted `AnalyzeChildOperations` so `AnalyzeLambdaBody` stays under the 60-line cap (MA0051).

## Tests (positive / boundary)

- `ShouldAnalyzeDeepButUnderCapExpression`: 39-clause `||` chain. The leftmost clause is deepest in the operation tree (one level per `||`) but under the cap, so its non-virtual member is still flagged (`{|Moq1302:...|}`). Shallower clauses reference a virtual member and are not flagged.
- `ShouldBailSilentlyBeyondDepthCapWithoutCrashing`: 499-clause `||` chain. The deepest clause sits far beyond the cap, so the walk stops before reaching it: zero diagnostics, no stack overflow.
- Full `LinqToMocksExpressionShouldBeValid` suite: **166 passed**.

## Coverage

Block (line-rate) coverage of the reachable paths is complete (`AnalyzeMemberOperations`, `AnalyzeChildOperations` = 100%). The remaining uncovered lines are **defensive error-state guards** (`ContainsInvalidOperation` true-branch, `TypeKind.Error` guard, `body == null`, `memberLocation == null`, and the unreachable `default` symbol arm). Each requires `OperationKind.Invalid` / `TypeKind.Error` input, i.e. code that produces compiler errors, which the analyzer-test contract (`.github/instructions/csharp.instructions.md:13`) forbids. This matches the accepted-exclusion pattern used by the #1242 and #1262 fixes.

## Moq version compatibility

Behavior is unchanged for valid expressions across both reference sets. Tests run against `Net80WithNewMoq`; the analyzer targets netstandard2.0 / Roslyn 4.8 (`OperationKind.Invalid` and `DescendantsAndSelf()` are available there). No new rule, severity, or category change, so `AnalyzerReleases.Unshipped.md` is unchanged.

## Validation

- `dotnet format`: clean
- `dotnet build src/Analyzers`: succeeded, **0 warnings**
- `dotnet test --filter LinqToMocksExpressionShouldBeValid`: **166 passed**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analysis of deeply nested LINQ-to-Mocks expressions with a depth limit to prevent stack overflows and stop diagnostics beyond the cap.
  * Added early detection for invalid/incomplete expression bindings to avoid misleading diagnostics.
  * Reduced false positives by ignoring members whose containing type is in an error state.

* **Tests**
  * Added new analyzer boundary tests for under-cap, exact-cap, just-beyond-cap, and very deep expressions to ensure correct suppression and no crashes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->