### PR TITLE
fix(codefix): Moq1400 fixer only replaces argument that still contains MockBehavior.Default

### DIFF
--- a/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
+++ b/src/CodeFixes/SetExplicitMockBehaviorCodeAction.cs
@@ -1,5 +1,6 @@
 ﻿using Microsoft.CodeAnalysis.CodeActions;
 using Microsoft.CodeAnalysis.Editing;
+using Microsoft.CodeAnalysis.Operations;
 using Microsoft.CodeAnalysis.Simplification;
 
 namespace Moq.CodeFixes;
@@ -11,8 +12,16 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
     private readonly BehaviorType _behaviorType;
     private readonly DiagnosticEditProperties.EditType _editType;
     private readonly int _position;
+    private readonly bool _replaceRequiresDefaultReference;
 
-    public SetExplicitMockBehaviorCodeAction(string title, Document document, SyntaxNode nodeToFix, BehaviorType behaviorType, DiagnosticEditProperties.EditType editType, int position)
+    public SetExplicitMockBehaviorCodeAction(
+        string title,
+        Document document,
+        SyntaxNode nodeToFix,
+        BehaviorType behaviorType,
+        DiagnosticEditProperties.EditType editType,
+        int position,
+        bool replaceRequiresDefaultReference)
     {
         if (title is null)
         {
@@ -40,6 +49,7 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
         _behaviorType = behaviorType;
         _editType = editType;
         _position = position;
+        _replaceRequiresDefaultReference = replaceRequiresDefaultReference;
     }
 
     public override string Title { get; }
@@ -63,7 +73,7 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
         // shape the analyzer saw at analysis time. If the document changed between analysis and fix
         // application (stale lightbulb), the resolved node may no longer match that shape. Return the
         // original document instead of applying a wrong edit or letting the argument rewriters throw.
-        if (!CanApplyEdit(editor.SemanticModel, knownSymbols.MockBehavior))
+        if (!CanApplyEdit(editor.SemanticModel, knownSymbols.MockBehavior, knownSymbols.MockBehaviorDefault))
         {
             return _document;
         }
@@ -105,17 +115,28 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
         return false;
     }
 
+    private static bool ContainsMockBehaviorDefaultReference(SemanticModel semanticModel, ArgumentSyntax argument, IFieldSymbol mockBehaviorDefault)
+    {
+        IOperation? operation = semanticModel.GetOperation(argument.Expression);
+        System.Diagnostics.Debug.Assert(operation is not null, "A valid argument expression should produce an operation.");
+
+        return operation!.DescendantsAndSelf().OfType<IFieldReferenceOperation>().Any(field => field.Member.IsInstanceOf(mockBehaviorDefault));
+    }
+
     /// <summary>
     /// Validates that the edit recorded on the diagnostic can be applied safely to the current node.
     /// Guards against a stale lightbulb where the document changed after analysis: the node must still
     /// be an invocation or object creation, <see cref="_position"/> must be in range for the requested
-    /// edit, and an <see cref="DiagnosticEditProperties.EditType.Insert"/> must not duplicate a
-    /// <c>MockBehavior</c> argument the user added after the diagnostic was produced.
+    /// edit, an <see cref="DiagnosticEditProperties.EditType.Insert"/> must not duplicate a
+    /// <c>MockBehavior</c> argument the user added after the diagnostic was produced, and an explicit
+    /// behavior fix <see cref="DiagnosticEditProperties.EditType.Replace"/> must still point at an
+    /// argument containing <c>MockBehavior.Default</c>.
     /// </summary>
     /// <param name="semanticModel">The semantic model used to resolve argument types.</param>
     /// <param name="mockBehaviorType">The <c>MockBehavior</c> type symbol.</param>
+    /// <param name="mockBehaviorDefault">The <c>MockBehavior.Default</c> field symbol.</param>
     /// <returns><see langword="true"/> when the edit can be applied safely; otherwise <see langword="false"/>.</returns>
-    private bool CanApplyEdit(SemanticModel semanticModel, ISymbol mockBehaviorType)
+    private bool CanApplyEdit(SemanticModel semanticModel, ISymbol mockBehaviorType, IFieldSymbol mockBehaviorDefault)
     {
         if (!TryGetArgumentList(out SeparatedSyntaxList<ArgumentSyntax> arguments))
         {
@@ -130,7 +151,10 @@ internal sealed class SetExplicitMockBehaviorCodeAction : CodeAction
             DiagnosticEditProperties.EditType.Insert =>
                 _position <= arguments.Count
                 && !ContainsMockBehaviorArgument(semanticModel, arguments, mockBehaviorType),
-            DiagnosticEditProperties.EditType.Replace => _position < arguments.Count,
+            DiagnosticEditProperties.EditType.Replace =>
+                _position < arguments.Count
+                && (!_replaceRequiresDefaultReference
+                    || ContainsMockBehaviorDefaultReference(semanticModel, arguments[_position], mockBehaviorDefault)),
             _ => false,
         };
     }

--- a/src/CodeFixes/SetExplicitMockBehaviorFixer.cs
+++ b/src/CodeFixes/SetExplicitMockBehaviorFixer.cs
@@ -32,7 +32,7 @@ public class SetExplicitMockBehaviorFixer : CodeFixProvider
             return;
         }
 
-        context.RegisterCodeFix(new SetExplicitMockBehaviorCodeAction("Set MockBehavior (Loose)", context.Document, nodeToFix, BehaviorType.Loose, editProperties.TypeOfEdit, editProperties.EditPosition), context.Diagnostics);
-        context.RegisterCodeFix(new SetExplicitMockBehaviorCodeAction("Set MockBehavior (Strict)", context.Document, nodeToFix, BehaviorType.Strict, editProperties.TypeOfEdit, editProperties.EditPosition), context.Diagnostics);
+        context.RegisterCodeFix(new SetExplicitMockBehaviorCodeAction("Set MockBehavior (Loose)", context.Document, nodeToFix, BehaviorType.Loose, editProperties.TypeOfEdit, editProperties.EditPosition, replaceRequiresDefaultReference: true), context.Diagnostics);
+        context.RegisterCodeFix(new SetExplicitMockBehaviorCodeAction("Set MockBehavior (Strict)", context.Document, nodeToFix, BehaviorType.Strict, editProperties.TypeOfEdit, editProperties.EditPosition, replaceRequiresDefaultReference: true), context.Diagnostics);
     }
 }

--- a/src/CodeFixes/SetStrictMockBehaviorFixer.cs
+++ b/src/CodeFixes/SetStrictMockBehaviorFixer.cs
@@ -32,6 +32,6 @@ public class SetStrictMockBehaviorFixer : CodeFixProvider
             return;
         }
 
-        context.RegisterCodeFix(new SetExplicitMockBehaviorCodeAction("Set MockBehavior (Strict)", context.Document, nodeToFix, BehaviorType.Strict, editProperties.TypeOfEdit, editProperties.EditPosition), context.Diagnostics);
+        context.RegisterCodeFix(new SetExplicitMockBehaviorCodeAction("Set MockBehavior (Strict)", context.Document, nodeToFix, BehaviorType.Strict, editProperties.TypeOfEdit, editProperties.EditPosition, replaceRequiresDefaultReference: false), context.Diagnostics);
     }
 }

--- a/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
@@ -63,6 +63,57 @@ public class SetExplicitMockBehaviorFixerTests
         }
         """;
 
+    private static readonly string SourceWithLooseBehavior = """
+        using Moq;
+
+        public interface ISample
+        {
+            void Method();
+        }
+
+        internal class UnitTest
+        {
+            private void Test()
+            {
+                var mock = new Mock<ISample>(MockBehavior.Loose);
+            }
+        }
+        """;
+
+    private static readonly string SourceWithDefaultBehavior = """
+        using Moq;
+
+        public interface ISample
+        {
+            void Method();
+        }
+
+        internal class UnitTest
+        {
+            private void Test()
+            {
+                var mock = new Mock<ISample>(MockBehavior.Default);
+            }
+        }
+        """;
+
+    private static readonly string SourceWithCompoundDefaultBehavior = """
+        using Moq;
+
+        public interface ISample
+        {
+            void Method();
+        }
+
+        internal class UnitTest
+        {
+            private void Test()
+            {
+                var mock = new Mock<ISample>(MockBehavior.Default | MockBehavior.Loose);
+            }
+        }
+        """;
+
     public static IEnumerable<object[]> StaleEditShapeData()
     {
         // EditType / EditPosition pairs that do NOT match `new Mock<ISample>()` (zero arguments):
@@ -73,6 +124,30 @@ public class SetExplicitMockBehaviorFixerTests
             ["Replace", "0"],
             ["Replace", "5"],
             ["Insert", "5"],
+        ];
+    }
+
+    public static IEnumerable<object[]> StaleReplaceNoOpData()
+    {
+        return
+        [
+            [SourceWithExplicitBehavior],
+            [SourceWithLooseBehavior],
+        ];
+    }
+
+    public static IEnumerable<object[]> StaleReplaceApplyData()
+    {
+        return
+        [
+            [
+                SourceWithDefaultBehavior,
+                SourceWithDefaultBehavior.Replace("MockBehavior.Default", "MockBehavior.Loose", StringComparison.Ordinal),
+            ],
+            [
+                SourceWithCompoundDefaultBehavior,
+                SourceWithCompoundDefaultBehavior.Replace("MockBehavior.Default | MockBehavior.Loose", "MockBehavior.Loose", StringComparison.Ordinal),
+            ],
         ];
     }
 
@@ -145,7 +220,91 @@ public class SetExplicitMockBehaviorFixerTests
         await AssertFixerNoOpAsync(model, tree, creation.Span, SourceWithImplicitBehavior, "Insert", "0");
     }
 
+    [Theory]
+    [MemberData(nameof(StaleReplaceNoOpData))]
+    public async Task StaleReplace_WhenUserChangedDefaultToExplicitBehavior_DoesNotOverwrite(string source)
+    {
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(source);
+        SyntaxNode root = await tree.GetRootAsync();
+
+        // Stale scenario where the analyzer recorded Replace for MockBehavior.Default at position 0,
+        // but the user changed the same argument to an explicit behavior before applying the code fix.
+        // The fixer must preserve the user's current value instead of replacing it.
+        ObjectCreationExpressionSyntax creation = root
+            .DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Single();
+
+        await AssertFixerNoOpAsync(model, tree, creation.Span, source, "Replace", "0");
+    }
+
+    [Theory]
+    [MemberData(nameof(StaleReplaceApplyData))]
+    public async Task StaleReplace_WhenArgumentStillContainsDefault_AppliesEdit(string source, string expected)
+    {
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(source);
+        SyntaxNode root = await tree.GetRootAsync();
+
+        // Replace remains valid when the current argument still contains MockBehavior.Default,
+        // including compound expressions where Default is not the top-level operation.
+        ObjectCreationExpressionSyntax creation = root
+            .DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Single();
+
+        await AssertFirstFixAsync(model, tree, creation.Span, source, expected, "Replace", "0");
+    }
+
     private static async Task AssertFixerNoOpAsync(SemanticModel model, SyntaxTree tree, TextSpan span, string sourceText, string editType, string editPosition)
+    {
+        await AssertFixerAsync(
+            model,
+            tree,
+            span,
+            sourceText,
+            editType,
+            editPosition,
+            async (document, actions) =>
+            {
+                string originalText = (await document.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString();
+                foreach (CodeAction action in actions)
+                {
+                    ImmutableArray<CodeActionOperation> operations = await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+                    ApplyChangesOperation applyChanges = Assert.Single(operations.OfType<ApplyChangesOperation>());
+                    Document changedDocument = applyChanges.ChangedSolution.GetDocument(document.Id)!;
+                    string changedText = (await changedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString();
+                    Assert.Equal(originalText, changedText);
+                }
+            }).ConfigureAwait(false);
+    }
+
+    private static async Task AssertFirstFixAsync(SemanticModel model, SyntaxTree tree, TextSpan span, string sourceText, string expectedText, string editType, string editPosition)
+    {
+        await AssertFixerAsync(
+            model,
+            tree,
+            span,
+            sourceText,
+            editType,
+            editPosition,
+            async (document, actions) =>
+            {
+                ImmutableArray<CodeActionOperation> operations = await actions[0].GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+                ApplyChangesOperation applyChanges = Assert.Single(operations.OfType<ApplyChangesOperation>());
+                Document changedDocument = applyChanges.ChangedSolution.GetDocument(document.Id)!;
+                string changedText = (await changedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString();
+                Assert.Equal(expectedText, changedText);
+            }).ConfigureAwait(false);
+    }
+
+    private static async Task AssertFixerAsync(
+        SemanticModel model,
+        SyntaxTree tree,
+        TextSpan span,
+        string sourceText,
+        string editType,
+        string editPosition,
+        Func<Document, IReadOnlyList<CodeAction>, Task> assertAsync)
     {
         DiagnosticDescriptor descriptor = new(
             DiagnosticIds.SetExplicitMockBehavior,
@@ -176,19 +335,10 @@ public class SetExplicitMockBehaviorFixerTests
         Moq.CodeFixes.SetExplicitMockBehaviorFixer fixer = new();
         await fixer.RegisterCodeFixesAsync(context).ConfigureAwait(false);
 
-        // The fixer registers two actions (Loose and Strict). Applying either must not throw and
-        // must leave the document unchanged, because the recorded edit shape does not match the node.
+        // The fixer registers two actions (Loose and Strict). Applying either must not throw.
         const int expectedActionCount = 2;
         Assert.Equal(expectedActionCount, actions.Count);
 
-        string originalText = (await document.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString();
-        foreach (CodeAction action in actions)
-        {
-            ImmutableArray<CodeActionOperation> operations = await action.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
-            ApplyChangesOperation applyChanges = Assert.Single(operations.OfType<ApplyChangesOperation>());
-            Document changedDocument = applyChanges.ChangedSolution.GetDocument(document.Id)!;
-            string changedText = (await changedDocument.GetTextAsync(CancellationToken.None).ConfigureAwait(false)).ToString();
-            Assert.Equal(originalText, changedText);
-        }
+        await assertAsync(document, actions).ConfigureAwait(false);
     }
 }


### PR DESCRIPTION
## Summary

Fixes #1296. The Moq1400 code fix (`SetExplicitMockBehaviorFixer`) could apply a **stale** `Replace` edit: when the target `MockBehavior` argument no longer contained `MockBehavior.Default`, the fixer still rewrote it, corrupting already-explicit behavior.

### Fix
- Add `_replaceRequiresDefaultReference` to `SetExplicitMockBehaviorCodeAction` plus a `ContainsMockBehaviorDefaultReference` symbol-based check.
- When the flag is set, the fixer applies its `Replace` **only if** the argument still contains a `MockBehavior.Default` reference; otherwise it leaves the code untouched (no stale rewrite).
- Wiring: `SetExplicitMockBehaviorFixer` (Moq1400) passes `true`; `SetStrictMockBehaviorFixer` passes `false`, preserving its existing behavior (no regression).

### Tests
- **Negative:** stale `Default`-already-explicit argument → fixer refuses (no change).
- **Positive:** argument still `MockBehavior.Default` → replaced with explicit behavior.
- **Boundary:** compound `MockBehavior.Default | MockBehavior.Loose` → detected and handled.

## Validation
- `dotnet build -p:PedanticMode=true`: 0 warnings, 0 errors
- `dotnet test` (full suite, husky pre-push): pass
- Moq version: 4.18.4

Closes #1296

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the explicit mock behavior code fix so it only updates an existing setting when the current value still matches the expected default state.
  * Prevents overwriting user changes when the surrounding code has already been modified.
* **Tests**
  * Added coverage for default, loose, and strict mock behavior scenarios.
  * Added new cases for stale code-fix situations to verify both no-op and successful update behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->