### PR TITLE
fix(analyzers): eliminate Moq1202/Moq1204 EventHandler-shaped Raise/Raises false positives

### DIFF
--- a/docs/rules/Moq1202.md
+++ b/docs/rules/Moq1202.md
@@ -91,5 +91,17 @@ class Test
 
 - `Action` (no parameters)
 - `Action<T>`, `Action<T1, T2>`, etc. (generic Action delegates)
-- `EventHandler<T>` (expects single argument of type T)
+- `EventHandler` (accepts `EventArgs` only, because Moq supplies the sender)
+- `EventHandler<T>` where `T` derives from `EventArgs`
+- Custom `(object sender, TArgs e)` delegates where `TArgs` derives from `EventArgs`
 - Custom delegate types (analyzed via their Invoke method signature)
+
+For `EventHandler`-shaped delegates, both forms are valid:
+
+```csharp
+mock.Raise(p => p.Completed += null, EventArgs.Empty);
+mock.Raise(p => p.Completed += null, new object(), EventArgs.Empty);
+```
+
+In the first form, Moq supplies the sender. In the second form, you pass the
+full delegate argument list.

--- a/docs/rules/Moq1204.md
+++ b/docs/rules/Moq1204.md
@@ -99,8 +99,20 @@ class Test
 
 - `Action` (no parameters)
 - `Action<T>`, `Action<T1, T2>`, etc. (generic Action delegates)
-- `EventHandler<T>` (expects single argument of type T)
+- `EventHandler` (accepts `EventArgs` only, because Moq supplies the sender)
+- `EventHandler<T>` where `T` derives from `EventArgs`
+- Custom `(object sender, TArgs e)` delegates where `TArgs` derives from `EventArgs`
 - Custom delegate types (analyzed via their Invoke method signature)
+
+For `EventHandler`-shaped delegates, both forms are valid:
+
+```csharp
+mock.Setup(x => x.Submit()).Raises(x => x.Completed += null, EventArgs.Empty);
+mock.Setup(x => x.Submit()).Raises(x => x.Completed += null, new object(), EventArgs.Empty);
+```
+
+In the first form, Moq supplies the sender. In the second form, you pass the
+full delegate argument list.
 
 ## Compatibility
 

--- a/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -69,14 +69,14 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticAn
             return;
         }
 
-        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes))
+        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes, out bool senderCanBeOmitted))
         {
             return;
         }
 
         string eventName = EventSyntaxExtensions.GetEventNameFromSelector(invocation, context.SemanticModel);
 
-        context.ValidateEventArgumentTypes(eventArguments, expectedParameterTypes, invocation, Rule, eventName);
+        context.ValidateEventArgumentTypes(eventArguments, expectedParameterTypes, senderCanBeOmitted, knownSymbols.EventArgs, invocation, Rule, eventName);
     }
 
     private static bool IsRaiseMethodCall(SemanticModel semanticModel, InvocationExpressionSyntax invocation, MoqKnownSymbols knownSymbols)

--- a/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -71,13 +71,13 @@ public class RaisesEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticA
             return;
         }
 
-        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes))
+        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes, out bool senderCanBeOmitted))
         {
             return;
         }
 
         string eventName = EventSyntaxExtensions.GetEventNameFromSelector(invocation, context.SemanticModel);
 
-        context.ValidateEventArgumentTypes(eventArguments, expectedParameterTypes, invocation, Rule, eventName);
+        context.ValidateEventArgumentTypes(eventArguments, expectedParameterTypes, senderCanBeOmitted, knownSymbols.EventArgs, invocation, Rule, eventName);
     }
 }

--- a/src/Common/EventSyntaxExtensions.cs
+++ b/src/Common/EventSyntaxExtensions.cs
@@ -1,3 +1,5 @@
+using Microsoft.CodeAnalysis.Operations;
+
 namespace Moq.Analyzers.Common;
 
 /// <summary>
@@ -11,6 +13,15 @@ internal static class EventSyntaxExtensions
     /// <param name="context">The analysis context.</param>
     /// <param name="eventArguments">The event arguments to validate.</param>
     /// <param name="expectedParameterTypes">The expected parameter types.</param>
+    /// <param name="senderCanBeOmitted">
+    /// When <see langword="true"/>, the delegate is EventHandler-shaped and Moq supplies the sender,
+    /// so supplying one argument fewer than the parameter count (omitting the sender) is also valid.
+    /// </param>
+    /// <param name="eventArgsType">
+    /// The <see cref="System.EventArgs"/> symbol used to model Moq's sender-supplying overload when
+    /// <paramref name="senderCanBeOmitted"/> is <see langword="true"/>. May be <see langword="null"/>
+    /// when the sender cannot be omitted.
+    /// </param>
     /// <param name="invocation">The invocation expression for error reporting.</param>
     /// <param name="rule">The diagnostic rule to report.</param>
     /// <param name="eventName">The event name to include in diagnostic messages.</param>
@@ -18,11 +29,25 @@ internal static class EventSyntaxExtensions
         this SyntaxNodeAnalysisContext context,
         ArgumentSyntax[] eventArguments,
         ITypeSymbol[] expectedParameterTypes,
+        bool senderCanBeOmitted,
+        INamedTypeSymbol? eventArgsType,
         InvocationExpressionSyntax invocation,
         DiagnosticDescriptor rule,
         string? eventName = null)
     {
-        if (eventArguments.Length != expectedParameterTypes.Length)
+        int offset = 0;
+
+        // The sender may only be omitted when the EventArgs symbol is available to model Moq's
+        // sender-supplying overload. That symbol is a precondition of EventHandler-shaped detection,
+        // so this guard also keeps the offset == 1 path from dereferencing a null EventArgs type.
+        if (senderCanBeOmitted && eventArgsType != null && eventArguments.Length == expectedParameterTypes.Length - 1)
+        {
+            // Moq's Raise/Raises(..., EventArgs) overloads supply the mock object as the sender for
+            // EventHandler-shaped delegates. Validate the arguments against the post-sender parameters.
+            System.Diagnostics.Debug.Assert(expectedParameterTypes.Length > 0, "EventHandler-shaped delegates have a sender parameter.");
+            offset = 1;
+        }
+        else if (eventArguments.Length != expectedParameterTypes.Length)
         {
             Location location = eventArguments.Length < expectedParameterTypes.Length
                 ? invocation.GetLocation()
@@ -37,7 +62,30 @@ internal static class EventSyntaxExtensions
             TypeInfo argumentTypeInfo = context.SemanticModel.GetTypeInfo(eventArguments[i].Expression, context.CancellationToken);
             ITypeSymbol? argumentType = argumentTypeInfo.Type;
 
-            if (argumentType != null && !context.SemanticModel.HasConversion(argumentType, expectedParameterTypes[i]))
+            bool hasConversion;
+            if (argumentType == null)
+            {
+                // A null-typed argument (e.g. a bare null literal) is treated as convertible to any
+                // reference parameter, matching the prior behavior.
+                hasConversion = true;
+            }
+            else if (offset == 1)
+            {
+                System.Diagnostics.Debug.Assert(eventArgsType != null, "The omitted-sender path requires the EventArgs symbol.");
+                hasConversion = HasOmittedSenderConversion(
+                    context.SemanticModel,
+                    eventArguments[i].Expression,
+                    argumentType,
+                    eventArgsType!,
+                    expectedParameterTypes[i + offset],
+                    context.CancellationToken);
+            }
+            else
+            {
+                hasConversion = context.SemanticModel.HasConversion(argumentType, expectedParameterTypes[i]);
+            }
+
+            if (!hasConversion)
             {
                 context.ReportDiagnostic(CreateEventDiagnostic(eventArguments[i].GetLocation(), rule, eventName));
             }
@@ -45,33 +93,69 @@ internal static class EventSyntaxExtensions
     }
 
     /// <summary>
-    /// Gets the parameter types for a given event delegate type.
-    /// This method handles various delegate types including Action delegates, EventHandler delegates,
-    /// and custom delegates by analyzing their structure and extracting parameter information.
+    /// Attempts to get the parameter types for a given event delegate type.
     /// </summary>
     /// <param name="eventType">The event delegate type to analyze.</param>
     /// <param name="knownSymbols">Known symbols for type checking.</param>
+    /// <param name="expectedParameterTypes">
+    /// The parameter types expected by the event delegate:
+    /// - For <see cref="System.Action"/>/<see cref="System.Action{T}"/> delegates: all generic type arguments
+    /// - For all other delegates (including <see cref="System.EventHandler"/>, <see cref="System.EventHandler{T}"/>,
+    ///   and custom delegates): the full <c>Invoke</c> parameter list.
+    /// </param>
+    /// <param name="senderCanBeOmitted">
+    /// <see langword="true"/> when the delegate is "EventHandler-shaped" — its <c>Invoke</c> signature is exactly
+    /// <c>(object sender, TArgs e)</c> with <c>TArgs</c> being <see cref="System.EventArgs"/> or derived from it.
+    /// Moq's <c>Raise(..., EventArgs)</c>/<c>Raises(..., EventArgs)</c> overloads supply the mock object as the
+    /// sender for such delegates, so the sender argument may be omitted at the call site.
+    /// </param>
     /// <returns>
-    /// An array of parameter types expected by the event delegate:
-    /// - For <see cref="System.Action"/> delegates: Returns all generic type arguments
-    /// - For <see cref="System.EventHandler{T}"/> delegates: Returns the single generic argument <c>T</c>
-    /// - For custom delegates: Returns parameters from the <c>Invoke</c> method
-    /// - For non-delegate types: Returns an empty array.
+    /// <see langword="true"/> if the delegate signature could be analyzed; <see langword="false"/> for
+    /// unresolved (error) types, non-named types (e.g. type parameters), and non-delegate types.
     /// </returns>
-    internal static ITypeSymbol[] GetEventParameterTypes(ITypeSymbol eventType, KnownSymbols knownSymbols)
+    internal static bool TryGetEventParameterTypes(
+        ITypeSymbol eventType,
+        KnownSymbols knownSymbols,
+        out ITypeSymbol[] expectedParameterTypes,
+        out bool senderCanBeOmitted)
     {
-        if (eventType is not INamedTypeSymbol namedType)
+        expectedParameterTypes = [];
+        senderCanBeOmitted = false;
+
+        // Error types (mid-edit code) and non-named types (e.g. type parameters, arrays) cannot be
+        // analyzed. Report failure instead of pretending the delegate has zero parameters.
+        if (eventType.TypeKind == TypeKind.Error || eventType is not INamedTypeSymbol namedType)
         {
-            return [];
+            return false;
         }
 
-        // Try different delegate type handlers in order of specificity
-        ITypeSymbol[]? parameterTypes =
-            TryGetActionDelegateParameters(namedType, knownSymbols) ??
-            TryGetEventHandlerDelegateParameters(namedType, knownSymbols) ??
-            TryGetCustomDelegateParameters(namedType);
+        // System.Action / System.Action<T>: the type arguments are the parameters.
+        // NOTE: Action`2 and higher arities are intentionally resolved through the Invoke
+        // signature below, exactly as before (IsActionDelegate only matches Action and Action`1).
+        if (namedType.IsActionDelegate(knownSymbols))
+        {
+            expectedParameterTypes = namedType.TypeArguments.ToArray();
+            return true;
+        }
 
-        return parameterTypes ?? [];
+        // Any other delegate: read the Invoke signature.
+        IMethodSymbol? invokeMethod = namedType.DelegateInvokeMethod;
+        if (invokeMethod is null)
+        {
+            // Not a delegate type: unanalyzable.
+            return false;
+        }
+
+        ImmutableArray<IParameterSymbol> parameters = invokeMethod.Parameters;
+        ITypeSymbol[] types = new ITypeSymbol[parameters.Length];
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            types[i] = parameters[i].Type;
+        }
+
+        expectedParameterTypes = types;
+        senderCanBeOmitted = IsEventHandlerShaped(namedType, parameters, knownSymbols);
+        return true;
     }
 
     /// <summary>
@@ -81,6 +165,7 @@ internal static class EventSyntaxExtensions
     /// <param name="semanticModel">The semantic model.</param>
     /// <param name="eventArguments">The extracted event arguments.</param>
     /// <param name="expectedParameterTypes">The expected parameter types.</param>
+    /// <param name="senderCanBeOmitted">Whether the sender argument may be omitted (EventHandler-shaped delegates).</param>
     /// <param name="eventTypeExtractor">Function to extract event type from the event selector.</param>
     /// <param name="knownSymbols">Known symbols for type checking.</param>
     /// <returns><see langword="true" /> if arguments were successfully extracted; otherwise, <see langword="false" />.</returns>
@@ -89,11 +174,13 @@ internal static class EventSyntaxExtensions
         SemanticModel semanticModel,
         out ArgumentSyntax[] eventArguments,
         out ITypeSymbol[] expectedParameterTypes,
+        out bool senderCanBeOmitted,
         Func<SemanticModel, ExpressionSyntax, (bool Success, ITypeSymbol? EventType)> eventTypeExtractor,
         KnownSymbols knownSymbols)
     {
         eventArguments = [];
         expectedParameterTypes = [];
+        senderCanBeOmitted = false;
 
         SeparatedSyntaxList<ArgumentSyntax> arguments = invocation.ArgumentList.Arguments;
 
@@ -109,7 +196,12 @@ internal static class EventSyntaxExtensions
             return false;
         }
 
-        expectedParameterTypes = GetEventParameterTypes(eventType, knownSymbols);
+        if (!TryGetEventParameterTypes(eventType, knownSymbols, out expectedParameterTypes, out senderCanBeOmitted))
+        {
+            // The delegate type could not be analyzed (e.g. an error type in mid-edit code).
+            // Do not report diagnostics based on a guessed signature.
+            return false;
+        }
 
         if (arguments.Count > 1)
         {
@@ -132,19 +224,22 @@ internal static class EventSyntaxExtensions
     /// <param name="knownSymbols">Known symbols for type checking.</param>
     /// <param name="eventArguments">The extracted event arguments.</param>
     /// <param name="expectedParameterTypes">The expected parameter types.</param>
+    /// <param name="senderCanBeOmitted">Whether the sender argument may be omitted (EventHandler-shaped delegates).</param>
     /// <returns><see langword="true" /> if arguments were successfully extracted; otherwise, <see langword="false" />.</returns>
     internal static bool TryGetEventMethodArgumentsFromLambdaSelector(
         InvocationExpressionSyntax invocation,
         SemanticModel semanticModel,
         KnownSymbols knownSymbols,
         out ArgumentSyntax[] eventArguments,
-        out ITypeSymbol[] expectedParameterTypes)
+        out ITypeSymbol[] expectedParameterTypes,
+        out bool senderCanBeOmitted)
     {
         return TryGetEventMethodArguments(
             invocation,
             semanticModel,
             out eventArguments,
             out expectedParameterTypes,
+            out senderCanBeOmitted,
             static (sm, selector) =>
             {
                 bool success = sm.TryGetEventTypeFromLambdaSelector(selector, out ITypeSymbol? eventType);
@@ -191,52 +286,190 @@ internal static class EventSyntaxExtensions
     }
 
     /// <summary>
-    /// Attempts to get parameter types from Action delegate types.
+    /// Determines whether an omitted-sender payload is valid for Moq's sender-supplying overload.
     /// </summary>
-    /// <param name="namedType">The named type symbol to check.</param>
-    /// <param name="knownSymbols">Known symbols for type checking.</param>
-    /// <returns>Parameter types if this is an Action delegate; otherwise null.</returns>
-    private static ITypeSymbol[]? TryGetActionDelegateParameters(INamedTypeSymbol namedType, KnownSymbols knownSymbols)
+    /// <param name="semanticModel">The semantic model used for conversion classification.</param>
+    /// <param name="payloadExpression">The single payload argument expression.</param>
+    /// <param name="payloadType">The static type of the single payload argument.</param>
+    /// <param name="eventArgsType">The <see cref="System.EventArgs"/> symbol.</param>
+    /// <param name="delegateArgumentType">The delegate's post-sender parameter type.</param>
+    /// <param name="cancellationToken">A token to observe while resolving the payload operation.</param>
+    /// <returns><see langword="true"/> if the payload is valid; otherwise <see langword="false"/>.</returns>
+    private static bool HasOmittedSenderConversion(
+        SemanticModel semanticModel,
+        ExpressionSyntax payloadExpression,
+        ITypeSymbol payloadType,
+        INamedTypeSymbol eventArgsType,
+        ITypeSymbol delegateArgumentType,
+        CancellationToken cancellationToken)
     {
-        return namedType.IsActionDelegate(knownSymbols) ? namedType.TypeArguments.ToArray() : null;
+        // Overload selection: Moq's Raise/Raises(Action<T>, EventArgs) overload is chosen only when the
+        // payload is IMPLICITLY convertible to EventArgs. An explicit-only conversion (e.g. object to
+        // EventArgs) binds the params-object overload instead, so Moq never supplies the sender and the
+        // one-argument form throws at runtime. Report those cases.
+        if (!semanticModel.HasImplicitConversion(payloadType, eventArgsType))
+        {
+            return false;
+        }
+
+        // A user-defined conversion from the payload type to the EventArgs parameter runs its operator at
+        // the call site, so Moq receives an instance of the operator's return type, not the payload's own
+        // type. The exact runtime type is not statically known (the operator may return a subtype), so
+        // tolerate a reference or identity conversion from that return type to the delegate argument type.
+        if (semanticModel.TryGetUserDefinedConversionReturnType(payloadType, eventArgsType, out ITypeSymbol? convertedType))
+        {
+            System.Diagnostics.Debug.Assert(convertedType != null, "A user-defined conversion has a non-null operator return type.");
+            return semanticModel.HasReferenceOrIdentityConversion(convertedType!, delegateArgumentType);
+        }
+
+        // Runtime compatibility: once the sender-supplying overload is chosen, Moq casts the payload to
+        // the delegate's post-sender parameter type via reflection (a reference cast, never a user-defined
+        // conversion). When the payload's exact runtime type is statically known (an object-creation
+        // expression such as new EventArgs(), or the well-known System.EventArgs.Empty singleton), the cast
+        // succeeds only if that exact type is the delegate argument type or derives from it. A base
+        // EventArgs instance supplied for a derived-args delegate throws at runtime, so it is reported.
+        if (TryGetKnownExactType(semanticModel, payloadExpression, eventArgsType, cancellationToken, out ITypeSymbol? exactType))
+        {
+            System.Diagnostics.Debug.Assert(exactType != null, "A known-exact payload type is non-null.");
+            return IsOrDerivesFrom(exactType!, delegateArgumentType);
+        }
+
+        // Runtime type unknown (locals, parameters, properties, method results, casts): a base EventArgs
+        // value can legitimately hold a derived instance, so a reference downcast is tolerated (matching
+        // the full-argument path). User-defined conversions are excluded because Moq's reflection cast
+        // never invokes them. A payload with no reference conversion to the delegate argument type
+        // (e.g. an unrelated EventArgs subclass) can never bind and is reported.
+        return semanticModel.HasReferenceOrIdentityConversion(payloadType, delegateArgumentType);
     }
 
     /// <summary>
-    /// Attempts to get parameter types from EventHandler delegate types.
+    /// Attempts to resolve the payload's statically-known exact runtime type. This is possible only when
+    /// the payload is an object-creation expression (<c>new T(...)</c> constructs an instance of exactly
+    /// <c>T</c>) or the well-known <see cref="System.EventArgs.Empty"/> singleton (a base
+    /// <see cref="System.EventArgs"/> instance).
     /// </summary>
-    /// <param name="namedType">The named type symbol to check.</param>
-    /// <param name="knownSymbols">Known symbols for type checking.</param>
-    /// <returns>Parameter types if this is an EventHandler delegate; otherwise null.</returns>
-    private static ITypeSymbol[]? TryGetEventHandlerDelegateParameters(INamedTypeSymbol namedType, KnownSymbols knownSymbols)
+    /// <param name="semanticModel">The semantic model used to resolve the payload operation.</param>
+    /// <param name="payloadExpression">The payload argument expression.</param>
+    /// <param name="eventArgsType">The <see cref="System.EventArgs"/> symbol.</param>
+    /// <param name="cancellationToken">A token to observe while resolving the payload operation.</param>
+    /// <param name="exactType">The resolved exact runtime type, when known.</param>
+    /// <returns><see langword="true"/> when the exact runtime type is known; otherwise <see langword="false"/>.</returns>
+    private static bool TryGetKnownExactType(
+        SemanticModel semanticModel,
+        ExpressionSyntax payloadExpression,
+        INamedTypeSymbol eventArgsType,
+        CancellationToken cancellationToken,
+        out ITypeSymbol? exactType)
     {
-        if (namedType.IsEventHandlerDelegate(knownSymbols) && namedType.TypeArguments.Length > 0)
+        IOperation? operation = semanticModel.GetOperation(payloadExpression, cancellationToken);
+
+        // Reference and identity conversions (upcasts, downcasts, boxing) preserve object identity, so the
+        // wrapped expression's runtime type flows through unchanged. Unwrap them to inspect the underlying
+        // expression. A user-defined conversion is NOT unwrapped: it invokes an operator that constructs a
+        // new instance of the target type, so the operand's type is not the runtime type Moq receives.
+        while (operation is IConversionOperation conversion && conversion.OperatorMethod is null)
         {
-            return [namedType.TypeArguments[0]];
+            operation = conversion.Operand;
         }
 
-        return null;
+        // An object-creation expression constructs an instance of exactly its created type.
+        if (operation is IObjectCreationOperation creation && creation.Type != null)
+        {
+            exactType = creation.Type;
+            return true;
+        }
+
+        // System.EventArgs.Empty is a base EventArgs singleton.
+        if (operation is IFieldReferenceOperation fieldReference && IsEventArgsEmptyField(fieldReference.Field, eventArgsType))
+        {
+            exactType = eventArgsType;
+            return true;
+        }
+
+        exactType = null;
+        return false;
     }
 
     /// <summary>
-    /// Attempts to get parameter types from custom delegate types using the Invoke method.
+    /// Determines whether a field symbol is the well-known <see cref="System.EventArgs.Empty"/> field.
     /// </summary>
-    /// <param name="namedType">The named type symbol to check.</param>
-    /// <returns>Parameter types if this has a delegate Invoke method; otherwise null.</returns>
-    private static ITypeSymbol[]? TryGetCustomDelegateParameters(INamedTypeSymbol namedType)
+    /// <param name="field">The field symbol to test.</param>
+    /// <param name="eventArgsType">The <see cref="System.EventArgs"/> symbol.</param>
+    /// <returns><see langword="true"/> when the field is <see cref="System.EventArgs.Empty"/>; otherwise <see langword="false"/>.</returns>
+    private static bool IsEventArgsEmptyField(IFieldSymbol field, INamedTypeSymbol eventArgsType)
     {
-        IMethodSymbol? invokeMethod = namedType.DelegateInvokeMethod;
-        if (invokeMethod is null)
+        foreach (ISymbol member in eventArgsType.GetMembers("Empty"))
         {
-            return null;
+            if (member is IFieldSymbol && SymbolEqualityComparer.Default.Equals(member, field))
+            {
+                return true;
+            }
         }
 
-        ImmutableArray<IParameterSymbol> parameters = invokeMethod.Parameters;
-        ITypeSymbol[] types = new ITypeSymbol[parameters.Length];
-        for (int i = 0; i < parameters.Length; i++)
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a type is the specified base type or derives from it.
+    /// </summary>
+    /// <param name="type">The type to test.</param>
+    /// <param name="baseType">The candidate base type.</param>
+    /// <returns><see langword="true"/> when <paramref name="type"/> is or derives from <paramref name="baseType"/>; otherwise <see langword="false"/>.</returns>
+    private static bool IsOrDerivesFrom(ITypeSymbol type, ITypeSymbol baseType)
+    {
+        foreach (ITypeSymbol current in type.GetBaseTypesAndThis())
         {
-            types[i] = parameters[i].Type;
+            if (SymbolEqualityComparer.Default.Equals(current, baseType))
+            {
+                return true;
+            }
         }
 
-        return types;
+        return false;
+    }
+
+    /// <summary>
+    /// Determines whether a delegate is "EventHandler-shaped": <c>(object sender, TArgs e)</c> with
+    /// <c>TArgs</c> being <see cref="System.EventArgs"/> or derived from it. Moq's
+    /// <c>Raise(Action{T}, EventArgs)</c> and <c>Raises(Action{T}, EventArgs)</c> overloads invoke such
+    /// delegates as <c>handler(mock.Object, args)</c>, so the sender argument may be omitted by callers.
+    /// </summary>
+    /// <param name="namedType">The delegate type.</param>
+    /// <param name="invokeParameters">The delegate's <c>Invoke</c> parameters.</param>
+    /// <param name="knownSymbols">Known symbols for type checking.</param>
+    /// <returns><see langword="true"/> if the delegate is EventHandler-shaped; otherwise <see langword="false"/>.</returns>
+    private static bool IsEventHandlerShaped(
+        INamedTypeSymbol namedType,
+        ImmutableArray<IParameterSymbol> invokeParameters,
+        KnownSymbols knownSymbols)
+    {
+        // Fast path: the non-generic System.EventHandler delegate itself.
+        if (knownSymbols.EventHandler is not null
+            && SymbolEqualityComparer.Default.Equals(namedType, knownSymbols.EventHandler))
+        {
+            return true;
+        }
+
+        if (invokeParameters.Length != 2
+            || invokeParameters[0].Type.SpecialType != SpecialType.System_Object)
+        {
+            return false;
+        }
+
+        INamedTypeSymbol? eventArgsType = knownSymbols.EventArgs;
+        if (eventArgsType is null)
+        {
+            return false;
+        }
+
+        foreach (ITypeSymbol baseType in invokeParameters[1].Type.GetBaseTypesAndThis())
+        {
+            if (SymbolEqualityComparer.Default.Equals(baseType, eventArgsType))
+            {
+                return true;
+            }
+        }
+
+        return false;
     }
 }

--- a/src/Common/SemanticModelExtensions.cs
+++ b/src/Common/SemanticModelExtensions.cs
@@ -103,6 +103,57 @@ internal static class SemanticModelExtensions
     }
 
     /// <summary>
+    /// Determines if an implicit or identity conversion exists between two types.
+    /// </summary>
+    /// <param name="semanticModel">The semantic model to use for classification.</param>
+    /// <param name="source">The source type symbol.</param>
+    /// <param name="destination">The destination type symbol.</param>
+    /// <returns><see langword="true"/> if an implicit or identity conversion exists; otherwise, <see langword="false"/>.</returns>
+    internal static bool HasImplicitConversion(this SemanticModel semanticModel, ITypeSymbol source, ITypeSymbol destination)
+    {
+        Microsoft.CodeAnalysis.CSharp.Conversion conversion = semanticModel.Compilation.ClassifyConversion(source, destination);
+        return conversion.Exists && (conversion.IsImplicit || conversion.IsIdentity);
+    }
+
+    /// <summary>
+    /// Determines if an identity or reference conversion exists between two types. Reference conversions
+    /// are the only conversions a runtime cast performs, so user-defined and boxing conversions are
+    /// excluded.
+    /// </summary>
+    /// <param name="semanticModel">The semantic model to use for classification.</param>
+    /// <param name="source">The source type symbol.</param>
+    /// <param name="destination">The destination type symbol.</param>
+    /// <returns><see langword="true"/> if an identity or reference conversion exists; otherwise, <see langword="false"/>.</returns>
+    internal static bool HasReferenceOrIdentityConversion(this SemanticModel semanticModel, ITypeSymbol source, ITypeSymbol destination)
+    {
+        Microsoft.CodeAnalysis.CSharp.Conversion conversion = semanticModel.Compilation.ClassifyConversion(source, destination);
+        return conversion.Exists && (conversion.IsIdentity || conversion.IsReference);
+    }
+
+    /// <summary>
+    /// Determines whether the conversion from <paramref name="source"/> to <paramref name="destination"/>
+    /// is user-defined and, if so, returns the conversion operator's return type. A user-defined conversion
+    /// runs its operator at the call site, producing a new instance of the operator's return type.
+    /// </summary>
+    /// <param name="semanticModel">The semantic model to use for classification.</param>
+    /// <param name="source">The source type symbol.</param>
+    /// <param name="destination">The destination type symbol.</param>
+    /// <param name="returnType">The conversion operator's return type, when the conversion is user-defined.</param>
+    /// <returns><see langword="true"/> when the conversion is user-defined; otherwise, <see langword="false"/>.</returns>
+    internal static bool TryGetUserDefinedConversionReturnType(this SemanticModel semanticModel, ITypeSymbol source, ITypeSymbol destination, out ITypeSymbol? returnType)
+    {
+        Microsoft.CodeAnalysis.CSharp.Conversion conversion = semanticModel.Compilation.ClassifyConversion(source, destination);
+        if (conversion.Exists && conversion.IsUserDefined && conversion.MethodSymbol is not null)
+        {
+            returnType = conversion.MethodSymbol.ReturnType;
+            return true;
+        }
+
+        returnType = null;
+        return false;
+    }
+
+    /// <summary>
     /// Extracts the event name from a lambda selector of the form: x => x.EventName += null.
     /// </summary>
     /// <param name="semanticModel">The semantic model.</param>

--- a/src/Common/WellKnown/KnownSymbols.cs
+++ b/src/Common/WellKnown/KnownSymbols.cs
@@ -48,6 +48,16 @@ internal class KnownSymbols
     internal INamedTypeSymbol? EventHandler1 => TypeProvider.GetOrCreateTypeByMetadataName("System.EventHandler`1");
 
     /// <summary>
+    /// Gets the delegate <see cref="System.EventHandler"/> (the non-generic form).
+    /// </summary>
+    internal INamedTypeSymbol? EventHandler => TypeProvider.GetOrCreateTypeByMetadataName("System.EventHandler");
+
+    /// <summary>
+    /// Gets the class <see cref="System.EventArgs"/>.
+    /// </summary>
+    internal INamedTypeSymbol? EventArgs => TypeProvider.GetOrCreateTypeByMetadataName("System.EventArgs");
+
+    /// <summary>
     /// Gets the class <see cref="System.Threading.Tasks.ValueTask{T}"/>.
     /// </summary>
     internal INamedTypeSymbol? ValueTask1 => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.ValueTask`1");

--- a/tests/Moq.Analyzers.Test/Common/EventSyntaxExtensionsTests.cs
+++ b/tests/Moq.Analyzers.Test/Common/EventSyntaxExtensionsTests.cs
@@ -152,40 +152,56 @@ public class EventSyntaxExtensionsTests
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 
-    [Theory]
-    [InlineData("using System;\nclass C { event Action<double> MyEvent; }", "double")]
-    [InlineData("using System;\nclass C { event EventHandler<EventArgs> MyEvent; }", "System.EventArgs")]
-    public void GetEventParameterTypes_SingleTypeArgDelegate_ReturnsSingleType(
-        string code,
-        string expectedTypeName)
+    [Fact]
+    public void TryGetEventParameterTypes_ActionOfT_ReturnsSingleTypeWithoutOptionalSender()
     {
-        (ITypeSymbol eventType, KnownSymbols knownSymbols) = GetEventFieldTypeWithKnownSymbols(code, "MyEvent");
+        (ITypeSymbol eventType, KnownSymbols knownSymbols) = GetEventFieldTypeWithKnownSymbols(
+            "using System;\nclass C { event Action<double> MyEvent; }", "MyEvent");
 
-        ITypeSymbol[] result = EventSyntaxExtensions.GetEventParameterTypes(eventType, knownSymbols);
+        bool success = EventSyntaxExtensions.TryGetEventParameterTypes(eventType, knownSymbols, out ITypeSymbol[] result, out bool senderCanBeOmitted);
 
+        Assert.True(success);
         Assert.Single(result);
-        Assert.Equal(expectedTypeName, result[0].ToDisplayString());
+        Assert.Equal("double", result[0].ToDisplayString());
+        Assert.False(senderCanBeOmitted);
+    }
+
+    [Fact]
+    public void TryGetEventParameterTypes_GenericEventHandler_ReturnsInvokeParamsWithOptionalSender()
+    {
+        (ITypeSymbol eventType, KnownSymbols knownSymbols) = GetEventFieldTypeWithKnownSymbols(
+            "using System;\nclass C { event EventHandler<EventArgs> MyEvent; }", "MyEvent");
+
+        bool success = EventSyntaxExtensions.TryGetEventParameterTypes(eventType, knownSymbols, out ITypeSymbol[] result, out bool senderCanBeOmitted);
+
+        Assert.True(success);
+        Assert.Equal(2, result.Length);
+        Assert.Contains("object", result[0].ToDisplayString(), StringComparison.Ordinal);
+        Assert.Equal("System.EventArgs", result[1].ToDisplayString());
+        Assert.True(senderCanBeOmitted);
     }
 
     [Theory]
     [InlineData("using System;\nclass C { event Action<int, string> MyEvent; }", "int", "string")]
     [InlineData("delegate void MyDelegate(int x, bool y);\nclass C { event MyDelegate MyEvent; }", "int", "bool")]
-    public void GetEventParameterTypes_MultiParamDelegate_ReturnsAllParameterTypes(
+    public void TryGetEventParameterTypes_MultiParamDelegate_ReturnsAllParameterTypes(
         string code,
         string expectedFirst,
         string expectedSecond)
     {
         (ITypeSymbol eventType, KnownSymbols knownSymbols) = GetEventFieldTypeWithKnownSymbols(code, "MyEvent");
 
-        ITypeSymbol[] result = EventSyntaxExtensions.GetEventParameterTypes(eventType, knownSymbols);
+        bool success = EventSyntaxExtensions.TryGetEventParameterTypes(eventType, knownSymbols, out ITypeSymbol[] result, out bool senderCanBeOmitted);
 
+        Assert.True(success);
         Assert.Equal(2, result.Length);
         Assert.Equal(expectedFirst, result[0].ToDisplayString());
         Assert.Equal(expectedSecond, result[1].ToDisplayString());
+        Assert.False(senderCanBeOmitted);
     }
 
     [Fact]
-    public void GetEventParameterTypes_CustomDelegateNoParameters_ReturnsEmpty()
+    public void TryGetEventParameterTypes_CustomDelegateNoParameters_ReturnsEmpty()
     {
         const string code = @"
 delegate void MyDelegate();
@@ -195,13 +211,15 @@ class C
 }";
         (ITypeSymbol eventType, KnownSymbols knownSymbols) = GetEventFieldTypeWithKnownSymbols(code, "MyEvent");
 
-        ITypeSymbol[] result = EventSyntaxExtensions.GetEventParameterTypes(eventType, knownSymbols);
+        bool success = EventSyntaxExtensions.TryGetEventParameterTypes(eventType, knownSymbols, out ITypeSymbol[] result, out bool senderCanBeOmitted);
 
+        Assert.True(success);
         Assert.Empty(result);
+        Assert.False(senderCanBeOmitted);
     }
 
     [Fact]
-    public void GetEventParameterTypes_NonNamedTypeSymbol_ReturnsEmpty()
+    public void TryGetEventParameterTypes_NonNamedTypeSymbol_ReturnsFalse()
     {
         const string code = @"
 class C
@@ -217,13 +235,39 @@ class C
 
         Assert.IsNotAssignableFrom<INamedTypeSymbol>(arrayType);
 
-        ITypeSymbol[] result = EventSyntaxExtensions.GetEventParameterTypes(arrayType, knownSymbols);
+        bool success = EventSyntaxExtensions.TryGetEventParameterTypes(arrayType, knownSymbols, out ITypeSymbol[] result, out bool senderCanBeOmitted);
 
+        Assert.False(success);
         Assert.Empty(result);
+        Assert.False(senderCanBeOmitted);
     }
 
     [Fact]
-    public void GetEventParameterTypes_PlainEventHandler_ReturnsFallbackInvokeParams()
+    public void TryGetEventParameterTypes_NonDelegateNamedType_ReturnsFalse()
+    {
+        const string code = @"
+class C
+{
+    string Field;
+}";
+        (SemanticModel model, SyntaxTree tree) = CompilationHelper.CreateCompilation(code);
+        KnownSymbols knownSymbols = new KnownSymbols(model.Compilation);
+        VariableDeclaratorSyntax fieldSyntax = tree.GetRoot()
+            .DescendantNodes().OfType<VariableDeclaratorSyntax>().First();
+        IFieldSymbol field = (IFieldSymbol)model.GetDeclaredSymbol(fieldSyntax)!;
+        ITypeSymbol stringType = field.Type;
+
+        Assert.IsAssignableFrom<INamedTypeSymbol>(stringType);
+
+        bool success = EventSyntaxExtensions.TryGetEventParameterTypes(stringType, knownSymbols, out ITypeSymbol[] result, out bool senderCanBeOmitted);
+
+        Assert.False(success);
+        Assert.Empty(result);
+        Assert.False(senderCanBeOmitted);
+    }
+
+    [Fact]
+    public void TryGetEventParameterTypes_PlainEventHandler_ReturnsInvokeParamsWithOptionalSender()
     {
         const string code = @"
 using System;
@@ -233,11 +277,28 @@ class C
 }";
         (ITypeSymbol eventType, KnownSymbols knownSymbols) = GetEventFieldTypeWithKnownSymbols(code, "MyEvent");
 
-        ITypeSymbol[] result = EventSyntaxExtensions.GetEventParameterTypes(eventType, knownSymbols);
+        bool success = EventSyntaxExtensions.TryGetEventParameterTypes(eventType, knownSymbols, out ITypeSymbol[] result, out bool senderCanBeOmitted);
 
+        Assert.True(success);
         Assert.Equal(2, result.Length);
         Assert.Contains("object", result[0].ToDisplayString(), StringComparison.Ordinal);
         Assert.Contains("EventArgs", result[1].ToDisplayString(), StringComparison.Ordinal);
+        Assert.True(senderCanBeOmitted);
+    }
+
+    [Fact]
+    public void TryGetEventParameterTypes_ErrorType_ReturnsFalse()
+    {
+        (ITypeSymbol eventType, KnownSymbols knownSymbols) = GetEventFieldTypeWithKnownSymbols(
+            "class C { event UnresolvedDelegateType MyEvent; }", "MyEvent");
+
+        Assert.Equal(TypeKind.Error, eventType.TypeKind);
+
+        bool success = EventSyntaxExtensions.TryGetEventParameterTypes(eventType, knownSymbols, out ITypeSymbol[] result, out bool senderCanBeOmitted);
+
+        Assert.False(success);
+        Assert.Empty(result);
+        Assert.False(senderCanBeOmitted);
     }
 
     [Fact]
@@ -262,12 +323,14 @@ class C
             model,
             out ArgumentSyntax[] eventArguments,
             out ITypeSymbol[] expectedParameterTypes,
+            out bool senderCanBeOmitted,
             (_, _) => (true, null),
             knownSymbols);
 
         Assert.False(result);
         Assert.Empty(eventArguments);
         Assert.Empty(expectedParameterTypes);
+        Assert.False(senderCanBeOmitted);
     }
 
     [Fact]
@@ -292,12 +355,14 @@ class C
             model,
             out ArgumentSyntax[] eventArguments,
             out ITypeSymbol[] expectedParameterTypes,
+            out bool senderCanBeOmitted,
             (_, _) => (false, null),
             knownSymbols);
 
         Assert.False(result);
         Assert.Empty(eventArguments);
         Assert.Empty(expectedParameterTypes);
+        Assert.False(senderCanBeOmitted);
     }
 
     [Fact]
@@ -322,12 +387,14 @@ class C
             model,
             out ArgumentSyntax[] eventArguments,
             out ITypeSymbol[] expectedParameterTypes,
+            out bool senderCanBeOmitted,
             (_, _) => (true, null),
             knownSymbols);
 
         Assert.False(result);
         Assert.Empty(eventArguments);
         Assert.Empty(expectedParameterTypes);
+        Assert.False(senderCanBeOmitted);
     }
 
     [Fact]
@@ -360,6 +427,7 @@ class C { event MyDelegate MyEvent; }",
             model,
             out ArgumentSyntax[] eventArguments,
             out ITypeSymbol[] expectedParameterTypes,
+            out bool senderCanBeOmitted,
             (_, _) => (true, delegateType),
             knownSymbols);
 
@@ -367,6 +435,7 @@ class C { event MyDelegate MyEvent; }",
         Assert.Empty(eventArguments);
         Assert.Single(expectedParameterTypes);
         Assert.Equal("int", expectedParameterTypes[0].ToDisplayString());
+        Assert.False(senderCanBeOmitted);
     }
 
     [Fact]
@@ -397,12 +466,14 @@ class C { event MyDelegate MyEvent; }",
             model,
             out ArgumentSyntax[] eventArguments,
             out ITypeSymbol[] expectedParameterTypes,
+            out bool senderCanBeOmitted,
             (_, _) => (true, delegateType),
             knownSymbols);
 
         Assert.True(result);
         Assert.Equal(2, eventArguments.Length);
         Assert.Equal(2, expectedParameterTypes.Length);
+        Assert.False(senderCanBeOmitted);
     }
 
     [Fact]

--- a/tests/Moq.Analyzers.Test/RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis.Testing;
 using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.RaiseEventArgumentsShouldMatchEventSignatureAnalyzer>;
 
 namespace Moq.Analyzers.Test;
@@ -52,6 +53,140 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests
 
             // Invalid: Wrong argument type
             ["""mock.Raise(n => n.CustomEvent += null, {|Moq1202:"wrong"|});"""],
+        }.WithNamespaces().WithMoqReferenceAssemblyGroups();
+    }
+
+    public static IEnumerable<object[]> EventHandlerShapedTestData()
+    {
+        return new object[][]
+        {
+            // Canonical Moq pattern for non-generic EventHandler: Moq supplies the sender.
+            ["""mock.Raise(n => n.Closed += null, EventArgs.Empty);"""],
+
+            // A derived EventArgs is implicitly convertible to the base EventHandler parameter, so the
+            // statically-known exact runtime type upcasts cleanly.
+            ["""mock.Raise(n => n.Closed += null, new CustomEventArgs());"""],
+
+            // Two-argument form binds Raise(..., params object[]) and is also legal.
+            ["""mock.Raise(n => n.Closed += null, new object(), EventArgs.Empty);"""],
+
+            // Two-argument form with a null-typed sender argument is legal (null binds to any reference).
+            ["""mock.Raise(n => n.Closed += null, null, EventArgs.Empty);"""],
+
+            // EventHandler<CustomEventArgs>: args-only form (existing behavior).
+            ["""mock.Raise(n => n.CustomEvent += null, new CustomEventArgs());"""],
+
+            // EventHandler<CustomEventArgs>: two-argument form (previously a false positive).
+            ["""mock.Raise(n => n.CustomEvent += null, new object(), new CustomEventArgs());"""],
+
+            // Custom (object sender, TArgs e) delegate: both forms are legal.
+            ["""mock.Raise(n => n.ShapedEvent += null, new CustomEventArgs());"""],
+            ["""mock.Raise(n => n.ShapedEvent += null, new object(), new CustomEventArgs());"""],
+
+            // Invalid: payload not convertible to EventArgs.
+            ["""mock.Raise(n => n.Closed += null, {|Moq1202:42|});"""],
+
+            // Invalid: object payload is only EXPLICITLY convertible to EventArgs. Overload resolution
+            // binds the params-object array overload instead of the EventArgs overload, so Moq does not
+            // supply the sender and the one-argument form throws at runtime and must be flagged.
+            ["""mock.Raise(n => n.Closed += null, {|Moq1202:new object()|});"""],
+
+            // Invalid: an unrelated EventArgs subclass has no conversion to the CustomEventArgs delegate
+            // parameter, so Moq cannot bind it even though it selects the sender-supplying overload.
+            ["""mock.Raise(n => n.CustomEvent += null, {|Moq1202:new OtherEventArgs()|});"""],
+
+            // Invalid: EventArgs.Empty is a base EventArgs singleton. Moq selects the sender-supplying
+            // overload, then casts the payload to CustomEventArgs at runtime and throws because the exact
+            // runtime type is System.EventArgs. The exact type is statically known, so it is flagged.
+            ["""mock.Raise(n => n.CustomEvent += null, {|Moq1202:EventArgs.Empty|});"""],
+
+            // Invalid: a freshly constructed base EventArgs has a statically-known exact runtime type that
+            // cannot be cast to the derived CustomEventArgs delegate parameter.
+            ["""mock.Raise(n => n.CustomEvent += null, {|Moq1202:new EventArgs()|});"""],
+
+            // Invalid: a user-defined explicit conversion exists to CustomEventArgs, but Moq's reflection
+            // cast never invokes user-defined operators, so the freshly constructed SourceEventArgs throws.
+            ["""mock.Raise(n => n.CustomEvent += null, {|Moq1202:new SourceEventArgs()|});"""],
+
+            // Valid (tolerated): an EventArgs-typed local can hold a derived CustomEventArgs at runtime, so
+            // the downcast is statically indistinguishable from a valid one. Moq accepts it, so no flag.
+            ["""EventArgs downcastArgs = new CustomEventArgs(); mock.Raise(n => n.CustomEvent += null, downcastArgs);"""],
+
+            // Valid (tolerated): a field reference other than EventArgs.Empty has an unknown exact runtime
+            // type, so the downcast is tolerated exactly like the local-variable case above.
+            ["""mock.Raise(n => n.CustomEvent += null, SharedArgs);"""],
+
+            // Valid (tolerated): an explicit cast wraps an object-creation whose exact runtime type derives
+            // from the delegate parameter, so the cast is unwrapped and the payload accepted.
+            ["""mock.Raise(n => n.CustomEvent += null, (EventArgs)new CustomEventArgs());"""],
+
+            // Invalid: an explicit cast wraps an object-creation whose exact runtime type is an unrelated
+            // sibling. The cast is unwrapped and the payload flagged because it can never bind.
+            ["""mock.Raise(n => n.CustomEvent += null, {|Moq1202:(EventArgs)new OtherEventArgs()|});"""],
+
+            // Invalid: nested casts wrap a base EventArgs object-creation. All conversions are unwrapped to
+            // reveal the exact runtime type, which cannot be cast to the derived delegate parameter.
+            ["""mock.Raise(n => n.CustomEvent += null, {|Moq1202:(EventArgs)(object)new EventArgs()|});"""],
+
+            // Invalid: an EventArgs-typed local declared as a type with only a user-defined conversion to
+            // the delegate parameter. Moq's reflection cast never invokes user-defined operators, so it is
+            // flagged even though its runtime type is unknown to the analyzer.
+            ["""SourceEventArgs sourceArgs = new SourceEventArgs(); mock.Raise(n => n.CustomEvent += null, {|Moq1202:sourceArgs|});"""],
+
+            // Valid: an explicit user-defined conversion is applied at the call site, so the operator runs and
+            // constructs a genuine CustomEventArgs before Moq receives it. The conversion is not unwrapped
+            // because it does not preserve object identity.
+            ["""mock.Raise(n => n.CustomEvent += null, (CustomEventArgs)new SourceEventArgs());"""],
+
+            // Valid: an implicit user-defined conversion to the delegate argument type is applied at the call
+            // site. The operator runs and Moq receives a genuine CustomEventArgs, so no diagnostic is reported.
+            ["""mock.Raise(n => n.CustomEvent += null, new ConvertibleToCustom());"""],
+
+            // Invalid: an implicit user-defined conversion produces an unrelated sibling (OtherEventArgs). The
+            // operator runs and Moq receives an OtherEventArgs, which cannot be cast to CustomEventArgs.
+            ["""mock.Raise(n => n.CustomEvent += null, {|Moq1202:new ConvertibleToOther()|});"""],
+
+            // Valid: a conditional expression whose runtime type is not statically known. The value is a
+            // CustomEventArgs at runtime, so no diagnostic is reported (matches the unknown-runtime-type path).
+            ["""mock.Raise(n => n.CustomEvent += null, true ? new CustomEventArgs() : new CustomEventArgs());"""],
+
+            // Valid: a null-coalescing expression yields a CustomEventArgs. The runtime type is tolerated as a
+            // reference or identity conversion to the delegate argument type, so no diagnostic is reported.
+            ["""CustomEventArgs maybeArgs = new CustomEventArgs(); mock.Raise(n => n.CustomEvent += null, maybeArgs ?? new CustomEventArgs());"""],
+
+            // Invalid: three arguments for a two-parameter delegate.
+            ["""mock.Raise(n => n.Closed += null, new object(), EventArgs.Empty, {|Moq1202:"extra"|});"""],
+
+            // Invalid: no arguments at all.
+            ["""{|Moq1202:mock.Raise(n => n.Closed += null)|};"""],
+        }.WithNamespaces().WithMoqReferenceAssemblyGroups();
+    }
+
+    public static IEnumerable<object[]> MultiParameterAndNestedGenericTestData()
+    {
+        return new object[][]
+        {
+            // Action<T1, T2> is resolved through the Invoke signature.
+            ["""mock.Raise(n => n.PairChanged += null, 1, "two");"""],
+            ["""mock.Raise(n => n.PairChanged += null, 1, {|Moq1202:2|});"""],
+
+            // Nested generic payload.
+            ["""mock.Raise(n => n.ItemsChanged += null, new List<Dictionary<string, int>>());"""],
+            ["""mock.Raise(n => n.ItemsChanged += null, {|Moq1202:new List<int>()|});"""],
+
+            // EventHandler<T> where T does not derive from EventArgs: full form required.
+            ["""mock.Raise(n => n.StringHandler += null, new object(), "payload");"""],
+            ["""{|Moq1202:mock.Raise(n => n.StringHandler += null, "payload")|};"""],
+        }.WithNamespaces().WithMoqReferenceAssemblyGroups();
+    }
+
+    public static IEnumerable<object[]> UnresolvableDelegateTestData()
+    {
+        return new object[][]
+        {
+            // The delegate type does not resolve (mid-edit code): no Moq1202 must be reported.
+            ["""mock.Raise(n => n.Broken += null, 42);"""],
+            ["""mock.Raise(n => n.Broken += null, EventArgs.Empty, "extra");"""],
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 
@@ -147,5 +282,141 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests
             }
             """,
             referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(EventHandlerShapedTestData))]
+    public async Task ShouldHandleEventHandlerShapedDelegates(string referenceAssemblyGroup, string @namespace, string raiseCall)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+              {{@namespace}}
+              using System;
+
+              internal class CustomEventArgs : EventArgs { }
+
+              internal class OtherEventArgs : EventArgs { }
+
+              internal class SourceEventArgs : EventArgs
+              {
+                  public static explicit operator CustomEventArgs(SourceEventArgs value) => new CustomEventArgs();
+              }
+
+              internal class ConvertibleToCustom
+              {
+                  public static implicit operator CustomEventArgs(ConvertibleToCustom value) => new CustomEventArgs();
+              }
+
+              internal class ConvertibleToOther
+              {
+                  public static implicit operator OtherEventArgs(ConvertibleToOther value) => new OtherEventArgs();
+              }
+
+              internal delegate void ShapedEventHandler(object sender, CustomEventArgs e);
+
+              internal interface INotifier
+              {
+                  event EventHandler Closed;
+                  event EventHandler<CustomEventArgs> CustomEvent;
+                  event ShapedEventHandler ShapedEvent;
+              }
+
+              internal class UnitTest
+              {
+                  private static readonly EventArgs SharedArgs = new CustomEventArgs();
+
+                  private void Test()
+                  {
+                      var mock = new Mock<INotifier>();
+                      {{raiseCall}}
+                  }
+              }
+              """,
+            referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(MultiParameterAndNestedGenericTestData))]
+    public async Task ShouldHandleMultiParameterAndNestedGenericDelegates(string referenceAssemblyGroup, string @namespace, string raiseCall)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+              {{@namespace}}
+              using System;
+              using System.Collections.Generic;
+
+              internal interface INotifier
+              {
+                  event Action<int, string> PairChanged;
+                  event Action<List<Dictionary<string, int>>> ItemsChanged;
+                  event EventHandler<string> StringHandler;
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      var mock = new Mock<INotifier>();
+                      {{raiseCall}}
+                  }
+              }
+              """,
+            referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnresolvableDelegateTestData))]
+    public async Task ShouldNotReportWhenEventDelegateTypeDoesNotResolve(string referenceAssemblyGroup, string @namespace, string raiseCall)
+    {
+        // CompilerDiagnostics.None suppresses CS0246 for the intentionally-unresolved delegate type,
+        // mirroring the malformed-code pattern used in MockRepositoryVerifyAnalyzerTests.cs:327.
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+              {{@namespace}}
+              using System;
+
+              internal interface IBrokenNotifier
+              {
+                  event UnresolvedDelegateType Broken;
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      var mock = new Mock<IBrokenNotifier>();
+                      {{raiseCall}}
+                  }
+              }
+              """,
+            referenceAssemblyGroup,
+            CompilerDiagnostics.None);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnresolvableDelegateTestData))]
+    public async Task ShouldNotReportWhenEventTypeIsNotDelegate(string referenceAssemblyGroup, string @namespace, string raiseCall)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+              {{@namespace}}
+              using System;
+
+              internal interface IBrokenNotifier
+              {
+                  event string Broken;
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      var mock = new Mock<IBrokenNotifier>();
+                      {{raiseCall}}
+                  }
+              }
+              """,
+            referenceAssemblyGroup,
+            CompilerDiagnostics.None);
     }
 }

--- a/tests/Moq.Analyzers.Test/RaisesEventArgumentsShouldMatchEventSignatureAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/RaisesEventArgumentsShouldMatchEventSignatureAnalyzerTests.cs
@@ -1,3 +1,4 @@
+using Microsoft.CodeAnalysis.Testing;
 using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.RaisesEventArgumentsShouldMatchEventSignatureAnalyzer>;
 
 namespace Moq.Analyzers.Test;
@@ -77,6 +78,140 @@ public class RaisesEventArgumentsShouldMatchEventSignatureAnalyzerTests
             // Invalid: Raises on Returns chain with EventHandler<CustomArgs> event with wrong type
             ["""mockProvider.Setup(x => x.GetValue()).Returns(1).Raises(x => x.CustomEvent += null, {|Moq1204:"wrong"|});"""],
         }.WithNamespaces().WithNewMoqReferenceAssemblyGroups();
+    }
+
+    public static IEnumerable<object[]> EventHandlerShapedTestData()
+    {
+        return new object[][]
+        {
+            // Canonical Moq pattern for non-generic EventHandler: Moq supplies the sender.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.Closed += null, EventArgs.Empty);"""],
+
+            // A derived EventArgs is implicitly convertible to the base EventHandler parameter, so the
+            // statically-known exact runtime type upcasts cleanly.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.Closed += null, new CustomEventArgs());"""],
+
+            // Two-argument form binds Raises(..., params object[]) and is also legal.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.Closed += null, new object(), EventArgs.Empty);"""],
+
+            // Two-argument form with a null-typed sender argument is legal (null binds to any reference).
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.Closed += null, null, EventArgs.Empty);"""],
+
+            // EventHandler<CustomEventArgs>: args-only form (existing behavior).
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, new CustomEventArgs());"""],
+
+            // EventHandler<CustomEventArgs>: two-argument form (previously a false positive).
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, new object(), new CustomEventArgs());"""],
+
+            // Custom (object sender, TArgs e) delegate: both forms are legal.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.ShapedEvent += null, new CustomEventArgs());"""],
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.ShapedEvent += null, new object(), new CustomEventArgs());"""],
+
+            // Invalid: payload not convertible to EventArgs.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.Closed += null, {|Moq1204:42|});"""],
+
+            // Invalid: object payload is only EXPLICITLY convertible to EventArgs. Overload resolution
+            // binds the params-object array overload instead of the EventArgs overload, so Moq does not
+            // supply the sender and the one-argument form throws at runtime and must be flagged.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.Closed += null, {|Moq1204:new object()|});"""],
+
+            // Invalid: an unrelated EventArgs subclass has no conversion to the CustomEventArgs delegate
+            // parameter, so Moq cannot bind it even though it selects the sender-supplying overload.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, {|Moq1204:new OtherEventArgs()|});"""],
+
+            // Invalid: EventArgs.Empty is a base EventArgs singleton. Moq selects the sender-supplying
+            // overload, then casts the payload to CustomEventArgs at runtime and throws because the exact
+            // runtime type is System.EventArgs. The exact type is statically known, so it is flagged.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, {|Moq1204:EventArgs.Empty|});"""],
+
+            // Invalid: a freshly constructed base EventArgs has a statically-known exact runtime type that
+            // cannot be cast to the derived CustomEventArgs delegate parameter.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, {|Moq1204:new EventArgs()|});"""],
+
+            // Invalid: a user-defined explicit conversion exists to CustomEventArgs, but Moq's reflection
+            // cast never invokes user-defined operators, so the freshly constructed SourceEventArgs throws.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, {|Moq1204:new SourceEventArgs()|});"""],
+
+            // Valid (tolerated): an EventArgs-typed local can hold a derived CustomEventArgs at runtime, so
+            // the downcast is statically indistinguishable from a valid one. Moq accepts it, so no flag.
+            ["""EventArgs downcastArgs = new CustomEventArgs(); mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, downcastArgs);"""],
+
+            // Valid (tolerated): a field reference other than EventArgs.Empty has an unknown exact runtime
+            // type, so the downcast is tolerated exactly like the local-variable case above.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, SharedArgs);"""],
+
+            // Valid (tolerated): an explicit cast wraps an object-creation whose exact runtime type derives
+            // from the delegate parameter, so the cast is unwrapped and the payload accepted.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, (EventArgs)new CustomEventArgs());"""],
+
+            // Invalid: an explicit cast wraps an object-creation whose exact runtime type is an unrelated
+            // sibling. The cast is unwrapped and the payload flagged because it can never bind.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, {|Moq1204:(EventArgs)new OtherEventArgs()|});"""],
+
+            // Invalid: nested casts wrap a base EventArgs object-creation. All conversions are unwrapped to
+            // reveal the exact runtime type, which cannot be cast to the derived delegate parameter.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, {|Moq1204:(EventArgs)(object)new EventArgs()|});"""],
+
+            // Invalid: an EventArgs-typed local declared as a type with only a user-defined conversion to
+            // the delegate parameter. Moq's reflection cast never invokes user-defined operators, so it is
+            // flagged even though its runtime type is unknown to the analyzer.
+            ["""SourceEventArgs sourceArgs = new SourceEventArgs(); mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, {|Moq1204:sourceArgs|});"""],
+
+            // Valid: an explicit user-defined conversion is applied at the call site, so the operator runs and
+            // constructs a genuine CustomEventArgs before Moq receives it. The conversion is not unwrapped
+            // because it does not preserve object identity.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, (CustomEventArgs)new SourceEventArgs());"""],
+
+            // Valid: an implicit user-defined conversion to the delegate argument type is applied at the call
+            // site. The operator runs and Moq receives a genuine CustomEventArgs, so no diagnostic is reported.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, new ConvertibleToCustom());"""],
+
+            // Invalid: an implicit user-defined conversion produces an unrelated sibling (OtherEventArgs). The
+            // operator runs and Moq receives an OtherEventArgs, which cannot be cast to CustomEventArgs.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, {|Moq1204:new ConvertibleToOther()|});"""],
+
+            // Valid: a conditional expression whose runtime type is not statically known. The value is a
+            // CustomEventArgs at runtime, so no diagnostic is reported (matches the unknown-runtime-type path).
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, true ? new CustomEventArgs() : new CustomEventArgs());"""],
+
+            // Valid: a null-coalescing expression yields a CustomEventArgs. The runtime type is tolerated as a
+            // reference or identity conversion to the delegate argument type, so no diagnostic is reported.
+            ["""CustomEventArgs maybeArgs = new CustomEventArgs(); mockProvider.Setup(x => x.Submit()).Raises(n => n.CustomEvent += null, maybeArgs ?? new CustomEventArgs());"""],
+
+            // Invalid: three arguments for a two-parameter delegate.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.Closed += null, new object(), EventArgs.Empty, {|Moq1204:"extra"|});"""],
+
+            // Invalid: no arguments at all.
+            ["""{|Moq1204:mockProvider.Setup(x => x.Submit()).Raises(n => n.Closed += null)|};"""],
+        }.WithNamespaces().WithMoqReferenceAssemblyGroups();
+    }
+
+    public static IEnumerable<object[]> MultiParameterAndNestedGenericTestData()
+    {
+        return new object[][]
+        {
+            // Action<T1, T2> is resolved through the Invoke signature.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.PairChanged += null, 1, "two");"""],
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.PairChanged += null, 1, {|Moq1204:2|});"""],
+
+            // Nested generic payload.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.ItemsChanged += null, new List<Dictionary<string, int>>());"""],
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.ItemsChanged += null, {|Moq1204:new List<int>()|});"""],
+
+            // EventHandler<T> where T does not derive from EventArgs: full form required.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.StringHandler += null, new object(), "payload");"""],
+            ["""{|Moq1204:mockProvider.Setup(x => x.Submit()).Raises(n => n.StringHandler += null, "payload")|};"""],
+        }.WithNamespaces().WithMoqReferenceAssemblyGroups();
+    }
+
+    public static IEnumerable<object[]> UnresolvableDelegateTestData()
+    {
+        return new object[][]
+        {
+            // The delegate type does not resolve (mid-edit code): no Moq1204 must be reported.
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.Broken += null, 42);"""],
+            ["""mockProvider.Setup(x => x.Submit()).Raises(n => n.Broken += null, EventArgs.Empty, "extra");"""],
+        }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 
     [Theory]
@@ -237,6 +372,150 @@ public class RaisesEventArgumentsShouldMatchEventSignatureAnalyzerTests
             }
             """,
             referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(EventHandlerShapedTestData))]
+    public async Task ShouldHandleEventHandlerShapedDelegates(string referenceAssemblyGroup, string @namespace, string raisesCall)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+            {{@namespace}}
+            using Moq;
+            using System;
+
+            internal class CustomEventArgs : EventArgs { }
+
+            internal class OtherEventArgs : EventArgs { }
+
+            internal class SourceEventArgs : EventArgs
+            {
+                public static explicit operator CustomEventArgs(SourceEventArgs value) => new CustomEventArgs();
+            }
+
+            internal class ConvertibleToCustom
+            {
+                public static implicit operator CustomEventArgs(ConvertibleToCustom value) => new CustomEventArgs();
+            }
+
+            internal class ConvertibleToOther
+            {
+                public static implicit operator OtherEventArgs(ConvertibleToOther value) => new OtherEventArgs();
+            }
+
+            internal delegate void ShapedEventHandler(object sender, CustomEventArgs e);
+
+            internal interface INotifier
+            {
+                void Submit();
+                event EventHandler Closed;
+                event EventHandler<CustomEventArgs> CustomEvent;
+                event ShapedEventHandler ShapedEvent;
+            }
+
+            internal class UnitTest
+            {
+                private static readonly EventArgs SharedArgs = new CustomEventArgs();
+
+                private void Test()
+                {
+                    var mockProvider = new Mock<INotifier>();
+                    {{raisesCall}}
+                }
+            }
+            """,
+            referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(MultiParameterAndNestedGenericTestData))]
+    public async Task ShouldHandleMultiParameterAndNestedGenericDelegates(string referenceAssemblyGroup, string @namespace, string raisesCall)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+            {{@namespace}}
+            using Moq;
+            using System;
+            using System.Collections.Generic;
+
+            internal interface INotifier
+            {
+                void Submit();
+                event Action<int, string> PairChanged;
+                event Action<List<Dictionary<string, int>>> ItemsChanged;
+                event EventHandler<string> StringHandler;
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    var mockProvider = new Mock<INotifier>();
+                    {{raisesCall}}
+                }
+            }
+            """,
+            referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnresolvableDelegateTestData))]
+    public async Task ShouldNotReportWhenEventDelegateTypeDoesNotResolve(string referenceAssemblyGroup, string @namespace, string raisesCall)
+    {
+        // CompilerDiagnostics.None suppresses CS0246 for the intentionally-unresolved delegate type,
+        // mirroring the malformed-code pattern used in MockRepositoryVerifyAnalyzerTests.cs:327.
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+            {{@namespace}}
+            using Moq;
+            using System;
+
+            internal interface IBrokenNotifier
+            {
+                void Submit();
+                event UnresolvedDelegateType Broken;
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    var mockProvider = new Mock<IBrokenNotifier>();
+                    {{raisesCall}}
+                }
+            }
+            """,
+            referenceAssemblyGroup,
+            CompilerDiagnostics.None);
+    }
+
+    [Theory]
+    [MemberData(nameof(UnresolvableDelegateTestData))]
+    public async Task ShouldNotReportWhenEventTypeIsNotDelegate(string referenceAssemblyGroup, string @namespace, string raisesCall)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+            {{@namespace}}
+            using Moq;
+            using System;
+
+            internal interface IBrokenNotifier
+            {
+                void Submit();
+                event string Broken;
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    var mockProvider = new Mock<IBrokenNotifier>();
+                    {{raisesCall}}
+                }
+            }
+            """,
+            referenceAssemblyGroup,
+            CompilerDiagnostics.None);
     }
 
     [Theory]


### PR DESCRIPTION
## Summary

Fixes #1248. Moq1202 (`Raise`) and Moq1204 (`Raises`) falsely flagged valid one-argument event raises for `EventHandler`-shaped delegates where Moq's sender-supplying overload applies.

The analyzers now model Moq's actual runtime behavior (ground-truthed against Moq 4.18.4):

- **Overload selection**: Moq's `Raise/Raises(Action<T>, EventArgs)` overload is chosen only when the payload is *implicitly* convertible to `EventArgs`. Explicit-only conversions bind the params-`object[]` overload (no sender supplied) and are reported.
- **User-defined conversions** run at the call site, so Moq receives an instance of the operator's return type. Detection uses that return type and tolerates a reference/identity conversion to the delegate argument type.
- **Known-exact runtime type** (object creation or the `EventArgs.Empty` singleton): Moq's reflection reference-cast succeeds only if that exact type is or derives from the delegate argument type.
- **Otherwise** a reference/identity conversion is tolerated (locals, fields, properties may hold a derived instance).

## Moq version compatibility

Ground-truthed against Moq 4.18.4 with an empirical repro harness. Behavior is independent of Moq version (the sender-supplying overload and reflection cast semantics are stable across 4.x). Tests run against all Moq reference-assembly groups.

## Tests

Positive, negative, and boundary cases added to both analyzer test files, including:
- Explicit and implicit user-defined operators (to the target type and to sibling types)
- Nested casts `(EventArgs)(object)new EventArgs()`
- Conditional (`?:`) and null-coalescing (`??`) payloads
- `EventArgs.Empty` for base vs derived `EventHandler<T>`

Invariants guarded with `Debug.Assert`.

## Validation Log

- `dotnet build src/CodeFixes/Moq.CodeFixes.csproj -c Debug /p:PedanticMode=true`: **0 Warning(s), 0 Error(s)**
- `dotnet test` (full suite): **Passed! Failed: 0, Passed: 3684, Total: 3684**
- `dotnet format --verify-no-changes`: **clean (exit 0)**
- Coverage of modified code: 100% of new logic; only 4 accepted defensive early-exit guards uncovered (unreachable via analyzer registration).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified which event delegate shapes are supported when raising events, including `EventHandler`, `EventHandler<T>`, and custom delegates.
  * Added examples showing when the sender argument can be omitted and when the full argument list is required.

* **Bug Fixes**
  * Improved event-argument validation so more valid `Raise()` and `Raises()` calls are accepted.
  * Expanded handling for type conversions, nested generics, and unresolved event signatures, reducing false diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->