### PR TITLE
fix(analyzers): Moq1208 detect explicit Returns<T>(delegate) mismatch; fix non-binding ReturnsAsync<T> (#1091, #1258)

### DIFF
--- a/docs/rules/Moq1208.md
+++ b/docs/rules/Moq1208.md
@@ -25,6 +25,7 @@ value like `int` or `string`, but the mocked method is async and returns
 The rule detects three forms of delegates:
 
 - **Lambdas**: `Returns(() => 42)`
+- **Explicit generic lambdas**: `Returns<string>(s => s.Length)`
 - **Anonymous methods**: `Returns(delegate { return 42; })`
 - **Method groups**: `Returns(GetInt)` where `GetInt` returns `int`
 
@@ -65,6 +66,9 @@ mock.Setup(x => x.GetValueAsync()).Returns(() => 42); // Moq1208
 // Lambda returning string on a Task<string> method.
 mock.Setup(x => x.GetNameAsync()).Returns(() => "hello"); // Moq1208
 
+// Explicit generic Returns<T> lambda returning int on a Task<int> method.
+mock.Setup(x => x.GetValueAsync()).Returns<string>(s => s.Length); // Moq1208
+
 // Anonymous method returning int on a Task<int> method.
 mock.Setup(x => x.GetValueAsync()).Returns(delegate { return 42; }); // Moq1208
 
@@ -95,6 +99,20 @@ mock.Setup(x => x.GetValueAsync()).ReturnsAsync(() => 42);
 // Anonymous methods and method groups work the same way.
 mock.Setup(x => x.GetValueAsync()).ReturnsAsync(delegate { return 42; });
 mock.Setup(x => x.GetValueAsync()).ReturnsAsync(GetInt);
+```
+
+When the original code uses `Returns<T1..TN>(...)`, the code fix removes the
+explicit type arguments and emits plain `ReturnsAsync(...)`. Moq's
+`ReturnsAsync` overloads use a different generic arity, so copying the
+`Returns<T1..TN>` list would not compile. The fix is only offered when the
+delegate declares explicit parameter types, so C# can infer the dropped types.
+
+```csharp
+// Before.
+mock.Setup(x => x.GetValueAsync()).Returns<string>((string s) => s.Length);
+
+// After.
+mock.Setup(x => x.GetValueAsync()).ReturnsAsync((string s) => s.Length);
 ```
 
 ### Option 2: Wrap the value yourself

--- a/src/Analyzers/AnalyzerReleases.Unshipped.md
+++ b/src/Analyzers/AnalyzerReleases.Unshipped.md
@@ -9,7 +9,7 @@ Moq1003 | Usage | Warning | InternalTypeMustHaveInternalsVisibleToAnalyzer
 Moq1004 | Usage | Warning | NoMockOfLoggerAnalyzer
 Moq1200 | Correctness | Error | SetupShouldBeUsedOnlyForOverridableMembersAnalyzer now reports sealed default interface members
 Moq1207 | Correctness | Error | SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer now reports sealed default interface members
-Moq1208 | Correctness | Warning | ReturnsDelegateShouldReturnTaskAnalyzer
+Moq1208 | Correctness | Warning | ReturnsDelegateShouldReturnTaskAnalyzer detects explicit Returns<T> delegate mismatches and fixes with inferred ReturnsAsync
 Moq1210 | Correctness | Error | VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer now reports sealed default interface members and only offers Make member virtual when legal
 Moq1600 | Usage | Warning | ProtectedSetupShouldUseItExprAnalyzer
 

--- a/src/Analyzers/ReturnsDelegateShouldReturnTaskAnalyzer.cs
+++ b/src/Analyzers/ReturnsDelegateShouldReturnTaskAnalyzer.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Moq.Analyzers;
@@ -223,6 +224,15 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
 
         ExpressionSyntax firstArgument = returnsInvocation.ArgumentList.Arguments[0].Expression;
 
+        // For anonymous functions with explicit Returns<T1..TN> type arguments, prefer body
+        // analysis. Roslyn target-types the function against the selected delegate and can
+        // report Task<int> even when the body returns int.
+        if (HasExplicitReturnsTypeArguments(returnsInvocation)
+            && firstArgument is AnonymousFunctionExpressionSyntax anonymousFunction)
+        {
+            return GetReturnTypeFromAnonymousFunction(anonymousFunction, semanticModel);
+        }
+
         // For anonymous methods, prefer body analysis. Roslyn may infer the return type
         // from the target delegate type (e.g., Task<int>) for parameterless anonymous methods,
         // masking the actual body return type (e.g., int).
@@ -249,6 +259,40 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
         }
 
         return null;
+    }
+
+    private static bool HasExplicitReturnsTypeArguments(InvocationExpressionSyntax returnsInvocation)
+    {
+        return returnsInvocation.Expression is MemberAccessExpressionSyntax
+        {
+            Name: GenericNameSyntax,
+        };
+    }
+
+    private static ITypeSymbol? GetReturnTypeFromAnonymousFunction(
+        AnonymousFunctionExpressionSyntax anonymousFunction,
+        SemanticModel semanticModel)
+    {
+        Debug.Assert(!anonymousFunction.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword), "Async lambdas are handled by Moq1206.");
+
+        if (anonymousFunction is AnonymousMethodExpressionSyntax { Body: BlockSyntax anonymousMethodBlock })
+        {
+            return GetReturnTypeFromBlock(anonymousMethodBlock, semanticModel);
+        }
+
+        // AnonymousMethodExpressionSyntax (handled above) and LambdaExpressionSyntax are the
+        // only two AnonymousFunctionExpressionSyntax subtypes, so what remains is a lambda.
+        Debug.Assert(anonymousFunction is LambdaExpressionSyntax, "Only anonymous methods and lambdas derive from AnonymousFunctionExpressionSyntax.");
+        LambdaExpressionSyntax lambda = (LambdaExpressionSyntax)anonymousFunction;
+
+        if (lambda.Block is BlockSyntax lambdaBlock)
+        {
+            return GetReturnTypeFromBlock(lambdaBlock, semanticModel);
+        }
+
+        // A lambda without a block body always has an expression body.
+        Debug.Assert(lambda.ExpressionBody is not null, "A block-less lambda has an expression body.");
+        return semanticModel.GetTypeInfo(lambda.ExpressionBody!).Type;
     }
 
     private static ITypeSymbol? GetReturnTypeFromBlock(BlockSyntax block, SemanticModel semanticModel)

--- a/src/CodeFixes/ReturnsDelegateShouldReturnTaskFixer.cs
+++ b/src/CodeFixes/ReturnsDelegateShouldReturnTaskFixer.cs
@@ -1,4 +1,5 @@
 using System.Composition;
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.CodeFixes;
 
@@ -47,6 +48,11 @@ public sealed class ReturnsDelegateShouldReturnTaskFixer : CodeFixProvider
             return;
         }
 
+        if (memberAccess.Name is GenericNameSyntax && !TypeInferenceCanBindDroppedTypeArguments(memberAccess))
+        {
+            return;
+        }
+
         context.RegisterCodeFix(
             CodeAction.Create(
                 title: Title,
@@ -55,27 +61,48 @@ public sealed class ReturnsDelegateShouldReturnTaskFixer : CodeFixProvider
             diagnostic);
     }
 
+    private static bool TypeInferenceCanBindDroppedTypeArguments(MemberAccessExpressionSyntax memberAccess)
+    {
+        Debug.Assert(memberAccess.Name is GenericNameSyntax, "Only explicit Returns<T> calls need this guard.");
+
+        // The analyzer only flags a Returns call that is the target of an invocation with at
+        // least one delegate argument, so both facts are invariants at this point.
+        Debug.Assert(memberAccess.Parent is InvocationExpressionSyntax, "A flagged Returns member access is always invoked.");
+        InvocationExpressionSyntax returnsInvocation = (InvocationExpressionSyntax)memberAccess.Parent!;
+
+        Debug.Assert(returnsInvocation.ArgumentList.Arguments.Count > 0, "A flagged Returns call always has a delegate argument.");
+
+        ExpressionSyntax firstArgument = returnsInvocation.ArgumentList.Arguments[0].Expression;
+        return firstArgument switch
+        {
+            ParenthesizedLambdaExpressionSyntax lambda when lambda.ParameterList.Parameters.Count > 0 => AllParametersHaveExplicitTypes(lambda.ParameterList.Parameters),
+            AnonymousMethodExpressionSyntax { ParameterList: { } parameterList } when parameterList.Parameters.Count > 0 => AllParametersHaveExplicitTypes(parameterList.Parameters),
+            _ => false,
+        };
+    }
+
+    private static bool AllParametersHaveExplicitTypes(SeparatedSyntaxList<ParameterSyntax> parameters)
+    {
+        Debug.Assert(parameters.Count > 0, "Only delegates with parameters can infer dropped Returns<T> type arguments.");
+
+        for (int i = 0; i < parameters.Count; i++)
+        {
+            if (parameters[i].Type == null)
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
     private static Task<Document> ReplaceReturnsWithReturnsAsync(
         Document document,
         SyntaxNode root,
         MemberAccessExpressionSyntax memberAccess)
     {
         SimpleNameSyntax oldName = memberAccess.Name;
-        SimpleNameSyntax newName;
-
-        // Moq's IReturns<TMock, TResult> interface defines method-level generic overloads
-        // like Returns<T1>(Func<T1, TResult>). When a user writes .Returns<string>(s => 42),
-        // the syntax is GenericNameSyntax. Preserve type arguments to maintain developer intent.
-        if (oldName is GenericNameSyntax genericName)
-        {
-            newName = SyntaxFactory.GenericName(
-                SyntaxFactory.Identifier("ReturnsAsync"),
-                genericName.TypeArgumentList);
-        }
-        else
-        {
-            newName = SyntaxFactory.IdentifierName("ReturnsAsync");
-        }
+        SimpleNameSyntax newName = SyntaxFactory.IdentifierName("ReturnsAsync");
 
         newName = newName
             .WithLeadingTrivia(oldName.GetLeadingTrivia())

--- a/tests/Moq.Analyzers.Test/ReturnsDelegateShouldReturnTaskAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/ReturnsDelegateShouldReturnTaskAnalyzerTests.cs
@@ -81,6 +81,12 @@ public class ReturnsDelegateShouldReturnTaskAnalyzerTests(ITestOutputHelper outp
                 new Mock<AsyncService>().Setup(expr).Returns(() => Task.FromResult(42));
                 """,
             ],
+
+            // Generic Returns<T> with lambda body returning Task<int> (correct)
+            ["""new Mock<AsyncService>().Setup(c => c.ProcessAsync(It.IsAny<string>())).Returns<string>(s => Task.FromResult(s.Length));"""],
+
+            // Generic Returns<T> with async lambda is Moq1206's domain, not ours
+            ["""new Mock<AsyncService>().Setup(c => c.ProcessAsync(It.IsAny<string>())).Returns<string>(async s => await Task.FromResult(s.Length));"""],
         };
 
         return data.WithNamespaces().WithMoqReferenceAssemblyGroups();
@@ -138,6 +144,18 @@ public class ReturnsDelegateShouldReturnTaskAnalyzerTests(ITestOutputHelper outp
 
             // Method group returning string on Task<string> method
             ["""new Mock<AsyncService>().Setup(c => c.GetNameAsync()).{|Moq1208:Returns(GetString)|};"""],
+
+            // Generic Returns<T> with implicit lambda returning wrong type on Task<int> method
+            ["""new Mock<AsyncService>().Setup(c => c.ProcessAsync(It.IsAny<string>())).{|Moq1208:Returns<string>(s => s.Length)|};"""],
+
+            // Generic Returns<T> with block-bodied lambda returning wrong type on Task<int> method
+            ["""new Mock<AsyncService>().Setup(c => c.ProcessAsync(It.IsAny<string>())).{|Moq1208:Returns<string>(s => { return s.Length; })|};"""],
+
+            // Generic Returns<T> with explicitly typed lambda returning wrong type on Task<int> method
+            ["""new Mock<AsyncService>().Setup(c => c.ProcessAsync(It.IsAny<string>())).{|Moq1208:Returns<string>((string s) => s.Length)|};"""],
+
+            // Generic Returns<T> with anonymous method returning wrong type on Task<int> method
+            ["""new Mock<AsyncService>().Setup(c => c.ProcessAsync(It.IsAny<string>())).{|Moq1208:Returns<string>(delegate (string s) { return s.Length; })|};"""],
         };
 
         return data.WithNamespaces().WithMoqReferenceAssemblyGroups();
@@ -160,12 +178,6 @@ public class ReturnsDelegateShouldReturnTaskAnalyzerTests(ITestOutputHelper outp
 
             // Invocation as value, not delegate: GetInt() is a call, not a method group (GH PR #942 review thread)
             ["""new Mock<AsyncService>().Setup(c => c.GetValueAsync()).Returns(GetInt());"""],
-
-            // Generic Returns<T> with sync lambda: target-type inference masks the mismatch (analyzer gap, see PR #1089)
-            ["""new Mock<AsyncService>().Setup(c => c.ProcessAsync(It.IsAny<string>())).Returns<string>(s => s.Length);"""],
-
-            // Generic Returns<T> with async lambda (no mismatch)
-            ["""new Mock<AsyncService>().Setup(c => c.ProcessAsync(It.IsAny<string>())).Returns<string>(async s => s.Length);"""],
         };
 
         return data.WithNamespaces().WithMoqReferenceAssemblyGroups();

--- a/tests/Moq.Analyzers.Test/ReturnsDelegateShouldReturnTaskFixerTests.cs
+++ b/tests/Moq.Analyzers.Test/ReturnsDelegateShouldReturnTaskFixerTests.cs
@@ -1,4 +1,10 @@
+using System.Collections.Immutable;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Testing;
+using Microsoft.CodeAnalysis.Text;
 using Verifier = Moq.Analyzers.Test.Helpers.CodeFixVerifier<Moq.Analyzers.ReturnsDelegateShouldReturnTaskAnalyzer, Moq.CodeFixes.ReturnsDelegateShouldReturnTaskFixer>;
 
 namespace Moq.Analyzers.Test;
@@ -76,6 +82,31 @@ public class ReturnsDelegateShouldReturnTaskFixerTests(ITestOutputHelper output)
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 
+    public static IEnumerable<object[]> ExplicitTypeArgumentFixData()
+    {
+        return new object[][]
+        {
+            [
+                """Returns<string>((string x) => default)""",
+                """ReturnsAsync((string x) => default)""",
+            ],
+            [
+                """Returns<string>(delegate (string x) { return default; })""",
+                """ReturnsAsync(delegate (string x) { return default; })""",
+            ],
+        };
+    }
+
+    public static IEnumerable<object[]> ExplicitTypeArgumentNoFixData()
+    {
+        return new object[][]
+        {
+            ["""Returns<string>(x => default)"""],
+            ["""Returns<string>((x) => default)"""],
+            ["""Returns<string>(GetLengthAsync)"""],
+        };
+    }
+
     [Theory]
     [MemberData(nameof(TestData))]
     public async Task ShouldReplaceReturnsWithReturnsAsync(string referenceAssemblyGroup, string @namespace, string original, string quickFix)
@@ -88,6 +119,34 @@ public class ReturnsDelegateShouldReturnTaskFixerTests(ITestOutputHelper output)
     public async Task ShouldReplaceReturnsWithReturnsAsyncForAnonymousDelegateAndMethodGroup(string referenceAssemblyGroup, string @namespace, string original, string quickFix)
     {
         await VerifyAsync(referenceAssemblyGroup, @namespace, original, quickFix, CompilerDiagnostics.None);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExplicitTypeArgumentFixData))]
+    public async Task ShouldDropTypeArgumentsWhenExplicitParameterTypesAllowInference(string original, string expected)
+    {
+        string source = Template("using Moq;\nusing System.Threading.Tasks;", $"new Mock<AsyncService>().Setup(s => s.ProcessAsync(It.IsAny<string>())).{original};");
+        (AdhocWorkspace workspace, Document document, List<CodeAction> actions) = await GetCodeActionsAsync(source);
+        using (workspace)
+        {
+            CodeAction action = Assert.Single(actions);
+            string changedText = await GetChangedTextAsync(action, document);
+
+            Assert.Contains(expected, changedText, StringComparison.Ordinal);
+            Assert.DoesNotContain("ReturnsAsync<string>", changedText, StringComparison.Ordinal);
+        }
+    }
+
+    [Theory]
+    [MemberData(nameof(ExplicitTypeArgumentNoFixData))]
+    public async Task ShouldNotOfferFixWhenDroppedTypeArgumentsCannotBeInferred(string original)
+    {
+        string source = Template("using Moq;\nusing System.Threading.Tasks;", $"new Mock<AsyncService>().Setup(s => s.ProcessAsync(It.IsAny<string>())).{original};");
+        (AdhocWorkspace workspace, Document _, List<CodeAction> actions) = await GetCodeActionsAsync(source);
+        using (workspace)
+        {
+            Assert.Empty(actions);
+        }
     }
 
     private static string Template(string ns, string mock) =>
@@ -105,6 +164,8 @@ public class ReturnsDelegateShouldReturnTaskFixerTests(ITestOutputHelper output)
         internal class UnitTest
         {
             private static int GetInt() => 42;
+            private static int GetLength(string input) => input.Length;
+            private static Task<int> GetLengthAsync(string input) => Task.FromResult(input.Length);
 
             private void Test()
             {
@@ -112,6 +173,65 @@ public class ReturnsDelegateShouldReturnTaskFixerTests(ITestOutputHelper output)
             }
         }
         """;
+
+    private static async Task<(AdhocWorkspace Workspace, Document Document, List<CodeAction> Actions)> GetCodeActionsAsync(string source)
+    {
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(source).ConfigureAwait(false);
+        SyntaxNode root = await tree.GetRootAsync().ConfigureAwait(false);
+        GenericNameSyntax returnsName = root
+            .DescendantNodes()
+            .OfType<GenericNameSyntax>()
+            .Single(name => string.Equals(name.Identifier.ValueText, "Returns", StringComparison.Ordinal));
+
+        Diagnostic diagnostic = CreateSyntheticDiagnosticAtSpan(tree, returnsName.Span);
+        AdhocWorkspace workspace = new();
+        Document document = CreateTestDocument(workspace, model, source);
+        List<CodeAction> actions = await InvokeFixerAsync(document, diagnostic).ConfigureAwait(false);
+        return (workspace, document, actions);
+    }
+
+    private static Diagnostic CreateSyntheticDiagnosticAtSpan(SyntaxTree tree, TextSpan span)
+    {
+        DiagnosticDescriptor descriptor = new(
+            DiagnosticIds.ReturnsDelegateMismatchOnAsyncMethod,
+            "Returns delegate mismatch",
+            "Returns delegate mismatch",
+            "Correctness",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        return Diagnostic.Create(descriptor, Location.Create(tree, span));
+    }
+
+    private static Document CreateTestDocument(AdhocWorkspace workspace, SemanticModel model, string source)
+    {
+        Project project = workspace.AddProject("TestProject", LanguageNames.CSharp)
+            .AddMetadataReferences(model.Compilation.References);
+        return project.AddDocument("Test.cs", SourceText.From(source));
+    }
+
+    private static async Task<List<CodeAction>> InvokeFixerAsync(Document document, Diagnostic diagnostic)
+    {
+        Moq.CodeFixes.ReturnsDelegateShouldReturnTaskFixer fixer = new();
+        List<CodeAction> actions = [];
+
+        CodeFixContext context = new(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        await fixer.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+        return actions;
+    }
+
+    private static async Task<string> GetChangedTextAsync(CodeAction action, Document document)
+    {
+        ImmutableArray<CodeActionOperation> operations = await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+        ApplyChangesOperation applyChanges = Assert.Single(operations.OfType<ApplyChangesOperation>());
+        Document changedDocument = applyChanges.ChangedSolution.GetDocument(document.Id)!;
+        return (await changedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString();
+    }
 
     private async Task VerifyAsync(string referenceAssemblyGroup, string @namespace, string original, string quickFix, CompilerDiagnostics? compilerDiagnostics = null)
     {


### PR DESCRIPTION
## Summary

Fixes #1091 and #1258 for the Moq1208 analyzer/fixer (`ReturnsDelegateShouldReturnTaskAnalyzer` / `Fixer`).

### #1091 — analyzer: flag explicit `Returns<T>(delegate)` mismatches on async methods

The existing analyzer already flags non-compiling return-type mismatches for anonymous methods (`Returns(delegate { return 42; })`) and method groups (`Returns(GetInt)`) via the `InvalidAnonymousDelegateAndMethodGroupTestData` bucket (run with `CompilerDiagnostics.None`). It did **not** cover the equivalent explicit-generic lambda form `Returns<string>(s => s.Length)`. This change closes that gap so the analyzer gives a Moq-specific hint (use `ReturnsAsync` / wrap with `Task.FromResult`) alongside the compiler error during live editing.

- New branch in `GetDelegateReturnType`: when the call is `Returns<T..>(...)` (`GenericNameSyntax`) and the argument is an anonymous function, analyze the lambda/anonymous-method body return type directly instead of trusting Roslyn's target-typed delegate return type.
- Async lambdas are filtered earlier (`HasSyncDelegateArgument`), so the `Debug.Assert(!async)` in `GetReturnTypeFromAnonymousFunction` is a true invariant guard (Moq1206 owns async).

### #1258 — fixer: emit plain `ReturnsAsync` instead of non-binding `ReturnsAsync<T>`

The old fixer preserved the `<T>` type-argument list when rewriting `Returns<T>` to `ReturnsAsync<T>`. `ReturnsAsync` has different generic arity, so `ReturnsAsync<string>(...)` never binds (CS1929). The fixer now drops the type-argument list and self-suppresses when dropping the args would leave an un-inferable delegate (implicitly-typed lambda params), offering the fix only when all delegate params are explicitly typed.

## Empirical grounding (Moq 4.18.4)

- `Returns((string x) => x.Length)` on a `Task<int>` method **compiles** and throws at runtime: `ArgumentException: Invalid callback. Setup on method with return type 'Task<int>' cannot invoke callback with return type 'int'.` (the real Moq1208 scenario).
- `Returns<string>(s => s.Length)` (explicit generic) does **not** compile (CS0029/CS1662); handled with `CompilerDiagnostics.None`, consistent with the existing anonymous-method / method-group cases.
- Corrected fixer output `ReturnsAsync((string s) => s.Length)` compiles and returns the expected value; the old `ReturnsAsync<string>(...)` reproduced CS1929.

## Validation

- `dotnet build tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj -c Debug /p:PedanticMode=true` → 0 warnings, 0 errors
- Targeted: `--filter FullyQualifiedName~ReturnsDelegateShouldReturnTask` → **225 passed, 0 failed**
- Pre-push hook (full solution build with warnings-as-errors + full test suite) → passed
- Tests cover positive, negative, and boundary cases (expression-bodied lambda, block-bodied lambda, explicitly-typed parenthesized lambda, anonymous method; valid `Task.FromResult` body and async-lambda negatives).

Moq version compatibility: tests run across all `MoqReferenceAssemblyGroups`.

Fixes #1091
Fixes #1258

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and code fixes for async mock setups that use explicit generic `Returns<T>(...)` patterns.
  * Eligible fixes now reliably rewrite to `ReturnsAsync(...)` while avoiding leftover generic type arguments that could break compilation.
  * The fix is now withheld when dropping explicit type arguments can’t be safely inferred.
* **Documentation**
  * Updated rule guidance for additional delegate patterns, including explicit generic lambdas, with clearer `Returns<T>(...)` examples and fix behavior details.
* **Tests**
  * Expanded analyzer and code-fix test coverage for valid, invalid, and compiler-suppressed scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->