### PR TITLE
fix(analyzers): Moq1400/Moq1410 boxed-enum reference-equality false positive

### DIFF
--- a/src/Analyzers/MockBehaviorConstantValues.cs
+++ b/src/Analyzers/MockBehaviorConstantValues.cs
@@ -1,0 +1,27 @@
+namespace Moq.Analyzers;
+
+internal static class MockBehaviorConstantValues
+{
+    /// <summary>
+    /// Returns true when an operand has a constant value equal to a known MockBehavior field.
+    /// </summary>
+    /// <param name="operandConstant">The operand constant to compare.</param>
+    /// <param name="knownBehaviorField">The known MockBehavior field to compare against.</param>
+    /// <returns><see langword="true"/> when the constants are value-equal; otherwise, <see langword="false"/>.</returns>
+    internal static bool ConstantValueEquals(Optional<object?> operandConstant, IFieldSymbol? knownBehaviorField)
+    {
+        if (knownBehaviorField is null)
+        {
+            return false;
+        }
+
+        System.Diagnostics.Debug.Assert(knownBehaviorField.HasConstantValue, "Known MockBehavior fields must expose constant values.");
+
+        if (!operandConstant.HasValue)
+        {
+            return false;
+        }
+
+        return object.Equals(operandConstant.Value, knownBehaviorField.ConstantValue);
+    }
+}

--- a/src/Analyzers/SetExplicitMockBehaviorAnalyzer.cs
+++ b/src/Analyzers/SetExplicitMockBehaviorAnalyzer.cs
@@ -30,6 +30,8 @@ public class SetExplicitMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBas
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Should be fixed. Ignoring for now to avoid additional churn as part of larger refactor.")]
     private protected override void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols)
     {
+        System.Diagnostics.Debug.Assert(knownSymbols.MockBehavior is not null, "Base registration requires the MockBehavior symbol.");
+
         // Extract the type name for the diagnostic message
         string typeName = GetMockedTypeName(context.Operation, target);
 
@@ -45,7 +47,8 @@ public class SetExplicitMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBas
         IArgumentOperation? mockArgument = arguments.DefaultIfNotSingle(argument => argument.Parameter.IsInstanceOf(mockParameter));
 
         // Is the behavior set via a default value?
-        if (mockArgument?.ArgumentKind == ArgumentKind.DefaultValue && mockArgument.Value.WalkDownConversion().ConstantValue.Value == knownSymbols.MockBehaviorDefault?.ConstantValue)
+        if (mockArgument?.ArgumentKind == ArgumentKind.DefaultValue
+            && MockBehaviorConstantValues.ConstantValueEquals(mockArgument.Value.WalkDownConversion().ConstantValue, knownSymbols.MockBehaviorDefault))
         {
             TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Insert, typeName);
         }

--- a/src/Analyzers/SetStrictMockBehaviorAnalyzer.cs
+++ b/src/Analyzers/SetStrictMockBehaviorAnalyzer.cs
@@ -54,6 +54,8 @@ public class SetStrictMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBase
     [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Should be fixed. Ignoring for now to avoid additional churn as part of larger refactor.")]
     private protected override void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols)
     {
+        System.Diagnostics.Debug.Assert(knownSymbols.MockBehavior is not null, "Base registration requires the MockBehavior symbol.");
+
         // Extract the mocked type name for the diagnostic message
         string mockedTypeName = GetMockedTypeName(context.Operation, target);
 
@@ -70,7 +72,8 @@ public class SetStrictMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBase
         IArgumentOperation? mockArgument = arguments.DefaultIfNotSingle(argument => argument.Parameter.IsInstanceOf(mockParameter));
 
         // Is the behavior set via a default value?
-        if (mockArgument?.ArgumentKind == ArgumentKind.DefaultValue && mockArgument.Value.WalkDownConversion().ConstantValue.Value == knownSymbols.MockBehaviorDefault?.ConstantValue
+        if (mockArgument?.ArgumentKind == ArgumentKind.DefaultValue
+            && MockBehaviorConstantValues.ConstantValueEquals(mockArgument.Value.WalkDownConversion().ConstantValue, knownSymbols.MockBehaviorDefault)
             && TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Insert, mockedTypeName))
         {
             return;
@@ -79,7 +82,7 @@ public class SetStrictMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBase
         // NOTE: This logic can't handle indirection (e.g. var x = MockBehavior.Default; new Mock(x);)
         //
         // The operation specifies a MockBehavior; is it MockBehavior.Strict?
-        if (mockArgument?.Value.WalkDownConversion().ConstantValue.Value != knownSymbols.MockBehaviorStrict?.ConstantValue
+        if (!MockBehaviorConstantValues.ConstantValueEquals(mockArgument?.Value.WalkDownConversion().ConstantValue ?? default, knownSymbols.MockBehaviorStrict)
             && mockArgument?.DescendantsAndSelf().OfType<IFieldReferenceOperation>().Any(argument => argument.Member.IsInstanceOf(knownSymbols.MockBehaviorStrict)) != true)
         {
             TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Replace, mockedTypeName);

--- a/tests/Moq.Analyzers.Test/Common/MockBehaviorConstantValuesTests.cs
+++ b/tests/Moq.Analyzers.Test/Common/MockBehaviorConstantValuesTests.cs
@@ -1,0 +1,93 @@
+namespace Moq.Analyzers.Test.Common;
+
+public class MockBehaviorConstantValuesTests
+{
+    [Fact]
+    public void ConstantValueEquals_ReturnsFalse_WhenKnownBehaviorFieldIsNull()
+    {
+        IFieldSymbol defaultBehavior = GetEnumField("Default");
+
+        Assert.False(ConstantValueEquals(new Optional<object?>(defaultBehavior.ConstantValue), null));
+    }
+
+    [Fact]
+    public void ConstantValueEquals_ReturnsFalse_WhenOperandHasNoValue()
+    {
+        IFieldSymbol strict = GetEnumField("Strict");
+
+        Assert.False(ConstantValueEquals(default, strict));
+    }
+
+    [Fact]
+    public void ConstantValueEquals_ReturnsTrue_WhenBoxedValuesAreEqual()
+    {
+        IFieldSymbol strict = GetEnumField("Strict");
+
+        Assert.True(ConstantValueEquals(new Optional<object?>(strict.ConstantValue), strict));
+    }
+
+    [Fact]
+    public void ConstantValueEquals_ReturnsFalse_WhenBoxedValuesDiffer()
+    {
+        IFieldSymbol defaultBehavior = GetEnumField("Default");
+        IFieldSymbol strict = GetEnumField("Strict");
+
+        Assert.False(ConstantValueEquals(new Optional<object?>(defaultBehavior.ConstantValue), strict));
+    }
+
+    [Fact]
+    public void ConstantValueEquals_ReturnsTrue_WhenBothConstantsAreNull()
+    {
+        IFieldSymbol nullField = GetStringField("Value");
+
+        Assert.True(ConstantValueEquals(new Optional<object?>(null), nullField));
+    }
+
+    private static bool ConstantValueEquals(Optional<object?> operandConstant, IFieldSymbol? knownBehaviorField)
+    {
+        Type helperType = typeof(Moq.Analyzers.SetStrictMockBehaviorAnalyzer).Assembly.GetType(
+            "Moq.Analyzers.MockBehaviorConstantValues",
+            throwOnError: true)!;
+        System.Reflection.MethodInfo method = helperType.GetMethod(
+            nameof(ConstantValueEquals),
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Static)!;
+
+#pragma warning disable ECS0900 // Reflection invocation boxes the Optional<object?> argument; unavoidable and confined to test code.
+        object? result = method.Invoke(null, [operandConstant, knownBehaviorField]);
+#pragma warning restore ECS0900
+        return Assert.IsType<bool>(result);
+    }
+
+    private static IFieldSymbol GetEnumField(string fieldName)
+    {
+        const string code = """
+            internal enum Behavior
+            {
+                Default = 1,
+                Strict = 2,
+            }
+            """;
+
+        (SemanticModel model, _) = CompilationHelper.CreateCompilation(code);
+        INamedTypeSymbol? behavior = model.Compilation.GetTypeByMetadataName("Behavior");
+        Assert.NotNull(behavior);
+
+        return behavior!.GetMembers(fieldName).OfType<IFieldSymbol>().Single();
+    }
+
+    private static IFieldSymbol GetStringField(string fieldName)
+    {
+        const string code = """
+            internal static class Constants
+            {
+                public const string Value = null;
+            }
+            """;
+
+        (SemanticModel model, _) = CompilationHelper.CreateCompilation(code);
+        INamedTypeSymbol? constants = model.Compilation.GetTypeByMetadataName("Constants");
+        Assert.NotNull(constants);
+
+        return constants!.GetMembers(fieldName).OfType<IFieldSymbol>().Single();
+    }
+}

--- a/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorAnalyzerTests.cs
@@ -14,6 +14,7 @@ public class SetExplicitMockBehaviorAnalyzerTests
             ["""{|Moq1400:new Mock<ISample>(MockBehavior.Default)|};"""],
             ["""new Mock<ISample>(MockBehavior.Loose);"""],
             ["""new Mock<ISample>(MockBehavior.Strict);"""],
+            ["""MockBehavior GetBehavior() => MockBehavior.Strict; MockBehavior behavior = GetBehavior(); new Mock<ISample>(behavior);"""],
 
             // MockRepository patterns (AnalyzeObjectCreation path)
             ["""{|Moq1400:new MockRepository(MockBehavior.Default)|};"""],

--- a/tests/Moq.Analyzers.Test/SetStrictMockBehaviorAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetStrictMockBehaviorAnalyzerTests.cs
@@ -14,6 +14,13 @@ public class SetStrictMockBehaviorAnalyzerTests
             ["""{|Moq1410:new Mock<ISample>(MockBehavior.Default)|};"""],
             ["""{|Moq1410:new Mock<ISample>(MockBehavior.Loose)|};"""],
             ["""new Mock<ISample>(MockBehavior.Strict);"""],
+            ["""const MockBehavior behavior = MockBehavior.Strict; new Mock<ISample>(behavior);"""],
+            ["""MockBehavior GetBehavior() => MockBehavior.Strict; MockBehavior behavior = GetBehavior(); {|Moq1410:new Mock<ISample>(behavior)|};"""],
+
+            // Numeric cast boundary: (MockBehavior)0 is Strict (underlying value 0), so no diagnostic is
+            // reported. (MockBehavior)2 is not a defined behavior and is not Strict, so it is reported.
+            ["""new Mock<ISample>((MockBehavior)0);"""],
+            ["""{|Moq1410:new Mock<ISample>((MockBehavior)2)|};"""],
 
             // MockRepository patterns (AnalyzeObjectCreation path)
             ["""{|Moq1410:new MockRepository(MockBehavior.Default)|};"""],


### PR DESCRIPTION
Fixes #1255

## Problem

`SetExplicitMockBehaviorAnalyzer` and `SetStrictMockBehaviorAnalyzer` compared two boxed enum constants (`object?`) with `==`/`!=`, which is **reference equality of separate boxes**. This is unreliable and produced false positives for cases where `MockBehavior` was passed via a local `const` (not a field reference), e.g.:

```csharp
const MockBehavior b = MockBehavior.Strict;
new Mock<ISample>(b); // Moq1410 falsely fired
```

## Root cause (ground-truthed against Moq 4.18.4 + Roslyn probe)

- Moq's `MockBehavior` enum: **Strict=0, Loose=1, Default=Loose=1**.
- Roslyn `IFieldSymbol.ConstantValue` for an enum member returns the boxed **underlying int** (0 for Strict), and `GetConstantValue` for an enum expression also returns a boxed int.
- `object.Equals(boxedInt, boxedInt)` compares by value and is correct; `==` on `object?` compared box references and was not.

The direct-`MockBehavior.Strict` field-reference case was already suppressed by a separate `IFieldReferenceOperation` identity check, so the bug only surfaced for non-field-reference constants (locals/consts).

## Fix

New `MockBehaviorConstantValues.ConstantValueEquals(Optional<object?> operandConstant, IFieldSymbol? knownBehaviorField)` helper:
- null-field guard returns false,
- `Debug.Assert(knownBehaviorField.HasConstantValue)` invariant,
- `!operandConstant.HasValue` guard returns false,
- then `object.Equals(operandConstant.Value, knownBehaviorField.ConstantValue)` value comparison.

Both analyzers add `Debug.Assert(knownSymbols.MockBehavior is not null)` and use the helper in the omitted-`DefaultValue` branch. The `Default`/`Loose` (both=1) distinction is unchanged — it uses field-reference identity, not constant value.

## Tests (positive, negative, boundary)

- `SetStrictMockBehaviorAnalyzerTests`: added numeric-cast boundary rows — `(MockBehavior)0` → no flag (IS Strict), `(MockBehavior)2` → Moq1410 flag (correctly not Strict).
- `MockBehaviorConstantValuesTests` (new): direct reflection-based unit tests exercising the **shipping** assembly's internal helper for the defensive null-field guard, no-value, equal, and unequal branches (this reaches the null-field guard unreachable via normal analyzer tests).

## Validation

- `dotnet build tests/Moq.Analyzers.Test`: **0 warnings, 0 errors**.
- Targeted tests (`MockBehavior|SetStrict|SetExplicit`): **261 passed, 0 failed**.
- Pre-push full build + test suite: **passed** (~17.7 min).
- `dotnet format --verify-no-changes`: clean.

Moq version compatibility: verified against Moq 4.18.4.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of mock behavior values in analyzers, including cases where the value comes through conversions, constants, or helper methods.
  * Made analyzer results more reliable for both default and strict mock behavior suggestions.

* **Tests**
  * Added coverage for constant-value comparisons and new mock behavior usage patterns.
  * Expanded analyzer test cases for explicit and strict mock behavior scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->