### PR TITLE
fix(analyzers): flag sealed default interface members; block illegal 'make virtual' fix (Moq1200/1207/1210)

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ something is wrong with your Moq configuration.
 | [Moq1600](docs/rules/Moq1600.md) | Usage         | Protected setup should use `ItExpr` matchers                                            |
 
 See [docs/rules/README.md](docs/rules/README.md) for full documentation.
+Rules Moq1200, Moq1207, and Moq1210 treat sealed default interface members as non-overridable because Moq cannot intercept them.
 
 ## Getting started
 

--- a/docs/rules/Moq1200.md
+++ b/docs/rules/Moq1200.md
@@ -8,10 +8,11 @@
 
 ---
 
-Mocking requires generating a subclass of the class to be mocked. Methods not marked `virtual` cannot be overridden.
+Mocking requires Moq to intercept calls through a generated proxy. Class members must be `virtual` or `abstract`.
+Interface members are valid unless they are `static` or sealed default interface members.
 To fix:
 
-- Mock an interface instead of a clas
+- Mock an interface instead of a class
 - Make the method to be mocked `virtual`
 
 ```csharp
@@ -22,6 +23,17 @@ class SampleClass
 
 var mock = new Mock<SampleClass>()
     .Setup(x => x.Property); // Moq1200: Setup should be used only for overridable members
+```
+
+Sealed default interface members also violate this rule because Moq 4.18.4 cannot intercept them:
+
+```csharp
+public interface IService
+{
+    sealed void Save() { }
+}
+
+new Mock<IService>().Setup(x => x.Save()); // Moq1200
 ```
 
 ## Solution

--- a/docs/rules/Moq1207.md
+++ b/docs/rules/Moq1207.md
@@ -17,7 +17,7 @@ This rule is triggered when `SetupSequence` is used on non-overridable members.
 SetupSequence should only be used for members that can be overridden. This includes:
 
 - Virtual and abstract members
-- Interface members
+- Interface members, except `static` members and sealed default interface members
 - Members that override virtual or abstract members (and are not sealed)
 
 Non-overridable members include:
@@ -25,6 +25,7 @@ Non-overridable members include:
 - Non-virtual methods and properties
 - Static members
 - Sealed members
+- Sealed default interface members
 - Fields
 
 This rule helps prevent runtime exceptions when Moq cannot intercept calls to non-overridable members. According to the [Moq documentation](https://github.com/devlooped/moq/wiki/Quickstart#customizing-mock-behavior), Moq can only mock virtual members, interface members, and abstract members.

--- a/docs/rules/Moq1210.md
+++ b/docs/rules/Moq1210.md
@@ -15,6 +15,10 @@ Because of this design, Moq can only intercept calls to members that are overrid
 - Members of an interface (which are implicitly virtual).
 - `virtual` or `abstract` members of a non-sealed class.
 
+Sealed default interface members are not overridable. Moq 4.18.4 throws
+`System.NotSupportedException` when they appear in `Verify` expressions, so this
+rule reports them.
+
 Non-virtual members cannot be overridden in a subclass due to how the .NET CLR works. Consequently, Moq's proxy cannot intercept calls to them. Attempting to `Verify` a non-virtual member will result in a `System.NotSupportedException` at runtime, with a message like "Non-overridable members ... may not be used in setup / verification expressions."
 
 This analyzer helps you avoid this runtime error by identifying `Verify` calls on non-overridable members at compile time.
@@ -46,7 +50,7 @@ var mock = new Mock<MyClass>();
 mock.Verify(x => x.MyMethod());
 ```
 
-To fix this, you can make the method `virtual`:
+To fix this for a class member, you can make the method `virtual`:
 
 ```csharp
 public class MyClass
@@ -60,6 +64,9 @@ public class MyClass
 var mock = new Mock<MyClass>();
 mock.Verify(x => x.MyMethod());
 ```
+
+The code fix is only offered when `virtual` is legal. It is not offered for
+static members, members of sealed classes, struct members, or interface members.
 
 ## Solution
 

--- a/src/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/AnalyzerReleases.Unshipped.md
@@ -7,7 +7,10 @@ Rule ID | Category | Severity | Notes
 --------|----------|----------|-------
 Moq1003 | Usage | Warning | InternalTypeMustHaveInternalsVisibleToAnalyzer
 Moq1004 | Usage | Warning | NoMockOfLoggerAnalyzer
+Moq1200 | Correctness | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer now reports sealed default interface members
+Moq1207 | Correctness | Error | SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer now reports sealed default interface members
 Moq1208 | Correctness | Warning | ReturnsDelegateShouldReturnTaskAnalyzer
+Moq1210 | Correctness | Error | VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer now reports sealed default interface members and only offers Make member virtual when legal
 Moq1600 | Usage | Warning | ProtectedSetupShouldUseItExprAnalyzer
 
 ### Changed Rules
@@ -16,15 +19,12 @@ Rule ID | New Category | New Severity | Old Category | Old Severity | Notes
 --------|--------------|--------------|--------------|--------------|-------
 Moq1100 | Correctness | Warning | Usage | Warning | CallbackSignatureShouldMatchMockedMethodAnalyzer
 Moq1101 | Correctness | Warning | Usage | Warning | NoMethodsInPropertySetupAnalyzer
-Moq1200 | Correctness | Error | Usage | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer
 Moq1201 | Correctness | Error | Usage | Error | SetupShouldNotIncludeAsyncResultAnalyzer
 Moq1202 | Correctness | Warning | Usage | Warning | RaiseEventArgumentsShouldMatchEventSignatureAnalyzer
 Moq1203 | Correctness | Warning | Usage | Warning | MethodSetupShouldSpecifyReturnValueAnalyzer
 Moq1204 | Correctness | Warning | Usage | Warning | RaisesEventArgumentsShouldMatchEventSignatureAnalyzer
 Moq1205 | Correctness | Warning | Usage | Warning | EventSetupHandlerShouldMatchEventTypeAnalyzer
 Moq1206 | Correctness | Warning | Usage | Warning | ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer
-Moq1207 | Correctness | Error | Usage | Error | SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer
-Moq1210 | Correctness | Error | Usage | Error | VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer
 Moq1400 | Best Practice | Warning | Usage | Warning | SetExplicitMockBehaviorAnalyzer
 Moq1410 | Best Practice | Info | Usage | Info | SetStrictMockBehaviorAnalyzer
 Moq1500 | Best Practice | Warning | Usage | Warning | MockRepositoryVerifyAnalyzer

--- a/src/Analyzers/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -61,7 +61,6 @@ public class SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer : Diagno
 
         ISymbol? mockedMemberSymbol = MoqVerificationHelpers.TryGetMockedMemberSymbol(invocationOperation);
         if (mockedMemberSymbol is null
-            || mockedMemberSymbol.ContainingType?.TypeKind == TypeKind.Interface
             || mockedMemberSymbol.IsOverridableOrAllowedMockMember(knownSymbols))
         {
             return;

--- a/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -89,7 +89,6 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
         // Attempt to locate the member reference from the Setup expression argument.
         ISymbol? candidate = MoqVerificationHelpers.TryGetMockedMemberSymbol(invocationOperation);
         if (candidate is null
-            || candidate.ContainingType?.TypeKind == TypeKind.Interface
             || candidate.IsOverridableOrAllowedMockMember(knownSymbols))
         {
             return false;

--- a/src/Analyzers/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -74,7 +74,7 @@ public class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAna
             mockedMemberSymbol = MoqVerificationHelpers.TryGetMockedMemberSymbol(invocationOperation);
         }
 
-        if (mockedMemberSymbol == null || IsInterfaceMember(mockedMemberSymbol))
+        if (mockedMemberSymbol == null)
         {
             return;
         }
@@ -97,11 +97,6 @@ public class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAna
 
         // VerifyNoOtherCalls doesn't take a lambda argument, so skip it
         return !targetMethod.IsInstanceOf(knownSymbols.Mock1VerifyNoOtherCalls);
-    }
-
-    private static bool IsInterfaceMember(ISymbol mockedMemberSymbol)
-    {
-        return mockedMemberSymbol.ContainingType?.TypeKind == TypeKind.Interface;
     }
 
     private static bool IsMemberAllowedForVerification(ISymbol mockedMemberSymbol, IMethodSymbol targetMethod, MoqKnownSymbols knownSymbols)

--- a/src/CodeFixes/VerifyOverridableMembersFixer.cs
+++ b/src/CodeFixes/VerifyOverridableMembersFixer.cs
@@ -1,4 +1,5 @@
 using System.Composition;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.Editing;
@@ -61,7 +62,7 @@ public sealed class VerifyOverridableMembersFixer : CodeFixProvider
         }
 
         // Check if we should offer a fix.
-        if (!(mockedMemberSymbol is IPropertySymbol or IMethodSymbol) || mockedMemberSymbol.IsOverridable() || mockedMemberSymbol.IsSealed)
+        if (!CanMakeMemberVirtual(mockedMemberSymbol))
         {
             return;
         }
@@ -72,6 +73,24 @@ public sealed class VerifyOverridableMembersFixer : CodeFixProvider
                 cancellationToken => MakeMemberVirtualAsync(context.Document, mockedMemberSymbol, cancellationToken),
                 nameof(VerifyOverridableMembersFixer)),
             diagnostic);
+    }
+
+    private static bool CanMakeMemberVirtual(ISymbol memberSymbol)
+    {
+        if (memberSymbol is not (IPropertySymbol or IMethodSymbol))
+        {
+            return false;
+        }
+
+        if (memberSymbol.IsStatic || memberSymbol.IsOverridable() || memberSymbol.IsSealed)
+        {
+            return false;
+        }
+
+        INamedTypeSymbol? containingType = memberSymbol.ContainingType;
+        Debug.Assert(containingType is not null, "Source member symbols should have a containing type.");
+
+        return containingType is { TypeKind: TypeKind.Class, IsSealed: false };
     }
 
     private static async Task<Solution> MakeMemberVirtualAsync(

--- a/src/Common/ISymbolExtensions.Moq.cs
+++ b/src/Common/ISymbolExtensions.Moq.cs
@@ -39,7 +39,7 @@ internal static partial class ISymbolExtensions
 
     internal static bool IsMoqSetupMethod(this ISymbol symbol, MoqKnownSymbols knownSymbols)
     {
-        return symbol.IsInstanceOf(knownSymbols.Mock1Setup) && symbol is IMethodSymbol { IsGenericMethod: true };
+        return symbol.IsInstanceOf(knownSymbols.Mock1Setup);
     }
 
     internal static bool IsMoqSetupAddMethod(this ISymbol symbol, MoqKnownSymbols knownSymbols)
@@ -59,7 +59,7 @@ internal static partial class ISymbolExtensions
 
     internal static bool IsMoqSetupSequenceMethod(this ISymbol symbol, MoqKnownSymbols knownSymbols)
     {
-        return symbol.IsInstanceOf(knownSymbols.Mock1SetupSequence) && symbol is IMethodSymbol { IsGenericMethod: true };
+        return symbol.IsInstanceOf(knownSymbols.Mock1SetupSequence);
     }
 
     internal static bool IsMoqVerificationMethod(this ISymbol symbol, MoqKnownSymbols knownSymbols)
@@ -163,6 +163,8 @@ internal static partial class ISymbolExtensions
                 propertySymbol.IsOverridable() || propertySymbol.IsTaskOrValueResultProperty(knownSymbols),
             IMethodSymbol methodSymbol =>
                 methodSymbol.IsOverridable(),
+            IEventSymbol eventSymbol =>
+                eventSymbol.IsOverridable(),
             _ => false,
         };
     }

--- a/src/Common/ISymbolExtensions.cs
+++ b/src/Common/ISymbolExtensions.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
@@ -110,12 +111,18 @@ internal static partial class ISymbolExtensions
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     internal static bool IsOverridable(this ISymbol symbol)
     {
-        return symbol switch
+        if (symbol.IsStatic)
         {
-            IMethodSymbol { IsStatic: true } or IPropertySymbol { IsStatic: true } => false,
-            _ when symbol.ContainingType?.TypeKind == TypeKind.Interface => true,
-            _ => !symbol.IsSealed &&
-                  (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false }),
-        };
+            return false;
+        }
+
+        if (symbol.ContainingType?.TypeKind == TypeKind.Interface)
+        {
+            Debug.Assert(!symbol.IsStatic, "Static interface members are not interceptable by Moq.");
+            return symbol.IsAbstract || symbol.IsVirtual;
+        }
+
+        return !symbol.IsSealed &&
+              (symbol.IsVirtual || symbol.IsAbstract || symbol is { IsOverride: true, IsSealed: false });
     }
 }

--- a/tests/Moq.Analyzers.Test/Common/ISymbolExtensionsTests.cs
+++ b/tests/Moq.Analyzers.Test/Common/ISymbolExtensionsTests.cs
@@ -373,13 +373,43 @@ public class C
     }
 
     [Fact]
-    public void IsOverridable_InterfaceMember_ReturnsTrue()
+    public void IsOverridable_AbstractInterfaceMember_ReturnsTrue()
     {
         (SemanticModel model, SyntaxTree tree) = CompilationHelper.CreateCompilation(
             "public interface I { void M(); }");
         IMethodSymbol method = GetMethodSymbols(model, tree)
             .First(m => string.Equals(m.Name, "M", StringComparison.Ordinal));
         Assert.True(((ISymbol)method).IsOverridable());
+    }
+
+    [Fact]
+    public void IsOverridable_DefaultInterfaceMember_ReturnsTrue()
+    {
+        (SemanticModel model, SyntaxTree tree) = CompilationHelper.CreateCompilation(
+            "public interface I { void M() { } }");
+        IMethodSymbol method = GetMethodSymbols(model, tree)
+            .First(m => string.Equals(m.Name, "M", StringComparison.Ordinal));
+        Assert.True(((ISymbol)method).IsOverridable());
+    }
+
+    [Fact]
+    public void IsOverridable_SealedDefaultInterfaceMember_ReturnsFalse()
+    {
+        (SemanticModel model, SyntaxTree tree) = CompilationHelper.CreateCompilation(
+            "public interface I { sealed void M() { } }");
+        IMethodSymbol method = GetMethodSymbols(model, tree)
+            .First(m => string.Equals(m.Name, "M", StringComparison.Ordinal));
+        Assert.False(((ISymbol)method).IsOverridable());
+    }
+
+    [Fact]
+    public void IsOverridable_StaticInterfaceMember_ReturnsFalse()
+    {
+        (SemanticModel model, SyntaxTree tree) = CompilationHelper.CreateCompilation(
+            "public interface I { static void M() { } }");
+        IMethodSymbol method = GetMethodSymbols(model, tree)
+            .First(m => string.Equals(m.Name, "M", StringComparison.Ordinal));
+        Assert.False(((ISymbol)method).IsOverridable());
     }
 
     [Fact]
@@ -447,6 +477,30 @@ public class Derived : Base { public sealed override void M() {} }";
             .OfType<IPropertySymbol>()
             .First();
         Assert.True(((ISymbol)prop).IsOverridable());
+    }
+
+    [Fact]
+    public void IsOverridableOrAllowedMockMember_VirtualEvent_ReturnsTrue()
+    {
+        (SemanticModel model, SyntaxTree tree) = CompilationHelper.CreateCompilation(
+            "public delegate void D(); public class C { public virtual event D E { add { } remove { } } }");
+        IEventSymbol eventSymbol = GetEventSymbols(model, tree)
+            .First(e => string.Equals(e.Name, "E", StringComparison.Ordinal));
+        MoqKnownSymbols knownSymbols = new(model.Compilation);
+
+        Assert.True(((ISymbol)eventSymbol).IsOverridableOrAllowedMockMember(knownSymbols));
+    }
+
+    [Fact]
+    public void IsOverridableOrAllowedMockMember_NonVirtualEvent_ReturnsFalse()
+    {
+        (SemanticModel model, SyntaxTree tree) = CompilationHelper.CreateCompilation(
+            "public delegate void D(); public class C { public event D E { add { } remove { } } }");
+        IEventSymbol eventSymbol = GetEventSymbols(model, tree)
+            .First(e => string.Equals(e.Name, "E", StringComparison.Ordinal));
+        MoqKnownSymbols knownSymbols = new(model.Compilation);
+
+        Assert.False(((ISymbol)eventSymbol).IsOverridableOrAllowedMockMember(knownSymbols));
     }
 
     [Fact]
@@ -586,6 +640,24 @@ public class C
     }
 
     [Fact]
+    public async Task IsMoqSetupMethod_VoidSetupCall_ReturnsTrue()
+    {
+        string code = @"
+using Moq;
+public interface IService { void DoWork(); }
+public class C
+{
+    public void M()
+    {
+        var mock = new Mock<IService>();
+        mock.Setup(x => x.DoWork());
+    }
+}";
+        (ISymbol symbol, MoqKnownSymbols knownSymbols) = await GetMoqInvocationSymbol(code, "Setup");
+        Assert.True(symbol.IsMoqSetupMethod(knownSymbols));
+    }
+
+    [Fact]
     public async Task IsMoqSetupMethod_NonSetupCall_ReturnsFalse()
     {
         string code = @"
@@ -633,6 +705,24 @@ public class C
     {
         var mock = new Mock<IService>();
         mock.SetupSequence(x => x.GetValue());
+    }
+}";
+        (ISymbol symbol, MoqKnownSymbols knownSymbols) = await GetMoqInvocationSymbol(code, "SetupSequence");
+        Assert.True(symbol.IsMoqSetupSequenceMethod(knownSymbols));
+    }
+
+    [Fact]
+    public async Task IsMoqSetupSequenceMethod_VoidSetupSequenceCall_ReturnsTrue()
+    {
+        string code = @"
+using Moq;
+public interface IService { void DoWork(); }
+public class C
+{
+    public void M()
+    {
+        var mock = new Mock<IService>();
+        mock.SetupSequence(x => x.DoWork());
     }
 }";
         (ISymbol symbol, MoqKnownSymbols knownSymbols) = await GetMoqInvocationSymbol(code, "SetupSequence");
@@ -935,6 +1025,16 @@ public class C
             .Select(t => model.GetDeclaredSymbol(t))
             .OfType<INamedTypeSymbol>()
             .SelectMany(t => t.GetMembers().OfType<IMethodSymbol>());
+    }
+
+    private static IEnumerable<IEventSymbol> GetEventSymbols(SemanticModel model, SyntaxTree tree)
+    {
+        return tree.GetRoot()
+            .DescendantNodes()
+            .OfType<BaseTypeDeclarationSyntax>()
+            .Select(t => model.GetDeclaredSymbol(t))
+            .OfType<INamedTypeSymbol>()
+            .SelectMany(t => t.GetMembers().OfType<IEventSymbol>());
     }
 
     private static (IPropertySymbol Property, MoqKnownSymbols KnownSymbols) GetPropertyFromMemberAccess(

--- a/tests/Moq.Analyzers.Test/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -44,6 +44,12 @@ public class SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzerTests
         {
             // SetupSequence with virtual indexer (should NOT be flagged) - Moq 4.18.4+ only
             ["""new Mock<SampleClassWithVirtualIndexer>().SetupSequence(x => x[0]);"""],
+
+            // Default interface members follow Moq 4.18.4 runtime behavior.
+            ["""new Mock<IDefaultInterfaceMembers>().SetupSequence(x => x.AbstractMethod());"""],
+            ["""new Mock<IDefaultInterfaceMembers>().SetupSequence(x => x.DefaultMethod());"""],
+            ["""new Mock<IDefaultInterfaceMembers>().SetupSequence(x => {|Moq1207:x.SealedDefaultMethod()|});"""],
+            ["""new Mock<IStaticInterfaceMembers>().SetupSequence(x => {|Moq1207:IStaticInterfaceMembers.StaticMethod()|});"""],
         }.WithNamespaces().WithNewMoqReferenceAssemblyGroups();
 
         return both.Concat(@new);
@@ -98,6 +104,18 @@ public class SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzerTests
             public class SampleClassWithVirtualIndexer
             {
                 public virtual int this[int index] => index; // Virtual indexer
+            }
+
+            public interface IDefaultInterfaceMembers
+            {
+                void AbstractMethod();
+                void DefaultMethod() { }
+                sealed void SealedDefaultMethod() { }
+            }
+
+            public interface IStaticInterfaceMembers
+            {
+                static void StaticMethod() { }
             }
 
             public class TestClass

--- a/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -52,6 +52,12 @@ public partial class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests(ITe
             // Explicit interface implementation (should NOT be flagged in new)
             ["""new Mock<IExplicitInterface>().Setup(x => ((IExplicitInterface)x).ExplicitMethod());"""],
 
+            // Default interface members follow Moq 4.18.4 runtime behavior.
+            ["""new Mock<IDefaultInterfaceMembers>().Setup(x => x.AbstractMethod());"""],
+            ["""new Mock<IDefaultInterfaceMembers>().Setup(x => x.DefaultMethod());"""],
+            ["""{|Moq1200:new Mock<IDefaultInterfaceMembers>().Setup(x => x.SealedDefaultMethod())|};"""],
+            ["""{|Moq1200:new Mock<IStaticInterfaceMembers>().Setup(x => IStaticInterfaceMembers.StaticMethod())|};"""],
+
             // It.Ref<T>.IsAny for ref parameters (requires Moq 4.8+, should work in newer versions)
             ["""new Mock<ISampleInterface>().Setup(x => x.ProcessRef(ref It.Ref<int>.IsAny)).Returns(true);"""],
         }.WithNamespaces().WithNewMoqReferenceAssemblyGroups();
@@ -90,6 +96,13 @@ public partial class SetupShouldBeUsedOnlyForOverridableMembersAnalyzerTests(ITe
                                 public class SampleClassWithVirtualIndexer { public virtual int this[int i] { get => 0; set { } } }
                                 public class SampleClassWithNonVirtualIndexer { public int this[int i] { get => 0; set { } } }
                                 public interface IExplicitInterface { void ExplicitMethod(); }
+                                public interface IDefaultInterfaceMembers
+                                {
+                                    void AbstractMethod();
+                                    void DefaultMethod() { }
+                                    sealed void SealedDefaultMethod() { }
+                                }
+                                public interface IStaticInterfaceMembers { static void StaticMethod() { } }
                                 public class SampleClassWithStaticMembers { public static int StaticField; public const int ConstField = 42; public static readonly int ReadonlyField = 42; public static void StaticMethod() { } }
 
                                 public abstract class BaseSampleClass

--- a/tests/Moq.Analyzers.Test/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests.cs
@@ -28,6 +28,7 @@ public partial class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests(IT
             ["""new Mock<ISampleInterface>().Verify(x => x.TestProperty);"""],
             ["""{|Moq1210:new Mock<SampleClass>().Verify(x => x.Field)|};"""],
             ["""{|Moq1210:new Mock<SampleClassWithNonVirtualIndexer>().Verify(x => x[0])|};"""],
+            ["""{|Moq1210:new Mock<SampleClassWithStaticMembers>().Verify(x => SampleClassWithStaticMembers.StaticMethod())|};"""],
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
 
         IEnumerable<object[]> newMoqOnly = new object[][]
@@ -36,6 +37,12 @@ public partial class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests(IT
             // VerifySet uses Action<T> syntax, not Expression<Func<T, ...>>
             ["""{|Moq1210:new Mock<SampleClass>().VerifySet(x => { x.Property = It.IsAny<int>(); })|};"""],
             ["""new Mock<ISampleInterface>().VerifySet(x => { x.TestProperty = It.IsAny<string>(); });"""],
+
+            // Default interface members follow Moq 4.18.4 runtime behavior.
+            ["""new Mock<IDefaultInterfaceMembers>().Verify(x => x.AbstractMethod());"""],
+            ["""new Mock<IDefaultInterfaceMembers>().Verify(x => x.DefaultMethod());"""],
+            ["""{|Moq1210:new Mock<IDefaultInterfaceMembers>().Verify(x => x.SealedDefaultMethod())|};"""],
+            ["""{|Moq1210:new Mock<IStaticInterfaceMembers>().Verify(x => IStaticInterfaceMembers.StaticMethod())|};"""],
         }.WithNamespaces().WithNewMoqReferenceAssemblyGroups();
 
         return both.Concat(newMoqOnly);
@@ -112,6 +119,104 @@ public partial class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests(IT
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 
+    public static IEnumerable<object[]> NoFixForIllegalVirtualMembersData()
+    {
+        return new object[][]
+        {
+            [
+                """
+                public class MyClass
+                {
+                    public static void MyMethod() { }
+                }
+                """,
+                """
+                var mock = new Mock<MyClass>();
+                {|Moq1210:mock.Verify(x => MyClass.MyMethod())|};
+                """,
+            ],
+            [
+                """
+                public sealed class MyClass
+                {
+                    public void MyMethod() { }
+                }
+                """,
+                """
+                var mock = new Mock<MyClass>();
+                {|Moq1210:mock.Verify(x => x.MyMethod())|};
+                """,
+            ],
+            [
+                """
+                public interface IMyInterface
+                {
+                    sealed void MyMethod() { }
+                }
+                """,
+                """
+                var mock = new Mock<IMyInterface>();
+                {|Moq1210:mock.Verify(x => x.MyMethod())|};
+                """,
+            ],
+            [
+                """
+                public interface IMyInterface
+                {
+                    static void MyMethod() { }
+                }
+                """,
+                """
+                var mock = new Mock<IMyInterface>();
+                {|Moq1210:mock.Verify(x => IMyInterface.MyMethod())|};
+                """,
+            ],
+        }.WithNamespaces().WithNewMoqReferenceAssemblyGroups();
+    }
+
+    public static IEnumerable<object[]> CanMakeMemberVirtualData()
+    {
+        return new object[][]
+        {
+            [
+                "public class MyClass { public void MyMethod() { } }",
+                "MyClass",
+                "MyMethod",
+                "True",
+            ],
+            [
+                "public class MyClass { public int MyField; }",
+                "MyClass",
+                "MyField",
+                "False",
+            ],
+            [
+                "public class MyClass { public static void MyMethod() { } }",
+                "MyClass",
+                "MyMethod",
+                "False",
+            ],
+            [
+                "public sealed class MyClass { public void MyMethod() { } }",
+                "MyClass",
+                "MyMethod",
+                "False",
+            ],
+            [
+                "public struct MyStruct { public void MyMethod() { } }",
+                "MyStruct",
+                "MyMethod",
+                "False",
+            ],
+            [
+                "public interface IMyInterface { sealed void MyMethod() { } }",
+                "IMyInterface",
+                "MyMethod",
+                "False",
+            ],
+        };
+    }
+
     [Theory]
     [MemberData(nameof(TestData))]
     public async Task ShouldAnalyzeVerifyForOverridableMembers(string referenceAssemblyGroup, string @namespace, string mock)
@@ -128,6 +233,13 @@ public partial class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests(IT
                                 public class SampleClassWithVirtualIndexer { public virtual int this[int i] { get => 0; set { } } }
                                 public class SampleClassWithNonVirtualIndexer { public int this[int i] { get => 0; set { } } }
                                 public interface IExplicitInterface { void ExplicitMethod(); }
+                                public interface IDefaultInterfaceMembers
+                                {
+                                    void AbstractMethod();
+                                    void DefaultMethod() { }
+                                    sealed void SealedDefaultMethod() { }
+                                }
+                                public interface IStaticInterfaceMembers { static void StaticMethod() { } }
                                 public class SampleClassWithStaticMembers { public static int StaticField; public const int ConstField = 42; public static readonly int ReadonlyField = 42; public static void StaticMethod() { } }
 
                                 public abstract class BaseSampleClass
@@ -318,6 +430,43 @@ public partial class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests(IT
     }
 
     [Theory]
+    [MemberData(nameof(NoFixForIllegalVirtualMembersData))]
+    public async Task NoFixForIllegalVirtualMembers(string referenceAssemblyGroup, string @namespace, string declaration, string verify)
+    {
+        string test = $$"""
+            {{@namespace}}
+
+            {{declaration}}
+
+            public class MyTest
+            {
+                public void Test()
+                {
+                    {{verify}}
+                }
+            }
+            """;
+
+        await Verify.VerifyCodeFixAsync(test, test, referenceAssemblyGroup);
+    }
+
+    [Theory]
+    [MemberData(nameof(CanMakeMemberVirtualData))]
+    public void CanMakeMemberVirtual_RequiresInstanceMemberInNonSealedClass(string source, string typeName, string memberName, string expected)
+    {
+        (SemanticModel model, SyntaxTree tree) = CompilationHelper.CreateCompilation(source);
+        INamedTypeSymbol typeSymbol = tree.GetRoot()
+            .DescendantNodes()
+            .OfType<BaseTypeDeclarationSyntax>()
+            .Select(t => model.GetDeclaredSymbol(t))
+            .OfType<INamedTypeSymbol>()
+            .First(t => string.Equals(t.Name, typeName, StringComparison.Ordinal));
+        ISymbol memberSymbol = typeSymbol.GetMembers(memberName).Single();
+
+        Assert.Equal(expected, InvokeCanMakeMemberVirtual(memberSymbol));
+    }
+
+    [Theory]
     [MemberData(nameof(MoqReferenceAssemblyGroups))]
     public async Task NoFixForInterfaceMembers(string referenceAssemblyGroup)
     {
@@ -448,5 +597,13 @@ public partial class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests(IT
             """;
 
         await Verifier.VerifyAnalyzerAsync(test, ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
+    private static string InvokeCanMakeMemberVirtual(ISymbol memberSymbol)
+    {
+        System.Reflection.MethodInfo method = typeof(Moq.CodeFixes.VerifyOverridableMembersFixer)
+            .GetMethod("CanMakeMemberVirtual", System.Reflection.BindingFlags.Static | System.Reflection.BindingFlags.NonPublic)!;
+        object? result = method.Invoke(null, new object?[] { memberSymbol });
+        return result?.ToString() ?? string.Empty;
     }
 }


### PR DESCRIPTION
Fixes #1264
Fixes #1256

## Problems

**#1264 (false negative):** `ISymbolExtensions.IsOverridable` treated every non-static interface member as overridable. A **sealed default interface member** (`interface I { sealed void M() {} }`) is NOT interceptable by Moq — `mock.Setup(x => x.M())`/`mock.Verify(x => x.M())` throw `NotSupportedException` at runtime — yet Moq1200/1207/1210 stayed silent. Additionally, the three overridability analyzers bailed out on all interface members before ever consulting `IsOverridable`, so a corrected check would never run. `IsMoqSetupMethod`/`IsMoqSetupSequenceMethod` also gated on `IsGenericMethod`, so **void** method setups (non-generic `Setup(Action<T>)`) were never recognized, hiding non-overridable void setups from Moq1200 entirely.

**#1256 (non-compiling fix):** `VerifyOverridableMembersFixer` ("Make member virtual" for Moq1210) only guarded against already-overridable/sealed members. It offered the fix for static members (→ CS0112), members of sealed classes (→ CS0549), and struct members (→ CS0106), producing code that fails to compile.

## Fix

- `IsOverridable`: interface members are overridable iff `IsAbstract || IsVirtual` (excludes sealed-default and static); static members are never overridable. `Debug.Assert` guards the static invariant.
- Removed the blanket interface bail-outs in `SetupShouldBeUsedOnlyForOverridableMembersAnalyzer`, `SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer`, and `VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer` so the corrected `IsOverridable` is consulted.
- Dropped the `IsGenericMethod` gate on `IsMoqSetupMethod`/`IsMoqSetupSequenceMethod` so void-method setups are recognized. Verified every downstream caller (Moq1201, Moq1208, ReturnsAsync, SetupShouldNotIncludeAsyncResult) has its own return-type/property guard, so no false positives are introduced.
- Added a defensive `IEventSymbol` arm to `IsOverridableOrAllowedMockMember`.
- `VerifyOverridableMembersFixer`: new `CanMakeMemberVirtual` gate offers the fix only for instance members of non-sealed **classes**; stays silent for static, sealed, struct, and interface members (including sealed-DIM). `Debug.Assert` guards the containing-type invariant.

## Empirical ground-truth (Moq 4.18.4)

Repro confirmed: `mock.Setup`/`Verify` on a **sealed** default interface member throws `NotSupportedException`; abstract and **non-sealed** default interface members do not throw. Roslyn symbol flags (IsAbstract/IsVirtual/IsSealed/IsStatic) matched the issue's table by dumping symbols.

## Tests (positive, negative, boundary)

Added coverage across `ISymbolExtensionsTests` and the three analyzer test files plus the fixer tests: abstract DIM (no flag), non-sealed default DIM (no flag), sealed DIM (flag, no fix offered), static interface member (flag), static class member (flag, no fix), sealed-class member (flag, no fix), struct member. Modified logic is covered; remaining misses are defensive null/document/already-virtual code-fix guards.

## Validation

- `dotnet build`: **0 warnings, 0 errors**.
- Targeted tests: **1001 passed**. Full suite: **3739 passed, 0 failed**.
- `dotnet format --verify-no-changes`: clean.
- Docs updated: `docs/rules/Moq1200.md`, `Moq1207.md`, `Moq1210.md`, `README.md`, `AnalyzerReleases.Unshipped.md`.

Moq version compatibility: verified against Moq 4.18.4.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analyzer rules now correctly flag sealed default interface members as non-overridable in setup, sequence, and verification scenarios.
  * Event members are now handled more accurately when checking whether a member can be used with Moq.
  * Code-fix availability is more precise, avoiding suggestions where a member cannot be made virtual.

* **Documentation**
  * Updated rule guidance and examples to clarify which members can be mocked or verified.
  * Added release notes covering the new analyzer behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->