### PR TITLE
fix(analyzers): detect Moq1001/Moq1002 on target-typed new

### DIFF
--- a/docs/rules/Moq1001.md
+++ b/docs/rules/Moq1001.md
@@ -22,6 +22,7 @@ interface IMyService
 }
 
 var mock = new Mock<IMyService>("123"); // Moq1001: Mocked interfaces cannot have constructor parameters
+Mock<IMyService> targetTypedMock = new("123"); // Moq1001
 ```
 
 ## Solution
@@ -33,6 +34,7 @@ interface IMyService
 }
 
 var mock = new Mock<IMyService>();
+Mock<IMyService> targetTypedMock = new();
 ```
 
 ## Suppress a warning

--- a/docs/rules/Moq1002.md
+++ b/docs/rules/Moq1002.md
@@ -21,6 +21,7 @@ class MyClass
 }
 
 var mock = new Mock<MyClass>(3); // Moq1002: Parameters provided into mock do not match any existing constructors
+Mock<MyClass> targetTypedMock = new(3); // Moq1002
 ```
 
 ## Solution
@@ -32,6 +33,7 @@ class MyClass
 }
 
 var mock = new Mock<MyClass>("three");
+Mock<MyClass> targetTypedMock = new("three");
 ```
 
 ## Suppress a warning

--- a/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -162,7 +162,7 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         }
 
         // These are for classes
-        context.RegisterSyntaxNodeAction(context => AnalyzeNewObject(context, knownSymbols), SyntaxKind.ObjectCreationExpression);
+        context.RegisterSyntaxNodeAction(context => AnalyzeNewObject(context, knownSymbols), SyntaxKind.ObjectCreationExpression, SyntaxKind.ImplicitObjectCreationExpression);
         context.RegisterSyntaxNodeAction(context => AnalyzeInstanceCall(context, knownSymbols), SyntaxKind.InvocationExpression);
     }
 
@@ -209,38 +209,43 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
 
     /// <summary>
     /// Analyzes when a Mock`1 object is created to verify the provided constructor arguments
-    /// match an existing constructor of the mocked class.
+    /// match an existing constructor of the mocked class. Handles both explicit
+    /// (<c>new Mock&lt;T&gt;(...)</c>) and target-typed (<c>Mock&lt;T&gt; mock = new(...)</c>) creation.
     /// </summary>
     /// <param name="context">The context.</param>
     /// <param name="knownSymbols">The <see cref="MoqKnownSymbols"/> used to lookup symbols against Moq types.</param>
     private static void AnalyzeNewObject(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        ObjectCreationExpressionSyntax newExpression = (ObjectCreationExpressionSyntax)context.Node;
+        BaseObjectCreationExpressionSyntax newExpression = (BaseObjectCreationExpressionSyntax)context.Node;
 
-        GenericNameSyntax? genericNameSyntax = GetGenericNameSyntax(newExpression.Type);
-        if (genericNameSyntax == null)
+        if (newExpression is ObjectCreationExpressionSyntax { Type: var typeSyntax }
+            && GetGenericNameSyntax(typeSyntax) is null)
         {
             return;
         }
 
         SymbolInfo symbolInfo = context.SemanticModel.GetSymbolInfo(newExpression, context.CancellationToken);
 
-        if (!symbolInfo
-            .Symbol?
-            .IsInstanceOf(knownSymbols.Mock1?.Constructors ?? ImmutableArray<IMethodSymbol>.Empty)
-            ?? false)
+        if (symbolInfo.Symbol is not IMethodSymbol constructor
+            || !constructor.IsInstanceOf(knownSymbols.Mock1?.Constructors ?? ImmutableArray<IMethodSymbol>.Empty))
         {
             return;
         }
 
-        if (symbolInfo.Symbol?.ContainingType is not INamedTypeSymbol { IsGenericType: true } typeSymbol)
-        {
-            return;
-        }
+        AnalyzeMockObjectCreation(context, knownSymbols, constructor.ContainingType, newExpression.ArgumentList);
+    }
 
-        ITypeSymbol mockedClass = typeSymbol.TypeArguments[0];
+    private static void AnalyzeMockObjectCreation(
+        SyntaxNodeAnalysisContext context,
+        MoqKnownSymbols knownSymbols,
+        INamedTypeSymbol containingType,
+        ArgumentListSyntax? argumentList)
+    {
+        System.Diagnostics.Debug.Assert(containingType.IsGenericType, "Mock<T> constructor should belong to a generic type.");
 
-        VerifyMockAttempt(context, knownSymbols, mockedClass, newExpression.ArgumentList, true);
+        ITypeSymbol mockedClass = containingType.TypeArguments[0];
+
+        VerifyMockAttempt(context, knownSymbols, mockedClass, argumentList, true);
     }
 
     /// <summary>

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Interfaces.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.Interfaces.cs
@@ -18,6 +18,7 @@ public partial class ConstructorArgumentsShouldMatchAnalyzerTests
             ["""new Mock<IFoo>();"""],
             ["""new Mock<IFoo>{|Moq1001:(MockBehavior.Default, 42)|};"""],
             ["""new Mock<IFoo>{|Moq1001:(42)|};"""],
+            ["""Mock<IFoo> mock = new{|Moq1001:(42)|};"""],
 
             // LINQ
             ["""Mock.Of<IFoo>();"""],

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.TargetTypedNew.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.TargetTypedNew.cs
@@ -1,0 +1,86 @@
+using Verifier = Moq.Analyzers.Test.Helpers.AnalyzerVerifier<Moq.Analyzers.ConstructorArgumentsShouldMatchAnalyzer>;
+
+namespace Moq.Analyzers.Test;
+
+#pragma warning disable SA1601 // Partial elements should be documented
+public partial class ConstructorArgumentsShouldMatchAnalyzerTests
+{
+    public static IEnumerable<object[]> TargetTypedNewTestData()
+    {
+        return new object[][]
+        {
+            ["""object value = new object();"""],
+            ["""List<int> values = new();"""],
+
+            ["""new Mock<IFoo>();"""],
+            ["""Mock<IFoo> interfaceMock = new();"""],
+            ["""new Mock<IFoo>(MockBehavior.Default);"""],
+            ["""Mock<IFoo> interfaceMock = new(MockBehavior.Default);"""],
+            ["""new Mock<IFoo>{|Moq1001:(42)|};"""],
+            ["""Mock<IFoo> interfaceMock = new{|Moq1001:(42)|};"""],
+            ["""new Mock<IFoo>{|Moq1001:(MockBehavior.Default, 42)|};"""],
+            ["""Mock<IFoo> interfaceMock = new{|Moq1001:(MockBehavior.Default, 42)|};"""],
+            ["""Mock<IFoo> CreateInterfaceMock() => new{|Moq1001:(42)|}; _ = CreateInterfaceMock();"""],
+
+            ["""new Mock<Foo>(false, 0);"""],
+            ["""Mock<Foo> classMock = new(false, 0);"""],
+            ["""new Mock<Foo>(MockBehavior.Default, false, 0);"""],
+            ["""Mock<Foo> classMock = new(MockBehavior.Default, false, 0);"""],
+            ["""new Mock<Foo>{|Moq1002:(1, true)|};"""],
+            ["""Mock<Foo> classMock = new{|Moq1002:(1, true)|};"""],
+            ["""new Mock<Foo>{|Moq1002:(MockBehavior.Default, 1, true)|};"""],
+            ["""Mock<Foo> classMock = new{|Moq1002:(MockBehavior.Default, 1, true)|};"""],
+            ["""Mock<Foo> CreateClassMock() => new{|Moq1002:(1, true)|}; _ = CreateClassMock();"""],
+
+            ["""new Mock<ClassDefaultCtor>();"""],
+            ["""Mock<ClassDefaultCtor> defaultCtorMock = new();"""],
+            ["""new Mock<ClassWithDefaultParamCtor>();"""],
+            ["""Mock<ClassWithDefaultParamCtor> defaultParamMock = new();"""],
+            ["""new Mock<ClassWithRequiredParamCtor>{|Moq1002:()|};"""],
+            ["""Mock<ClassWithRequiredParamCtor> requiredParamMock = new{|Moq1002:()|};"""],
+        }.WithNamespaces().WithMoqReferenceAssemblyGroups();
+    }
+
+    [Theory]
+    [MemberData(nameof(TargetTypedNewTestData))]
+    public async Task ShouldAnalyzeTargetTypedNewConstructorArguments(string referenceAssemblyGroup, string @namespace, string mock)
+    {
+        await Verifier.VerifyAnalyzerAsync(
+            $$"""
+              {{@namespace}}
+
+              internal interface IFoo
+              {
+              }
+
+              internal class Foo
+              {
+                  public Foo(bool b, int i) { }
+              }
+
+              internal class ClassDefaultCtor
+              {
+              }
+
+              internal class ClassWithDefaultParamCtor
+              {
+                  public ClassWithDefaultParamCtor(int a = 42) { }
+              }
+
+              internal class ClassWithRequiredParamCtor
+              {
+                  public ClassWithRequiredParamCtor(int a) { }
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      {{mock}}
+                  }
+              }
+              """,
+            referenceAssemblyGroup);
+    }
+}
+#pragma warning restore SA1601 // Partial elements should be documented


### PR DESCRIPTION
## Summary

Fixes #1245. `ConstructorArgumentsShouldMatchAnalyzer` (Moq1001/Moq1002) only registered `ObjectCreationExpression`, so target-typed `new` (`Mock<IFoo> m = new(42);`) was never analyzed — a false negative. Moq rejects those constructor args at runtime (verified on Moq 4.8.2 and 4.18.4).

## Changes

- Register `ImplicitObjectCreationExpression` alongside `ObjectCreationExpression`.
- Refactor `AnalyzeNewObject` to `BaseObjectCreationExpressionSyntax`; resolve the mocked type from the constructor symbol's `ContainingType.TypeArguments[0]` (symbol-based).
- `Debug.Assert` guards the `Mock<T>`-is-generic invariant.
- Docs updated for Moq1001/Moq1002.

## Tests

Positive (Moq1001 interface-with-args, Moq1002 class-wrong-args), negative (valid mocks, non-Mock `new`), boundary (return-context target-typed, default ctor, default-param ctor, required-param ctor), both explicit and target-typed forms, across old and new Moq reference groups.

## Validation

- `dotnet build /p:PedanticMode=true`: 0 warnings, 0 errors.
- Full pre-push build + test suite passed.
- Modified analyzer lines fully covered.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analyzer now correctly handles target-typed `new` expressions when checking mock constructor arguments.
  * Improved detection for both interface and class mock creation patterns.

* **Documentation**
  * Updated rule examples to show target-typed `new` syntax in both flagged and corrected scenarios.

* **Tests**
  * Added coverage for target-typed `new` constructor argument cases to help prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->