### PR TITLE
perf(analyzers): name pre-filter before GetSymbolInfo + thread CancellationToken (#1259)

### DIFF
--- a/src/Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/src/Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -75,7 +75,7 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
             return;
         }
 
-        if (!semanticModel.IsCallbackOrReturnInvocation(callbackOrReturnsInvocation, knownSymbols))
+        if (!semanticModel.IsCallbackOrReturnInvocation(callbackOrReturnsInvocation, knownSymbols, context.CancellationToken))
         {
             return;
         }
@@ -163,7 +163,7 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
         }
         else
         {
-            IEnumerable<IMethodSymbol> mockedMethodSymbols = semanticModel.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(setupInvocation);
+            IEnumerable<IMethodSymbol> mockedMethodSymbols = semanticModel.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(setupInvocation, context.CancellationToken);
             ValidateParameters(context, semanticModel, mockedMethodSymbols, lambdaParameters, methodName);
         }
     }

--- a/src/Analyzers/EventSetupHandlerShouldMatchEventTypeAnalyzer.cs
+++ b/src/Analyzers/EventSetupHandlerShouldMatchEventTypeAnalyzer.cs
@@ -50,12 +50,12 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
         // Check if this is a SetupAdd or SetupRemove method call on a Mock<T>
-        if (!IsEventSetupMethodCall(context.SemanticModel, invocation, knownSymbols))
+        if (!IsEventSetupMethodCall(context.SemanticModel, invocation, knownSymbols, context.CancellationToken))
         {
             return;
         }
 
-        if (!TryGetEventSetupArguments(invocation, context.SemanticModel, out ExpressionSyntax? handlerExpression, out ITypeSymbol? expectedEventType, out string? eventName))
+        if (!TryGetEventSetupArguments(invocation, context.SemanticModel, out ExpressionSyntax? handlerExpression, out ITypeSymbol? expectedEventType, out string? eventName, context.CancellationToken))
         {
             return;
         }
@@ -63,9 +63,19 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
         ValidateHandlerType(context, knownSymbols, handlerExpression!, expectedEventType!, eventName!);
     }
 
-    private static bool IsEventSetupMethodCall(SemanticModel semanticModel, InvocationExpressionSyntax invocation, MoqKnownSymbols knownSymbols)
+    private static bool IsEventSetupMethodCall(
+        SemanticModel semanticModel,
+        InvocationExpressionSyntax invocation,
+        MoqKnownSymbols knownSymbols,
+        CancellationToken cancellationToken)
     {
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+        // ADR-001 permits this name check only as a pre-filter; the symbol check below is authoritative.
+        if (!invocation.CouldBeInvocationWithAnyMethodName("SetupAdd", "SetupRemove"))
+        {
+            return false;
+        }
+
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
         if (symbolInfo.Symbol is not IMethodSymbol methodSymbol)
         {
             return false;
@@ -74,7 +84,13 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
         return methodSymbol.IsMoqEventSetupMethod(knownSymbols);
     }
 
-    private static bool TryGetEventSetupArguments(InvocationExpressionSyntax invocation, SemanticModel semanticModel, out ExpressionSyntax? handlerExpression, out ITypeSymbol? expectedEventType, out string? eventName)
+    private static bool TryGetEventSetupArguments(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        out ExpressionSyntax? handlerExpression,
+        out ITypeSymbol? expectedEventType,
+        out string? eventName,
+        CancellationToken cancellationToken)
     {
         handlerExpression = null;
         expectedEventType = null;
@@ -91,7 +107,7 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
 
         // First argument should be a lambda that sets up the event handler
         ExpressionSyntax setupExpression = arguments[0].Expression;
-        if (!TryGetEventAndHandlerFromSetup(semanticModel, setupExpression, out ITypeSymbol? eventType, out ExpressionSyntax? handler, out string? name))
+        if (!TryGetEventAndHandlerFromSetup(semanticModel, setupExpression, out ITypeSymbol? eventType, out ExpressionSyntax? handler, out string? name, cancellationToken))
         {
             return false;
         }
@@ -102,7 +118,13 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
         return true;
     }
 
-    private static bool TryGetEventAndHandlerFromSetup(SemanticModel semanticModel, ExpressionSyntax setupExpression, out ITypeSymbol? eventType, out ExpressionSyntax? handlerExpression, out string? eventName)
+    private static bool TryGetEventAndHandlerFromSetup(
+        SemanticModel semanticModel,
+        ExpressionSyntax setupExpression,
+        out ITypeSymbol? eventType,
+        out ExpressionSyntax? handlerExpression,
+        out string? eventName,
+        CancellationToken cancellationToken)
     {
         eventType = null;
         handlerExpression = null;
@@ -128,7 +150,7 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess, cancellationToken);
         if (symbolInfo.Symbol is not IEventSymbol eventSymbol)
         {
             return false;
@@ -143,7 +165,7 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
     private static void ValidateHandlerType(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols, ExpressionSyntax handlerExpression, ITypeSymbol expectedEventType, string eventName)
     {
         // Get the handler type from the expression
-        if (!TryGetHandlerTypeFromExpression(context.SemanticModel, knownSymbols, handlerExpression, out ITypeSymbol? handlerType))
+        if (!TryGetHandlerTypeFromExpression(context.SemanticModel, knownSymbols, handlerExpression, out ITypeSymbol? handlerType, context.CancellationToken))
         {
             return;
         }
@@ -161,7 +183,12 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
         }
     }
 
-    private static bool TryGetHandlerTypeFromExpression(SemanticModel semanticModel, MoqKnownSymbols knownSymbols, ExpressionSyntax handlerExpression, out ITypeSymbol? handlerType)
+    private static bool TryGetHandlerTypeFromExpression(
+        SemanticModel semanticModel,
+        MoqKnownSymbols knownSymbols,
+        ExpressionSyntax handlerExpression,
+        out ITypeSymbol? handlerType,
+        CancellationToken cancellationToken)
     {
         handlerType = null;
 
@@ -172,7 +199,7 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
             genericName.TypeArgumentList.Arguments.Count == 1)
         {
             // Use semantic model to check if this is actually It.IsAny
-            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess);
+            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess, cancellationToken);
             if (symbolInfo.Symbol is IMethodSymbol methodSymbol &&
                 methodSymbol.IsInstanceOf(knownSymbols.ItIsAny))
             {
@@ -181,14 +208,14 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
                 // path also cause compiler errors before the analyzer runs. The analyzer is designed to
                 // catch subtle Moq-specific type compatibility issues that pass C# compiler validation
                 // but are semantically incorrect for event handler assignment.
-                TypeInfo typeInfo = semanticModel.GetTypeInfo(genericName.TypeArgumentList.Arguments[0]);
+                TypeInfo typeInfo = semanticModel.GetTypeInfo(genericName.TypeArgumentList.Arguments[0], cancellationToken);
                 handlerType = typeInfo.Type;
                 return handlerType != null;
             }
         }
 
         // For other expressions, get the type directly
-        TypeInfo expressionTypeInfo = semanticModel.GetTypeInfo(handlerExpression);
+        TypeInfo expressionTypeInfo = semanticModel.GetTypeInfo(handlerExpression, cancellationToken);
         handlerType = expressionTypeInfo.ConvertedType;
         return handlerType != null;
     }

--- a/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
@@ -264,7 +264,7 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
             return;
         }
 
-        Location? memberLocation = GetMemberReferenceLocation(lambdaOperation, memberSymbol, context.Operation.SemanticModel);
+        Location? memberLocation = GetMemberReferenceLocation(lambdaOperation, memberSymbol, context.Operation.SemanticModel, context.CancellationToken);
         if (memberLocation == null)
         {
             return;
@@ -316,19 +316,23 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// <summary>
     /// Attempts to find the specific syntax location of the member reference within the lambda using symbol-based matching.
     /// </summary>
-    private static Location? GetMemberReferenceLocation(IAnonymousFunctionOperation lambdaOperation, ISymbol memberSymbol, SemanticModel? semanticModel)
+    private static Location? GetMemberReferenceLocation(
+        IAnonymousFunctionOperation lambdaOperation,
+        ISymbol memberSymbol,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken)
     {
         SyntaxNode syntax = lambdaOperation.Syntax;
 
         // 1. Try InvocationExpressionSyntax (for method calls)
-        Location? location = syntax.FindLocation<InvocationExpressionSyntax>(memberSymbol, semanticModel);
+        Location? location = syntax.FindLocation<InvocationExpressionSyntax>(memberSymbol, semanticModel, cancellationToken);
         if (location != null)
         {
             return location;
         }
 
         // 2. Try MemberAccessExpressionSyntax (for property/field access)
-        location = syntax.FindLocation<MemberAccessExpressionSyntax>(memberSymbol, semanticModel);
+        location = syntax.FindLocation<MemberAccessExpressionSyntax>(memberSymbol, semanticModel, cancellationToken);
         if (location != null)
         {
             return location;

--- a/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -64,24 +64,34 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticAn
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
         // Check if this is a Raise method call on a Mock<T>
-        if (!IsRaiseMethodCall(context.SemanticModel, invocation, knownSymbols))
+        if (!IsRaiseMethodCall(context.SemanticModel, invocation, knownSymbols, context.CancellationToken))
         {
             return;
         }
 
-        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes, out bool senderCanBeOmitted))
+        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes, out bool senderCanBeOmitted, context.CancellationToken))
         {
             return;
         }
 
-        string eventName = EventSyntaxExtensions.GetEventNameFromSelector(invocation, context.SemanticModel);
+        string eventName = EventSyntaxExtensions.GetEventNameFromSelector(invocation, context.SemanticModel, context.CancellationToken);
 
         context.ValidateEventArgumentTypes(eventArguments, expectedParameterTypes, senderCanBeOmitted, knownSymbols.EventArgs, invocation, Rule, eventName);
     }
 
-    private static bool IsRaiseMethodCall(SemanticModel semanticModel, InvocationExpressionSyntax invocation, MoqKnownSymbols knownSymbols)
+    private static bool IsRaiseMethodCall(
+        SemanticModel semanticModel,
+        InvocationExpressionSyntax invocation,
+        MoqKnownSymbols knownSymbols,
+        CancellationToken cancellationToken)
     {
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+        // ADR-001 permits this name check only as a pre-filter; the symbol check below is authoritative.
+        if (!invocation.CouldBeInvocationWithMethodName("Raise"))
+        {
+            return false;
+        }
+
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
         if (symbolInfo.Symbol is not IMethodSymbol methodSymbol)
         {
             return false;

--- a/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -66,17 +66,17 @@ public class RaisesEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticA
     {
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
-        if (!context.SemanticModel.IsRaisesInvocation(invocation, knownSymbols))
+        if (!context.SemanticModel.IsRaisesInvocation(invocation, knownSymbols, context.CancellationToken))
         {
             return;
         }
 
-        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes, out bool senderCanBeOmitted))
+        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes, out bool senderCanBeOmitted, context.CancellationToken))
         {
             return;
         }
 
-        string eventName = EventSyntaxExtensions.GetEventNameFromSelector(invocation, context.SemanticModel);
+        string eventName = EventSyntaxExtensions.GetEventNameFromSelector(invocation, context.SemanticModel, context.CancellationToken);
 
         context.ValidateEventArgumentTypes(eventArguments, expectedParameterTypes, senderCanBeOmitted, knownSymbols.EventArgs, invocation, Rule, eventName);
     }

--- a/src/Analyzers/ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer.cs
+++ b/src/Analyzers/ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer.cs
@@ -50,21 +50,21 @@ public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer : DiagnosticAnalyze
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
         // Check if this is a Returns method call with async lambda
-        if (!IsReturnsMethodCallWithAsyncLambda(invocation, context.SemanticModel, knownSymbols))
+        if (!IsReturnsMethodCallWithAsyncLambda(invocation, context.SemanticModel, knownSymbols, context.CancellationToken))
         {
             return;
         }
 
         // Find the Setup call that this Returns is chained from
         MemberAccessExpressionSyntax memberAccess = (MemberAccessExpressionSyntax)invocation.Expression;
-        InvocationExpressionSyntax? setupInvocation = memberAccess.Expression.FindSetupInvocation(context.SemanticModel, knownSymbols);
+        InvocationExpressionSyntax? setupInvocation = memberAccess.Expression.FindSetupInvocation(context.SemanticModel, knownSymbols, context.CancellationToken);
         if (setupInvocation == null)
         {
             return;
         }
 
         // Check if the Setup is for an async method and get the method name
-        string? methodName = GetAsyncMethodName(setupInvocation, context.SemanticModel, knownSymbols);
+        string? methodName = GetAsyncMethodName(setupInvocation, context.SemanticModel, knownSymbols, context.CancellationToken);
         if (methodName == null)
         {
             return;
@@ -81,16 +81,21 @@ public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer : DiagnosticAnalyze
         context.ReportDiagnostic(diagnostic);
     }
 
-    private static bool IsReturnsMethodCallWithAsyncLambda(InvocationExpressionSyntax invocation, SemanticModel semanticModel, MoqKnownSymbols knownSymbols)
+    private static bool IsReturnsMethodCallWithAsyncLambda(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        MoqKnownSymbols knownSymbols,
+        CancellationToken cancellationToken)
     {
-        if (invocation.Expression is not MemberAccessExpressionSyntax)
+        // ADR-001 permits this name check only as a pre-filter; the symbol check below is authoritative.
+        if (invocation.Expression is not MemberAccessExpressionSyntax { Name.Identifier.ValueText: "Returns" })
         {
             return false;
         }
 
         // Query the invocation (not the MemberAccessExpressionSyntax) so Roslyn has argument context
         // for overload resolution. Fall back to CandidateSymbols for delegate overloads.
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
         bool isReturnsMethod = symbolInfo.Symbol is IMethodSymbol method
             ? method.IsMoqReturnsMethod(knownSymbols)
             : symbolInfo.CandidateSymbols
@@ -120,7 +125,11 @@ public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer : DiagnosticAnalyze
                lambda.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword);
     }
 
-    private static string? GetAsyncMethodName(InvocationExpressionSyntax setupInvocation, SemanticModel semanticModel, MoqKnownSymbols knownSymbols)
+    private static string? GetAsyncMethodName(
+        InvocationExpressionSyntax setupInvocation,
+        SemanticModel semanticModel,
+        MoqKnownSymbols knownSymbols,
+        CancellationToken cancellationToken)
     {
         // Check if this is a Setup method call
         if (setupInvocation.Expression is not MemberAccessExpressionSyntax setupMemberAccess)
@@ -128,7 +137,7 @@ public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer : DiagnosticAnalyze
             return null;
         }
 
-        SymbolInfo setupSymbolInfo = semanticModel.GetSymbolInfo(setupMemberAccess);
+        SymbolInfo setupSymbolInfo = semanticModel.GetSymbolInfo(setupMemberAccess, cancellationToken);
         if (setupSymbolInfo.Symbol is null || !setupSymbolInfo.Symbol.IsMoqSetupMethod(knownSymbols))
         {
             return null;
@@ -141,7 +150,7 @@ public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer : DiagnosticAnalyze
             return null;
         }
 
-        SymbolInfo mockedSymbolInfo = semanticModel.GetSymbolInfo(mockedMemberExpression);
+        SymbolInfo mockedSymbolInfo = semanticModel.GetSymbolInfo(mockedMemberExpression, cancellationToken);
         if (mockedSymbolInfo.Symbol is not IMethodSymbol mockedMethod)
         {
             return null;

--- a/src/Analyzers/ReturnsDelegateShouldReturnTaskAnalyzer.cs
+++ b/src/Analyzers/ReturnsDelegateShouldReturnTaskAnalyzer.cs
@@ -52,12 +52,26 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
     {
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
-        if (!IsReturnsMethodCallWithSyncDelegate(invocation, context.SemanticModel, knownSymbols, out MemberAccessExpressionSyntax? memberAccess, out InvocationExpressionSyntax? setupInvocation))
+        if (!IsReturnsMethodCallWithSyncDelegate(
+            invocation,
+            context.SemanticModel,
+            knownSymbols,
+            out MemberAccessExpressionSyntax? memberAccess,
+            out InvocationExpressionSyntax? setupInvocation,
+            context.CancellationToken))
         {
             return;
         }
 
-        if (!TryGetMismatchInfo(setupInvocation, invocation, context.SemanticModel, knownSymbols, out string? methodName, out ITypeSymbol? expectedReturnType, out ITypeSymbol? delegateReturnType))
+        if (!TryGetMismatchInfo(
+            setupInvocation,
+            invocation,
+            context.SemanticModel,
+            knownSymbols,
+            out string? methodName,
+            out ITypeSymbol? expectedReturnType,
+            out ITypeSymbol? delegateReturnType,
+            context.CancellationToken))
         {
             return;
         }
@@ -79,19 +93,21 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
         SemanticModel semanticModel,
         MoqKnownSymbols knownSymbols,
         [NotNullWhen(true)] out MemberAccessExpressionSyntax? memberAccess,
-        [NotNullWhen(true)] out InvocationExpressionSyntax? setupInvocation)
+        [NotNullWhen(true)] out InvocationExpressionSyntax? setupInvocation,
+        CancellationToken cancellationToken)
     {
         memberAccess = null;
         setupInvocation = null;
 
-        if (invocation.Expression is not MemberAccessExpressionSyntax access)
+        // ADR-001 permits this name check only as a pre-filter; the symbol check below is authoritative.
+        if (invocation.Expression is not MemberAccessExpressionSyntax { Name.Identifier.ValueText: "Returns" } access)
         {
             return false;
         }
 
         // Query the invocation (not the MemberAccessExpressionSyntax) so Roslyn has argument context
         // for overload resolution. Fall back to CandidateSymbols for delegate overloads.
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
         bool isReturnsMethod = symbolInfo.Symbol is IMethodSymbol method
             ? method.IsMoqReturnsMethod(knownSymbols)
             : symbolInfo.CandidateReason is CandidateReason.OverloadResolutionFailure
@@ -104,12 +120,12 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        if (!HasSyncDelegateArgument(invocation, semanticModel))
+        if (!HasSyncDelegateArgument(invocation, semanticModel, cancellationToken))
         {
             return false;
         }
 
-        setupInvocation = access.Expression.FindSetupInvocation(semanticModel, knownSymbols);
+        setupInvocation = access.Expression.FindSetupInvocation(semanticModel, knownSymbols, cancellationToken);
         if (setupInvocation == null)
         {
             return false;
@@ -119,7 +135,10 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
         return true;
     }
 
-    private static bool HasSyncDelegateArgument(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+    private static bool HasSyncDelegateArgument(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         if (invocation.ArgumentList.Arguments.Count == 0)
         {
@@ -136,10 +155,13 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
         }
 
         // Method groups require semantic resolution to distinguish from raw values.
-        return IsMethodGroupExpression(firstArgument, semanticModel);
+        return IsMethodGroupExpression(firstArgument, semanticModel, cancellationToken);
     }
 
-    private static bool IsMethodGroupExpression(ExpressionSyntax expression, SemanticModel semanticModel)
+    private static bool IsMethodGroupExpression(
+        ExpressionSyntax expression,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         // Invocations (e.g., GetInt()) resolve to IMethodSymbol but are values, not method groups.
         if (expression is InvocationExpressionSyntax)
@@ -147,7 +169,7 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(expression);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
         if (symbolInfo.Symbol is IMethodSymbol)
         {
             return true;
@@ -165,7 +187,8 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
         MoqKnownSymbols knownSymbols,
         [NotNullWhen(true)] out string? methodName,
         [NotNullWhen(true)] out ITypeSymbol? expectedReturnType,
-        [NotNullWhen(true)] out ITypeSymbol? delegateReturnType)
+        [NotNullWhen(true)] out ITypeSymbol? delegateReturnType,
+        CancellationToken cancellationToken)
     {
         methodName = null;
         expectedReturnType = null;
@@ -178,7 +201,7 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
             return false;
         }
 
-        SymbolInfo mockedSymbolInfo = semanticModel.GetSymbolInfo(mockedMemberExpression);
+        SymbolInfo mockedSymbolInfo = semanticModel.GetSymbolInfo(mockedMemberExpression, cancellationToken);
         if (mockedSymbolInfo.Symbol is not IMethodSymbol mockedMethod)
         {
             return false;
@@ -198,7 +221,7 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
         }
 
         // Get the delegate's return type from the Returns() argument
-        delegateReturnType = GetDelegateReturnType(returnsInvocation, semanticModel);
+        delegateReturnType = GetDelegateReturnType(returnsInvocation, semanticModel, cancellationToken);
         if (delegateReturnType == null)
         {
             return false;
@@ -215,7 +238,10 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
         return true;
     }
 
-    private static ITypeSymbol? GetDelegateReturnType(InvocationExpressionSyntax returnsInvocation, SemanticModel semanticModel)
+    private static ITypeSymbol? GetDelegateReturnType(
+        InvocationExpressionSyntax returnsInvocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         if (returnsInvocation.ArgumentList.Arguments.Count == 0)
         {
@@ -230,7 +256,7 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
         if (HasExplicitReturnsTypeArguments(returnsInvocation)
             && firstArgument is AnonymousFunctionExpressionSyntax anonymousFunction)
         {
-            return GetReturnTypeFromAnonymousFunction(anonymousFunction, semanticModel);
+            return GetReturnTypeFromAnonymousFunction(anonymousFunction, semanticModel, cancellationToken);
         }
 
         // For anonymous methods, prefer body analysis. Roslyn may infer the return type
@@ -238,12 +264,12 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
         // masking the actual body return type (e.g., int).
         if (firstArgument is AnonymousMethodExpressionSyntax { Body: BlockSyntax block })
         {
-            return GetReturnTypeFromBlock(block, semanticModel);
+            return GetReturnTypeFromBlock(block, semanticModel, cancellationToken);
         }
 
         // GetSymbolInfo resolves lambdas to IMethodSymbol even when type conversion fails.
         // Raw values resolve to ILocalSymbol/IFieldSymbol/etc., filtered by the type check.
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(firstArgument);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(firstArgument, cancellationToken);
         if (symbolInfo.Symbol is IMethodSymbol methodSymbol)
         {
             return methodSymbol.ReturnType;
@@ -271,13 +297,14 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
 
     private static ITypeSymbol? GetReturnTypeFromAnonymousFunction(
         AnonymousFunctionExpressionSyntax anonymousFunction,
-        SemanticModel semanticModel)
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         Debug.Assert(!anonymousFunction.AsyncKeyword.IsKind(SyntaxKind.AsyncKeyword), "Async lambdas are handled by Moq1206.");
 
         if (anonymousFunction is AnonymousMethodExpressionSyntax { Body: BlockSyntax anonymousMethodBlock })
         {
-            return GetReturnTypeFromBlock(anonymousMethodBlock, semanticModel);
+            return GetReturnTypeFromBlock(anonymousMethodBlock, semanticModel, cancellationToken);
         }
 
         // AnonymousMethodExpressionSyntax (handled above) and LambdaExpressionSyntax are the
@@ -287,15 +314,18 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
 
         if (lambda.Block is BlockSyntax lambdaBlock)
         {
-            return GetReturnTypeFromBlock(lambdaBlock, semanticModel);
+            return GetReturnTypeFromBlock(lambdaBlock, semanticModel, cancellationToken);
         }
 
         // A lambda without a block body always has an expression body.
         Debug.Assert(lambda.ExpressionBody is not null, "A block-less lambda has an expression body.");
-        return semanticModel.GetTypeInfo(lambda.ExpressionBody!).Type;
+        return semanticModel.GetTypeInfo(lambda.ExpressionBody!, cancellationToken).Type;
     }
 
-    private static ITypeSymbol? GetReturnTypeFromBlock(BlockSyntax block, SemanticModel semanticModel)
+    private static ITypeSymbol? GetReturnTypeFromBlock(
+        BlockSyntax block,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken)
     {
         // Find the first return statement in this block,
         // pruning nested functions so we don't pick up their returns.
@@ -311,6 +341,6 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
             return null;
         }
 
-        return semanticModel.GetTypeInfo(returnStatement.Expression).Type;
+        return semanticModel.GetTypeInfo(returnStatement.Expression, cancellationToken).Type;
     }
 }

--- a/src/Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/src/Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -58,7 +58,8 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
     {
         InvocationExpressionSyntax setupInvocation = (InvocationExpressionSyntax)context.Node;
 
-        if (setupInvocation.Expression is not MemberAccessExpressionSyntax memberAccessExpression)
+        // ADR-001 permits this name check only as a pre-filter; the symbol check below is authoritative.
+        if (setupInvocation.Expression is not MemberAccessExpressionSyntax { Name.Identifier.ValueText: "Setup" } memberAccessExpression)
         {
             return;
         }

--- a/src/CodeFixes/CallbackSignatureShouldMatchMockedMethodFixer.cs
+++ b/src/CodeFixes/CallbackSignatureShouldMatchMockedMethodFixer.cs
@@ -162,7 +162,7 @@ public class CallbackSignatureShouldMatchMockedMethodFixer : CodeFixProvider
         }
 
         // Short-circuit: we only need to know if there is exactly one match.
-        IMethodSymbol[] matchingMockedMethods = semanticModel.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(setupMethodInvocation).Take(2).ToArray();
+        IMethodSymbol[] matchingMockedMethods = semanticModel.GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(setupMethodInvocation, cancellationToken).Take(2).ToArray();
 
         if (matchingMockedMethods.Length != 1)
         {

--- a/src/Common/EventSyntaxExtensions.cs
+++ b/src/Common/EventSyntaxExtensions.cs
@@ -225,6 +225,7 @@ internal static class EventSyntaxExtensions
     /// <param name="eventArguments">The extracted event arguments.</param>
     /// <param name="expectedParameterTypes">The expected parameter types.</param>
     /// <param name="senderCanBeOmitted">Whether the sender argument may be omitted (EventHandler-shaped delegates).</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns><see langword="true" /> if arguments were successfully extracted; otherwise, <see langword="false" />.</returns>
     internal static bool TryGetEventMethodArgumentsFromLambdaSelector(
         InvocationExpressionSyntax invocation,
@@ -232,7 +233,8 @@ internal static class EventSyntaxExtensions
         KnownSymbols knownSymbols,
         out ArgumentSyntax[] eventArguments,
         out ITypeSymbol[] expectedParameterTypes,
-        out bool senderCanBeOmitted)
+        out bool senderCanBeOmitted,
+        CancellationToken cancellationToken = default)
     {
         return TryGetEventMethodArguments(
             invocation,
@@ -240,9 +242,9 @@ internal static class EventSyntaxExtensions
             out eventArguments,
             out expectedParameterTypes,
             out senderCanBeOmitted,
-            static (sm, selector) =>
+            (sm, selector) =>
             {
-                bool success = sm.TryGetEventTypeFromLambdaSelector(selector, out ITypeSymbol? eventType);
+                bool success = sm.TryGetEventTypeFromLambdaSelector(selector, out ITypeSymbol? eventType, cancellationToken);
                 return (success, eventType);
             },
             knownSymbols);
@@ -253,8 +255,12 @@ internal static class EventSyntaxExtensions
     /// </summary>
     /// <param name="invocation">The method invocation containing the lambda selector.</param>
     /// <param name="semanticModel">The semantic model.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The event name if found; otherwise "event" as a fallback.</returns>
-    internal static string GetEventNameFromSelector(InvocationExpressionSyntax invocation, SemanticModel semanticModel)
+    internal static string GetEventNameFromSelector(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken = default)
     {
         SeparatedSyntaxList<ArgumentSyntax> arguments = invocation.ArgumentList.Arguments;
         if (arguments.Count < 1)
@@ -264,7 +270,7 @@ internal static class EventSyntaxExtensions
 
         ExpressionSyntax eventSelector = arguments[0].Expression;
 
-        return semanticModel.TryGetEventNameFromLambdaSelector(eventSelector, out string? eventName)
+        return semanticModel.TryGetEventNameFromLambdaSelector(eventSelector, out string? eventName, cancellationToken)
             ? eventName!
             : "event";
     }

--- a/src/Common/InvocationExpressionSyntaxExtensions.cs
+++ b/src/Common/InvocationExpressionSyntaxExtensions.cs
@@ -23,8 +23,13 @@ internal static class InvocationExpressionSyntaxExtensions
     /// <param name="receiver">The receiver expression to start walking from (typically the expression before the Returns call).</param>
     /// <param name="semanticModel">The semantic model for symbol resolution.</param>
     /// <param name="knownSymbols">The known Moq symbols for type checking.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The Setup invocation if found; otherwise, <see langword="null"/>.</returns>
-    internal static InvocationExpressionSyntax? FindSetupInvocation(this ExpressionSyntax receiver, SemanticModel semanticModel, MoqKnownSymbols knownSymbols)
+    internal static InvocationExpressionSyntax? FindSetupInvocation(
+        this ExpressionSyntax receiver,
+        SemanticModel semanticModel,
+        MoqKnownSymbols knownSymbols,
+        CancellationToken cancellationToken = default)
     {
         ExpressionSyntax current = receiver;
 
@@ -39,7 +44,7 @@ internal static class InvocationExpressionSyntaxExtensions
                 return null;
             }
 
-            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(candidateInvocation);
+            SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(candidateInvocation, cancellationToken);
             if (symbolInfo.Symbol != null && symbolInfo.Symbol.IsMoqSetupMethod(knownSymbols))
             {
                 return candidateInvocation;

--- a/src/Common/SemanticModelExtensions.cs
+++ b/src/Common/SemanticModelExtensions.cs
@@ -55,7 +55,10 @@ internal static class SemanticModelExtensions
         }
     }
 
-    internal static IEnumerable<IMethodSymbol> GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(this SemanticModel semanticModel, InvocationExpressionSyntax? setupMethodInvocation)
+    internal static IEnumerable<IMethodSymbol> GetAllMatchingMockedMethodSymbolsFromSetupMethodInvocation(
+        this SemanticModel semanticModel,
+        InvocationExpressionSyntax? setupMethodInvocation,
+        CancellationToken cancellationToken = default)
     {
         // Guard against incomplete or malformed setup invocations (for example a mid-edit
         // `Setup()` with no arguments), where indexing the first argument would throw.
@@ -68,25 +71,77 @@ internal static class SemanticModelExtensions
 
         return setupLambdaArgument?.Body is not InvocationExpressionSyntax mockedMethodInvocation
             ? []
-            : semanticModel.GetAllMatchingSymbols<IMethodSymbol>(mockedMethodInvocation);
+            : semanticModel.GetAllMatchingSymbols<IMethodSymbol>(mockedMethodInvocation, cancellationToken);
     }
 
-    internal static bool IsCallbackOrReturnInvocation(this SemanticModel semanticModel, InvocationExpressionSyntax callbackOrReturnsInvocation, MoqKnownSymbols knownSymbols)
+    internal static bool IsCallbackOrReturnInvocation(
+        this SemanticModel semanticModel,
+        InvocationExpressionSyntax callbackOrReturnsInvocation,
+        MoqKnownSymbols knownSymbols,
+        CancellationToken cancellationToken = default)
     {
         return semanticModel.IsMoqFluentInvocation(
             callbackOrReturnsInvocation,
             CallbackOrReturnNames,
             knownSymbols,
-            static (symbol, ks) => IsCallbackOrReturnSymbol(symbol, ks));
+            static (symbol, ks) => IsCallbackOrReturnSymbol(symbol, ks),
+            cancellationToken);
     }
 
-    internal static bool IsRaisesInvocation(this SemanticModel semanticModel, InvocationExpressionSyntax raisesInvocation, MoqKnownSymbols knownSymbols)
+    internal static bool IsRaisesInvocation(
+        this SemanticModel semanticModel,
+        InvocationExpressionSyntax raisesInvocation,
+        MoqKnownSymbols knownSymbols,
+        CancellationToken cancellationToken = default)
     {
         return semanticModel.IsMoqFluentInvocation(
             raisesInvocation,
             RaisesNames,
             knownSymbols,
-            static (symbol, ks) => symbol.IsMoqRaisesMethod(ks));
+            static (symbol, ks) => symbol.IsMoqRaisesMethod(ks),
+            cancellationToken);
+    }
+
+    /// <summary>
+    /// Determines whether an invocation can match a method name before semantic binding.
+    /// </summary>
+    /// <remarks>
+    /// ADR-001 permits this string check only as a pre-filter. Unknown invocation shapes
+    /// return <see langword="true"/> so the later symbol check remains authoritative.
+    /// </remarks>
+    /// <param name="invocation">The invocation to inspect.</param>
+    /// <param name="methodName">The method name that may match.</param>
+    /// <returns><see langword="false"/> only when the syntax method name is known and cannot match.</returns>
+    internal static bool CouldBeInvocationWithMethodName(this InvocationExpressionSyntax invocation, string methodName)
+    {
+        Debug.Assert(!string.IsNullOrEmpty(methodName), "A pre-filter name must be non-empty.");
+
+        return !TryGetInvocationMethodName(invocation, out string? invocationMethodName)
+            || string.Equals(invocationMethodName, methodName, StringComparison.Ordinal);
+    }
+
+    /// <summary>
+    /// Determines whether an invocation can match either method name before semantic binding.
+    /// </summary>
+    /// <remarks>
+    /// ADR-001 permits this string check only as a pre-filter. Unknown invocation shapes
+    /// return <see langword="true"/> so the later symbol check remains authoritative.
+    /// </remarks>
+    /// <param name="invocation">The invocation to inspect.</param>
+    /// <param name="firstMethodName">The first method name that may match.</param>
+    /// <param name="secondMethodName">The second method name that may match.</param>
+    /// <returns><see langword="false"/> only when the syntax method name is known and cannot match.</returns>
+    internal static bool CouldBeInvocationWithAnyMethodName(
+        this InvocationExpressionSyntax invocation,
+        string firstMethodName,
+        string secondMethodName)
+    {
+        Debug.Assert(!string.IsNullOrEmpty(firstMethodName), "A pre-filter name must be non-empty.");
+        Debug.Assert(!string.IsNullOrEmpty(secondMethodName), "A pre-filter name must be non-empty.");
+
+        return !TryGetInvocationMethodName(invocation, out string? invocationMethodName)
+            || string.Equals(invocationMethodName, firstMethodName, StringComparison.Ordinal)
+            || string.Equals(invocationMethodName, secondMethodName, StringComparison.Ordinal);
     }
 
     /// <summary>
@@ -159,13 +214,20 @@ internal static class SemanticModelExtensions
     /// <param name="semanticModel">The semantic model.</param>
     /// <param name="eventSelector">The lambda event selector expression.</param>
     /// <param name="eventName">The extracted event name, if found.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns><see langword="true" /> if the event name was found; otherwise, <see langword="false" />.</returns>
     internal static bool TryGetEventNameFromLambdaSelector(
         this SemanticModel semanticModel,
         ExpressionSyntax eventSelector,
-        out string? eventName)
+        out string? eventName,
+        CancellationToken cancellationToken = default)
     {
-        return TryGetEventPropertyFromLambdaSelector(semanticModel, eventSelector, static eventSymbol => eventSymbol.ToDisplayString(), out eventName);
+        return TryGetEventPropertyFromLambdaSelector(
+            semanticModel,
+            eventSelector,
+            static eventSymbol => eventSymbol.ToDisplayString(),
+            out eventName,
+            cancellationToken);
     }
 
     /// <summary>
@@ -174,13 +236,20 @@ internal static class SemanticModelExtensions
     /// <param name="semanticModel">The semantic model.</param>
     /// <param name="eventSelector">The lambda event selector expression.</param>
     /// <param name="eventType">The extracted event type, if found.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns><see langword="true" /> if the event type was found; otherwise, <see langword="false" />.</returns>
     internal static bool TryGetEventTypeFromLambdaSelector(
         this SemanticModel semanticModel,
         ExpressionSyntax eventSelector,
-        out ITypeSymbol? eventType)
+        out ITypeSymbol? eventType,
+        CancellationToken cancellationToken = default)
     {
-        return TryGetEventPropertyFromLambdaSelector(semanticModel, eventSelector, static eventSymbol => eventSymbol.Type, out eventType);
+        return TryGetEventPropertyFromLambdaSelector(
+            semanticModel,
+            eventSelector,
+            static eventSymbol => eventSymbol.Type,
+            out eventType,
+            cancellationToken);
     }
 
     /// <summary>
@@ -191,16 +260,18 @@ internal static class SemanticModelExtensions
     /// <param name="eventSelector">The lambda event selector expression.</param>
     /// <param name="propertySelector">A function to extract the desired property from the event symbol.</param>
     /// <param name="result">The extracted property, if found.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns><see langword="true" /> if the property was extracted; otherwise, <see langword="false" />.</returns>
     private static bool TryGetEventPropertyFromLambdaSelector<T>(
         SemanticModel semanticModel,
         ExpressionSyntax eventSelector,
         Func<IEventSymbol, T> propertySelector,
-        out T? result)
+        out T? result,
+        CancellationToken cancellationToken)
     {
         result = default;
 
-        if (TryGetEventSymbolFromLambdaSelector(semanticModel, eventSelector, out IEventSymbol? eventSymbol) &&
+        if (TryGetEventSymbolFromLambdaSelector(semanticModel, eventSelector, out IEventSymbol? eventSymbol, cancellationToken) &&
             eventSymbol != null)
         {
             result = propertySelector(eventSymbol);
@@ -210,12 +281,12 @@ internal static class SemanticModelExtensions
         return false;
     }
 
-    private static List<T> GetAllMatchingSymbols<T>(this SemanticModel semanticModel, ExpressionSyntax expression)
+    private static List<T> GetAllMatchingSymbols<T>(this SemanticModel semanticModel, ExpressionSyntax expression, CancellationToken cancellationToken)
         where T : class
     {
         List<T> matchingSymbols = new();
 
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(expression);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(expression, cancellationToken);
         switch (symbolInfo)
         {
             case { CandidateReason: CandidateReason.None, Symbol: T }:
@@ -256,11 +327,13 @@ internal static class SemanticModelExtensions
     /// <param name="semanticModel">The semantic model.</param>
     /// <param name="eventSelector">The lambda event selector expression.</param>
     /// <param name="eventSymbol">The extracted event symbol, if found.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns><see langword="true" /> if the event symbol was found; otherwise, <see langword="false" />.</returns>
     private static bool TryGetEventSymbolFromLambdaSelector(
         SemanticModel semanticModel,
         ExpressionSyntax eventSelector,
-        out IEventSymbol? eventSymbol)
+        out IEventSymbol? eventSymbol,
+        CancellationToken cancellationToken)
     {
         eventSymbol = null;
 
@@ -284,7 +357,7 @@ internal static class SemanticModelExtensions
         }
 
         // Get the symbol for the event
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess, cancellationToken);
         if (symbolInfo.Symbol is not IEventSymbol symbol)
         {
             return false;
@@ -308,14 +381,18 @@ internal static class SemanticModelExtensions
     /// <param name="fastPathNames">Method names for early rejection before the expensive GetSymbolInfo call.</param>
     /// <param name="knownSymbols">Known symbols passed through to the predicate to avoid closure allocations.</param>
     /// <param name="symbolPredicate">Predicate that validates the resolved symbol against known symbols.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns><see langword="true"/> if the invocation matches; otherwise, <see langword="false"/>.</returns>
     private static bool IsMoqFluentInvocation(
         this SemanticModel semanticModel,
         InvocationExpressionSyntax invocation,
         string[] fastPathNames,
         MoqKnownSymbols knownSymbols,
-        Func<ISymbol, MoqKnownSymbols, bool> symbolPredicate)
+        Func<ISymbol, MoqKnownSymbols, bool> symbolPredicate,
+        CancellationToken cancellationToken = default)
     {
+        Debug.Assert(fastPathNames.Length > 0, "At least one pre-filter name is required.");
+
         if (invocation.Expression is not MemberAccessExpressionSyntax memberAccess)
         {
             return false;
@@ -338,7 +415,7 @@ internal static class SemanticModelExtensions
             return false;
         }
 
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess);
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(memberAccess, cancellationToken);
         return symbolInfo.CandidateReason switch
         {
             CandidateReason.OverloadResolutionFailure => symbolInfo.CandidateSymbols.Any(s => symbolPredicate(s, knownSymbols)),
@@ -355,5 +432,27 @@ internal static class SemanticModelExtensions
         }
 
         return symbol.IsMoqCallbackMethod(knownSymbols) || symbol.IsMoqReturnsMethod(knownSymbols);
+    }
+
+    private static bool TryGetInvocationMethodName(InvocationExpressionSyntax invocation, out string? methodName)
+    {
+        switch (invocation.Expression)
+        {
+            case MemberAccessExpressionSyntax memberAccess:
+                methodName = memberAccess.Name.Identifier.ValueText;
+                return true;
+            case MemberBindingExpressionSyntax memberBinding:
+                methodName = memberBinding.Name.Identifier.ValueText;
+                return true;
+            case IdentifierNameSyntax identifier:
+                methodName = identifier.Identifier.ValueText;
+                return true;
+            case GenericNameSyntax genericName:
+                methodName = genericName.Identifier.ValueText;
+                return true;
+            default:
+                methodName = null;
+                return false;
+        }
     }
 }

--- a/src/Common/SyntaxNodeExtensions.cs
+++ b/src/Common/SyntaxNodeExtensions.cs
@@ -11,15 +11,20 @@ internal static class SyntaxNodeExtensions
     /// <param name="syntax">The root <see cref="SyntaxNode"/> to search from.</param>
     /// <param name="memberSymbol">The <see cref="ISymbol"/> to match.</param>
     /// <param name="semanticModel">The <see cref="SemanticModel"/> for symbol resolution.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
     /// <returns>The location of the matching node, or <see langword="null"/> if not found.</returns>
-    internal static Location? FindLocation<TSyntax>(this SyntaxNode syntax, ISymbol memberSymbol, SemanticModel? semanticModel)
+    internal static Location? FindLocation<TSyntax>(
+        this SyntaxNode syntax,
+        ISymbol memberSymbol,
+        SemanticModel? semanticModel,
+        CancellationToken cancellationToken = default)
         where TSyntax : SyntaxNode
     {
         TSyntax? node = syntax.DescendantNodes()
             .OfType<TSyntax>()
             .FirstOrDefault(n =>
             {
-                ISymbol? symbol = semanticModel?.GetSymbolInfo(n).Symbol;
+                ISymbol? symbol = semanticModel?.GetSymbolInfo(n, cancellationToken).Symbol;
                 return SymbolEqualityComparer.Default.Equals(symbol, memberSymbol);
             });
 

--- a/tests/Moq.Analyzers.Test/Common/SyntaxNodeExtensionsTests.cs
+++ b/tests/Moq.Analyzers.Test/Common/SyntaxNodeExtensionsTests.cs
@@ -63,7 +63,7 @@ class C
     public void FindLocation_NullSemanticModel_ReturnsNull()
     {
         // Arrange
-        const string code = "class C { void M() { } }";
+        const string code = "class C { void M() { N(); } void N() { } }";
         SyntaxTree tree = CSharpSyntaxTree.ParseText(code);
         SyntaxNode root = tree.GetRoot();
         (SemanticModel model, _) = CompilationHelper.CreateCompilation(code);

--- a/tests/Moq.Analyzers.Test/EventSetupHandlerShouldMatchEventTypeAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/EventSetupHandlerShouldMatchEventTypeAnalyzerTests.cs
@@ -32,6 +32,8 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzerTests
             ["""mockProvider.SetupAdd(x => x.SimpleEvent += It.IsAny<Action>());"""],
             ["""mockProvider.SetupRemove(x => x.StringEvent -= It.IsAny<Action<string>>());"""],
             ["""mockProvider.SetupAdd(x => x.CustomDelegate += It.IsAny<MyDelegate>());"""],
+            ["""mockProvider?.SetupRemove(x => x.StringEvent -= It.IsAny<Action<string>>());"""],
+            ["""new CustomEventSetup().SetupAdd(x => x.StringEvent += It.IsAny<Action<string>>());"""],
         }.WithNamespaces().WithNewMoqReferenceAssemblyGroups();
     }
 
@@ -56,6 +58,13 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzerTests
                 event EventHandler<CustomArgs> CustomEvent;
                 event Action SimpleEvent;
                 event MyDelegate CustomDelegate;
+            }
+
+            internal class CustomEventSetup
+            {
+                public void SetupAdd(Action<ITestInterface> setup)
+                {
+                }
             }
 
             internal class UnitTest
@@ -91,6 +100,13 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzerTests
                 event EventHandler<CustomArgs> CustomEvent;
                 event Action SimpleEvent;
                 event MyDelegate CustomDelegate;
+            }
+
+            internal class CustomEventSetup
+            {
+                public void SetupAdd(Action<ITestInterface> setup)
+                {
+                }
             }
 
             internal class UnitTest

--- a/tests/Moq.Analyzers.Test/RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests.cs
@@ -33,6 +33,15 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests
             // Valid: null literal for a reference-type parameter. The cast is required:
             // a bare 'null' is ambiguous between Raise(..., EventArgs) and Raise(..., params object[]) (CS0121).
             ["""mockProvider.Raise(p => p.StringOptionsChanged += null, (string)null);"""],
+
+            // Same method name on a non-Moq type must still be rejected by the symbol check
+            ["""new CustomRaiser().Raise(p => p.StringOptionsChanged += null, 42);"""],
+
+            // Direct generic invocation covers the shape-tolerant pre-filter's GenericNameSyntax path
+            ["""Raise<int>();"""],
+
+            // Delegate-array invocation has an unknown shape and must fall through to the symbol check
+            ["""Action[] actions = new Action[] { () => { } }; actions[0]();"""],
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
     }
 
@@ -119,6 +128,9 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests
 
             // Invalid: payload not convertible to EventArgs.
             ["""mock.Raise(n => n.Closed += null, {|Moq1202:42|});"""],
+
+            // Conditional access uses MemberBindingExpressionSyntax and must not be pre-filtered out.
+            ["""mock?.Raise(n => n.Closed += null, {|Moq1202:42|});"""],
 
             // Invalid: object payload is only EXPLICITLY convertible to EventArgs. Overload resolution
             // binds the params-object array overload instead of the EventArgs overload, so Moq does not
@@ -246,8 +258,19 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests
                   event Action<List<string>> ListChanged;
               }
 
+              internal class CustomRaiser
+              {
+                  public void Raise(Action<IOptionsProvider> selector, object value)
+                  {
+                  }
+              }
+
               internal class UnitTest
               {
+                  private static void Raise<T>()
+                  {
+                  }
+
                   private void Test()
                   {
                       var mockProvider = new Mock<IOptionsProvider>();

--- a/tests/Moq.Analyzers.Test/ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzerTests.cs
@@ -31,6 +31,9 @@ public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzerTests(ITestOutputHel
 
             // Double-parenthesized Setup with ReturnsAsync (valid)
             ["""((new Mock<AsyncClient>().Setup(c => c.GetAsync()))).ReturnsAsync("value");"""],
+
+            // Same method name on a non-Moq type must still be rejected by the symbol check
+            ["""new CustomReturns().Returns(async () => "value");"""],
         }.WithNamespaces().WithMoqReferenceAssemblyGroups();
 
         // Invalid patterns that SHOULD trigger the analyzer
@@ -89,6 +92,13 @@ public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzerTests(ITestOutputHel
                   public virtual ValueTask DoValueTaskAsync() => ValueTask.CompletedTask;
                   public virtual ValueTask<string> GetValueTaskAsync() => ValueTask.FromResult(string.Empty);
                   public virtual string GetSync() => string.Empty;
+              }
+
+              public class CustomReturns
+              {
+                  public void Returns(Func<Task<string>> value)
+                  {
+                  }
               }
 
               internal class UnitTest

--- a/tests/Moq.Analyzers.Test/ReturnsDelegateShouldReturnTaskAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/ReturnsDelegateShouldReturnTaskAnalyzerTests.cs
@@ -87,6 +87,9 @@ public class ReturnsDelegateShouldReturnTaskAnalyzerTests(ITestOutputHelper outp
 
             // Generic Returns<T> with async lambda is Moq1206's domain, not ours
             ["""new Mock<AsyncService>().Setup(c => c.ProcessAsync(It.IsAny<string>())).Returns<string>(async s => await Task.FromResult(s.Length));"""],
+
+            // Same method name on a non-Moq type must still be rejected by the symbol check
+            ["""new CustomReturns().Returns(() => 42);"""],
         };
 
         return data.WithNamespaces().WithMoqReferenceAssemblyGroups();
@@ -236,6 +239,13 @@ public class ReturnsDelegateShouldReturnTaskAnalyzerTests(ITestOutputHelper outp
                   public virtual Task<int> ProcessAsync(string input) => Task.FromResult(input.Length);
                   public virtual IList<int> GetItems() => new List<int>();
                   public virtual Task<int> Value { get; set; } = Task.FromResult(0);
+              }
+
+              public class CustomReturns
+              {
+                  public void Returns(Func<int> value)
+                  {
+                  }
               }
 
               internal class UnitTest

--- a/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetupShouldNotIncludeAsyncResultAnalyzerTests.cs
@@ -19,6 +19,9 @@ public class SetupShouldNotIncludeAsyncResultAnalyzerTests(ITestOutputHelper out
             ["""new Mock<AsyncClient>().Setup(c => {|Moq1201:c.GenericTaskAsync().Result|});"""],
 
             ["""new Mock<AsyncClient>().Setup(c => {|Moq1201:c.GenericValueTaskAsync().Result|});"""],
+
+            // Same method name on a non-Moq type must still be rejected by the symbol check
+            ["""new CustomSetup().Setup(c => c.GenericTaskAsync().Result);"""],
         }.WithNamespaces().WithOldMoqReferenceAssemblyGroups();
 
         // New Moq specific: Task<T>.Result should NOT produce diagnostic
@@ -47,6 +50,13 @@ public class SetupShouldNotIncludeAsyncResultAnalyzerTests(ITestOutputHelper out
                   public virtual ValueTask ValueTaskAsync() => ValueTask.CompletedTask;
 
                   public virtual ValueTask<string> GenericValueTaskAsync() => ValueTask.FromResult(string.Empty);
+              }
+
+              internal class CustomSetup
+              {
+                  public void Setup(System.Linq.Expressions.Expression<Func<AsyncClient, string>> expression)
+                  {
+                  }
               }
 
               internal class UnitTest


### PR DESCRIPTION
## Summary
Adds a cheap syntactic method-name pre-filter ahead of `GetSymbolInfo` and threads `CancellationToken` through the shared semantic helpers, reducing per-invocation analyzer work. No intended diagnostic-behavior change.

## Scope (larger than a single analyzer — please review ALL files)
Analyzers: CallbackSignatureShouldMatchMockedMethod (Moq1400), EventSetupHandlerShouldMatchEventType (Moq1205), LinqToMocksExpressionShouldBeValid, RaiseEventArgumentsShouldMatchEventSignature, ReturnsAsyncShouldBeUsedForAsyncMethods (Moq1206), ReturnsDelegateShouldReturnTask (Moq1208), SetupShouldNotIncludeAsyncResult (Moq1201). One fixer and four `src/Common` helpers (notably `SemanticModelExtensions.cs`, +135 lines: `CouldBeInvocationWithMethodName`/`TryGetInvocationMethodName`).

## Correctness argument
The pre-filter is an ADDITIVE constraint that only short-circuits the NEGATIVE/skip path; the authoritative `GetSymbolInfo`+`IsMoq*Method` symbol check still runs on every survivor, so no positive is ever concluded from a name alone. `CouldBe*` helpers return `true` conservatively on non-Member/Generic/Identifier shapes, preserving prior no-name-restriction behavior. Generic `Returns<T>` is preserved because `Name.Identifier.ValueText`/`TryGetInvocationMethodName` read the bare identifier (type args stripped).

## Validation
- PedanticMode build: 0 warnings, 0 errors
- Full suite (rebased on current main): `Passed! - Failed: 0, Passed: 4038`
- Added negative/edge tests for the affected analyzers

## Review status
A focused adversarial review confirmed SHIP for 5 of the 7 analyzers (Moq1201/1202/1205/1206/1208) with a proof that each pre-filter name set equals its required set. The remaining analyzers (Moq1400 CallbackSignature, LinqToMocks) and the fixer still need the same superset proof before merge. Do NOT merge until that review is complete and the perf + Codacy Coverage gates are green.

Closes #1259

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analyzer responsiveness by making code analysis more cancellation-aware.
  * Tightened setup detection so only valid setup calls are considered, reducing false positives.
  * Expanded handling for additional call patterns in event and callback-related checks, improving accuracy.

* **Tests**
  * Added broader test coverage for valid and invalid usage patterns, including non-matching method names and conditional-access scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->