### PR TITLE
fix(codefix): guard MockBehavior fixer against stale diagnostic shape (#1257)

### DIFF
--- a/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
+++ b/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
@@ -59,6 +59,15 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
             return _document;
         }
 
+        // Defense in depth: the edit properties attached to the diagnostic describe the argument-list
+        // shape the analyzer saw at analysis time. If the document changed between analysis and fix
+        // application (stale lightbulb), the resolved node may no longer match that shape. Return the
+        // original document instead of letting the argument rewriters throw.
+        if (!IsEditShapeValid())
+        {
+            return _document;
+        }
+
         SyntaxNode behavior = _behaviorType switch
         {
             BehaviorType.Loose => editor.Generator.MemberAccessExpression(knownSymbols.MockBehaviorLoose),
@@ -77,5 +86,33 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
 
         editor.ReplaceNode(_nodeToFix, newNode.WithAdditionalAnnotations(Simplifier.Annotation));
         return editor.GetChangedDocument();
+    }
+
+    /// <summary>
+    /// Validates that <see cref="_nodeToFix"/> is a node kind the argument rewriters understand
+    /// (invocation or object creation) and that <see cref="_position"/> is within range for the
+    /// requested edit against the node's current argument count.
+    /// </summary>
+    /// <returns><see langword="true"/> when the edit can be applied safely; otherwise <see langword="false"/>.</returns>
+    private bool IsEditShapeValid()
+    {
+        int argumentCount = _nodeToFix switch
+        {
+            InvocationExpressionSyntax invocation => invocation.ArgumentList.Arguments.Count,
+            BaseObjectCreationExpressionSyntax creation => creation.ArgumentList?.Arguments.Count ?? 0,
+            _ => -1,
+        };
+
+        if (argumentCount < 0)
+        {
+            return false;
+        }
+
+        return _editType switch
+        {
+            DiagnosticEditProperties.EditType.Insert => _position <= argumentCount,
+            DiagnosticEditProperties.EditType.Replace => _position < argumentCount,
+            _ => false,
+        };
     }
 }

--- a/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
+++ b/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
@@ -88,6 +88,23 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
         return editor.GetChangedDocument();
     }
 
+    private static bool ContainsMockBehaviorArgument(SemanticModel semanticModel, SeparatedSyntaxList<ArgumentSyntax> candidates, ISymbol mockBehaviorType)
+    {
+        foreach (ArgumentSyntax argument in candidates)
+        {
+            // Use the converted type, not the expression type, so an argument that binds to the
+            // MockBehavior parameter through an implicit conversion (for example the literal 0 or
+            // default) is still recognized as an explicit MockBehavior argument.
+            ITypeSymbol? argumentType = semanticModel.GetTypeInfo(argument.Expression).ConvertedType;
+            if (SymbolEqualityComparer.Default.Equals(argumentType, mockBehaviorType))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     /// <summary>
     /// Validates that the edit recorded on the diagnostic can be applied safely to the current node.
     /// Guards against a stale lightbulb where the document changed after analysis: the node must still
@@ -100,14 +117,7 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
     /// <returns><see langword="true"/> when the edit can be applied safely; otherwise <see langword="false"/>.</returns>
     private bool CanApplyEdit(SemanticModel semanticModel, ISymbol mockBehaviorType)
     {
-        SeparatedSyntaxList<ArgumentSyntax>? maybeArguments = _nodeToFix switch
-        {
-            InvocationExpressionSyntax invocation => invocation.ArgumentList.Arguments,
-            BaseObjectCreationExpressionSyntax creation => creation.ArgumentList?.Arguments ?? default(SeparatedSyntaxList<ArgumentSyntax>),
-            _ => null,
-        };
-
-        if (maybeArguments is not SeparatedSyntaxList<ArgumentSyntax> arguments)
+        if (!TryGetArgumentList(out SeparatedSyntaxList<ArgumentSyntax> arguments))
         {
             return false;
         }
@@ -119,26 +129,25 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
             // would duplicate it.
             DiagnosticEditProperties.EditType.Insert =>
                 _position <= arguments.Count
-                && !ContainsMockBehaviorArgument(arguments),
+                && !ContainsMockBehaviorArgument(semanticModel, arguments, mockBehaviorType),
             DiagnosticEditProperties.EditType.Replace => _position < arguments.Count,
             _ => false,
         };
+    }
 
-        bool ContainsMockBehaviorArgument(SeparatedSyntaxList<ArgumentSyntax> candidates)
+    private bool TryGetArgumentList(out SeparatedSyntaxList<ArgumentSyntax> arguments)
+    {
+        switch (_nodeToFix)
         {
-            foreach (ArgumentSyntax argument in candidates)
-            {
-                // Use the converted type, not the expression type, so an argument that binds to the
-                // MockBehavior parameter through an implicit conversion (for example the literal 0 or
-                // default) is still recognized as an explicit MockBehavior argument.
-                ITypeSymbol? argumentType = semanticModel.GetTypeInfo(argument.Expression).ConvertedType;
-                if (SymbolEqualityComparer.Default.Equals(argumentType, mockBehaviorType))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            case InvocationExpressionSyntax invocation:
+                arguments = invocation.ArgumentList.Arguments;
+                return true;
+            case BaseObjectCreationExpressionSyntax creation:
+                arguments = creation.ArgumentList?.Arguments ?? default;
+                return true;
+            default:
+                arguments = default;
+                return false;
         }
     }
 }

--- a/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
+++ b/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
@@ -128,7 +128,10 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
         {
             foreach (ArgumentSyntax argument in candidates)
             {
-                ITypeSymbol? argumentType = semanticModel.GetTypeInfo(argument.Expression).Type;
+                // Use the converted type, not the expression type, so an argument that binds to the
+                // MockBehavior parameter through an implicit conversion (for example the literal 0 or
+                // default) is still recognized as an explicit MockBehavior argument.
+                ITypeSymbol? argumentType = semanticModel.GetTypeInfo(argument.Expression).ConvertedType;
                 if (SymbolEqualityComparer.Default.Equals(argumentType, mockBehaviorType))
                 {
                     return true;

--- a/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
+++ b/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
@@ -62,8 +62,8 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
         // Defense in depth: the edit properties attached to the diagnostic describe the argument-list
         // shape the analyzer saw at analysis time. If the document changed between analysis and fix
         // application (stale lightbulb), the resolved node may no longer match that shape. Return the
-        // original document instead of letting the argument rewriters throw.
-        if (!IsEditShapeValid())
+        // original document instead of applying a wrong edit or letting the argument rewriters throw.
+        if (!CanApplyEdit(editor.SemanticModel, knownSymbols.MockBehavior))
         {
             return _document;
         }
@@ -89,30 +89,53 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
     }
 
     /// <summary>
-    /// Validates that <see cref="_nodeToFix"/> is a node kind the argument rewriters understand
-    /// (invocation or object creation) and that <see cref="_position"/> is within range for the
-    /// requested edit against the node's current argument count.
+    /// Validates that the edit recorded on the diagnostic can be applied safely to the current node.
+    /// Guards against a stale lightbulb where the document changed after analysis: the node must still
+    /// be an invocation or object creation, <see cref="_position"/> must be in range for the requested
+    /// edit, and an <see cref="DiagnosticEditProperties.EditType.Insert"/> must not duplicate a
+    /// <c>MockBehavior</c> argument the user added after the diagnostic was produced.
     /// </summary>
+    /// <param name="semanticModel">The semantic model used to resolve argument types.</param>
+    /// <param name="mockBehaviorType">The <c>MockBehavior</c> type symbol.</param>
     /// <returns><see langword="true"/> when the edit can be applied safely; otherwise <see langword="false"/>.</returns>
-    private bool IsEditShapeValid()
+    private bool CanApplyEdit(SemanticModel semanticModel, ISymbol mockBehaviorType)
     {
-        int argumentCount = _nodeToFix switch
+        SeparatedSyntaxList<ArgumentSyntax>? maybeArguments = _nodeToFix switch
         {
-            InvocationExpressionSyntax invocation => invocation.ArgumentList.Arguments.Count,
-            BaseObjectCreationExpressionSyntax creation => creation.ArgumentList?.Arguments.Count ?? 0,
-            _ => -1,
+            InvocationExpressionSyntax invocation => invocation.ArgumentList.Arguments,
+            BaseObjectCreationExpressionSyntax creation => creation.ArgumentList?.Arguments ?? default(SeparatedSyntaxList<ArgumentSyntax>),
+            _ => null,
         };
 
-        if (argumentCount < 0)
+        if (maybeArguments is not SeparatedSyntaxList<ArgumentSyntax> arguments)
         {
             return false;
         }
 
         return _editType switch
         {
-            DiagnosticEditProperties.EditType.Insert => _position <= argumentCount,
-            DiagnosticEditProperties.EditType.Replace => _position < argumentCount,
+            // Insert is emitted only when the MockBehavior parameter is defaulted (no explicit argument).
+            // If an explicit MockBehavior argument now exists, the diagnostic is stale; inserting another
+            // would duplicate it.
+            DiagnosticEditProperties.EditType.Insert =>
+                _position <= arguments.Count
+                && !ContainsMockBehaviorArgument(arguments),
+            DiagnosticEditProperties.EditType.Replace => _position < arguments.Count,
             _ => false,
         };
+
+        bool ContainsMockBehaviorArgument(SeparatedSyntaxList<ArgumentSyntax> candidates)
+        {
+            foreach (ArgumentSyntax argument in candidates)
+            {
+                ITypeSymbol? argumentType = semanticModel.GetTypeInfo(argument.Expression).Type;
+                if (SymbolEqualityComparer.Default.Equals(argumentType, mockBehaviorType))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
     }
 }

--- a/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
@@ -46,6 +46,23 @@ public class SetExplicitMockBehaviorFixerTests
         }
         """;
 
+    private static readonly string SourceWithImplicitBehavior = """
+        using Moq;
+
+        public interface ISample
+        {
+            void Method();
+        }
+
+        internal class UnitTest
+        {
+            private void Test()
+            {
+                var mock = new Mock<ISample>(0);
+            }
+        }
+        """;
+
     public static IEnumerable<object[]> StaleEditShapeData()
     {
         // EditType / EditPosition pairs that do NOT match `new Mock<ISample>()` (zero arguments):
@@ -109,6 +126,23 @@ public class SetExplicitMockBehaviorFixerTests
             .Single();
 
         await AssertFixerNoOpAsync(model, tree, creation.Span, SourceWithExplicitBehavior, "Insert", "0");
+    }
+
+    [Fact]
+    public async Task StaleInsert_WhenMockBehaviorSuppliedViaConversion_DoesNotDuplicate()
+    {
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(SourceWithImplicitBehavior);
+        SyntaxNode root = await tree.GetRootAsync();
+
+        // The user supplied the behavior as the literal 0, which binds to the MockBehavior parameter
+        // through an implicit conversion. The argument's expression type is int, but its converted
+        // type is MockBehavior, so the semantic check must still recognize it and no-op.
+        ObjectCreationExpressionSyntax creation = root
+            .DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Single();
+
+        await AssertFixerNoOpAsync(model, tree, creation.Span, SourceWithImplicitBehavior, "Insert", "0");
     }
 
     private static async Task AssertFixerNoOpAsync(SemanticModel model, SyntaxTree tree, TextSpan span, string sourceText, string editType, string editPosition)

--- a/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
@@ -29,6 +29,23 @@ public class SetExplicitMockBehaviorFixerTests
         }
         """;
 
+    private static readonly string SourceWithExplicitBehavior = """
+        using Moq;
+
+        public interface ISample
+        {
+            void Method();
+        }
+
+        internal class UnitTest
+        {
+            private void Test()
+            {
+                var mock = new Mock<ISample>(MockBehavior.Strict);
+            }
+        }
+        """;
+
     public static IEnumerable<object[]> StaleEditShapeData()
     {
         // EditType / EditPosition pairs that do NOT match `new Mock<ISample>()` (zero arguments):
@@ -55,7 +72,7 @@ public class SetExplicitMockBehaviorFixerTests
             .OfType<ObjectCreationExpressionSyntax>()
             .Single();
 
-        await AssertFixerNoOpAsync(model, tree, creation.Span, editType, editPosition);
+        await AssertFixerNoOpAsync(model, tree, creation.Span, Source, editType, editPosition);
     }
 
     [Fact]
@@ -73,10 +90,28 @@ public class SetExplicitMockBehaviorFixerTests
             .OfType<LocalDeclarationStatementSyntax>()
             .Single();
 
-        await AssertFixerNoOpAsync(model, tree, statement.Span, "Insert", "0");
+        await AssertFixerNoOpAsync(model, tree, statement.Span, Source, "Insert", "0");
     }
 
-    private static async Task AssertFixerNoOpAsync(SemanticModel model, SyntaxTree tree, TextSpan span, string editType, string editPosition)
+    [Fact]
+    public async Task StaleInsert_WhenMockBehaviorAlreadyPresent_DoesNotDuplicate()
+    {
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(SourceWithExplicitBehavior);
+        SyntaxNode root = await tree.GetRootAsync();
+
+        // Stale scenario where the diagnostic recorded Insert at position 0, but the user has since
+        // added an explicit MockBehavior argument. The node shape still admits an insert (position 0
+        // is in range), so only the semantic check can reject it; the fixer must no-op rather than
+        // insert a second MockBehavior argument.
+        ObjectCreationExpressionSyntax creation = root
+            .DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Single();
+
+        await AssertFixerNoOpAsync(model, tree, creation.Span, SourceWithExplicitBehavior, "Insert", "0");
+    }
+
+    private static async Task AssertFixerNoOpAsync(SemanticModel model, SyntaxTree tree, TextSpan span, string sourceText, string editType, string editPosition)
     {
         DiagnosticDescriptor descriptor = new(
             DiagnosticIds.SetExplicitMockBehavior,
@@ -95,7 +130,7 @@ public class SetExplicitMockBehaviorFixerTests
         using AdhocWorkspace workspace = new();
         Project project = workspace.AddProject("TestProject", LanguageNames.CSharp)
             .AddMetadataReferences(model.Compilation.References);
-        Document document = project.AddDocument("Test.cs", SourceText.From(Source));
+        Document document = project.AddDocument("Test.cs", SourceText.From(sourceText));
 
         List<CodeAction> actions = [];
         CodeFixContext context = new(

--- a/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
@@ -1,0 +1,124 @@
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Moq.Analyzers.Test;
+
+/// <summary>
+/// Direct unit tests for the stale-diagnostic guard in the MockBehavior code-fix pipeline.
+/// The standard analyzer/code-fix harness cannot reach this path because the analyzer always
+/// emits edit properties that match the node it analyzed; these tests simulate a diagnostic
+/// whose recorded edit shape no longer matches the document.
+/// </summary>
+public class SetExplicitMockBehaviorFixerTests
+{
+    private static readonly string Source = """
+        using Moq;
+
+        public interface ISample
+        {
+            void Method();
+        }
+
+        internal class UnitTest
+        {
+            private void Test()
+            {
+                var mock = new Mock<ISample>();
+            }
+        }
+        """;
+
+    public static IEnumerable<object[]> StaleEditShapeData()
+    {
+        // EditType / EditPosition pairs that do NOT match `new Mock<ISample>()` (zero arguments):
+        // Replace/0 exercises the empty-argument-list case; Replace/5 and Insert/5 exercise the
+        // out-of-range position checks. All must produce a graceful no-op instead of throwing.
+        return
+        [
+            ["Replace", "0"],
+            ["Replace", "5"],
+            ["Insert", "5"],
+        ];
+    }
+
+    [Theory]
+    [MemberData(nameof(StaleEditShapeData))]
+    public async Task StaleEditShape_DoesNotThrow_AndLeavesDocumentUnchanged(string editType, string editPosition)
+    {
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(Source);
+        SyntaxNode root = await tree.GetRootAsync();
+
+        // The diagnostic points at the object-creation node the analyzer would have flagged.
+        ObjectCreationExpressionSyntax creation = root
+            .DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Single();
+
+        await AssertFixerNoOpAsync(model, tree, creation.Span, editType, editPosition);
+    }
+
+    [Fact]
+    public async Task StaleNodeKind_NonInvocationOrCreation_DoesNotThrow_AndLeavesDocumentUnchanged()
+    {
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(Source);
+        SyntaxNode root = await tree.GetRootAsync();
+
+        // Stale scenario where the diagnostic span now resolves to a node the argument rewriters
+        // do not understand (the local declaration statement, not an invocation or object creation).
+        // The edit type and position are individually valid, so only the node-kind check can reject
+        // the edit; the fixer must no-op rather than attempt a rewrite.
+        LocalDeclarationStatementSyntax statement = root
+            .DescendantNodes()
+            .OfType<LocalDeclarationStatementSyntax>()
+            .Single();
+
+        await AssertFixerNoOpAsync(model, tree, statement.Span, "Insert", "0");
+    }
+
+    private static async Task AssertFixerNoOpAsync(SemanticModel model, SyntaxTree tree, TextSpan span, string editType, string editPosition)
+    {
+        DiagnosticDescriptor descriptor = new(
+            DiagnosticIds.SetExplicitMockBehavior,
+            "Test",
+            "Test message",
+            "Test",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty
+            .Add(DiagnosticEditProperties.EditTypeKey, editType)
+            .Add(DiagnosticEditProperties.EditPositionKey, editPosition);
+
+        Diagnostic diagnostic = Diagnostic.Create(descriptor, Location.Create(tree, span), properties);
+
+        using AdhocWorkspace workspace = new();
+        Project project = workspace.AddProject("TestProject", LanguageNames.CSharp)
+            .AddMetadataReferences(model.Compilation.References);
+        Document document = project.AddDocument("Test.cs", SourceText.From(Source));
+
+        List<CodeAction> actions = [];
+        CodeFixContext context = new(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        Moq.CodeFixes.SetExplicitMockBehaviorFixer fixer = new();
+        await fixer.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+
+        // The fixer registers two actions (Loose and Strict). Applying either must not throw and
+        // must leave the document unchanged, because the recorded edit shape does not match the node.
+        Assert.Equal(2, actions.Count);
+
+        string originalText = (await document.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString();
+        foreach (CodeAction action in actions)
+        {
+            ImmutableArray<CodeActionOperation> operations = await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+            ApplyChangesOperation applyChanges = Assert.Single(operations.OfType<ApplyChangesOperation>());
+            Document changedDocument = applyChanges.ChangedSolution.GetDocument(document.Id)!;
+            string changedText = (await changedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString();
+            Assert.Equal(originalText, changedText);
+        }
+    }
+}

--- a/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
@@ -178,7 +178,8 @@ public class SetExplicitMockBehaviorFixerTests
 
         // The fixer registers two actions (Loose and Strict). Applying either must not throw and
         // must leave the document unchanged, because the recorded edit shape does not match the node.
-        Assert.Equal(2, actions.Count);
+        const int expectedActionCount = 2;
+        Assert.Equal(expectedActionCount, actions.Count);
 
         string originalText = (await document.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString();
         foreach (CodeAction action in actions)


### PR DESCRIPTION
## Summary

Fixes part (a) of #1257: `SetExplicitMockBehaviorCodeAction.GetChangedDocumentAsync` applied the recorded edit (Insert/Replace argument) without checking that the resolved node still matched the shape the analyzer saw at analysis time. A stale lightbulb (document edited between analysis and fix application) could resolve to a non-invocation/creation node, or an out-of-range position, throwing from the argument rewriters.

Part (b) of #1257 (undefined `EditType`) already shipped in #1288.

## Change

- Add `IsEditShapeValid()` guard in `SetExplicitMockBehaviorCodeAction`. It validates the node kind (invocation / object-creation) and that `_position` is within the current argument count for the requested `EditType`. Returns the original document unchanged when the shape no longer matches, instead of letting the rewriters throw.

## Tests

New direct fixer unit tests (`SetExplicitMockBehaviorFixerTests`):
- `[Theory]` stale edit-shape rows (Replace/0 empty list, Replace/5 and Insert/5 out-of-range) against the object-creation node.
- `[Fact]` stale node-kind (diagnostic span resolves to a `LocalDeclarationStatementSyntax`, not an invocation/creation).

Both assert the fixer registers its two actions and applying either leaves the document unchanged (graceful no-op). The standard analyzer/code-fix harness cannot reach this path because the analyzer always emits edit properties matching the node it analyzed, so the tests synthesize the stale diagnostic directly.

Positive/negative/boundary coverage of `IsEditShapeValid`: node-kind mismatch, Insert range boundary, Replace range boundary. The `EditType` `_ => false` default is compiler-mandated switch-exhaustiveness and unreachable (EditType validated upstream in #1288); accepted exclusion.

## Validation

- `dotnet build ... /p:ContinuousIntegrationBuild=true` (PedanticMode): 0 warnings, 0 errors.
- `dotnet test --filter SetExplicitMockBehaviorFixer`: 4 passed.
- Behavior-only fix: no `docs/rules/` or `AnalyzerReleases` changes required.

## Moq version

No Moq API surface change; targets the same Moq versions as the existing fixer.

Related to #1257

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code action safety by validating that the diagnostic edit still matches the current code shape before applying changes.
  * Prevented fixes from running on unsupported/stale patterns, avoiding unintended document modifications.
  * For insert scenarios, now avoids adding a duplicate `MockBehavior` argument when it’s already present.

* **Tests**
  * Added/extended coverage for stale or mismatched diagnostics to ensure code actions no-op safely.
  * Confirmed applying the code actions leaves the document unchanged (no text changes, no exceptions), including duplicate-prevention cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->