### PR TITLE
refactor(analyzers): consolidate boilerplate via shared bases/helpers (#1273-#1276)

### DIFF
--- a/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
+++ b/src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Moq.Analyzers;
 /// Mock.As() should take interfaces only.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
+public class AsShouldBeUsedOnlyForInterfaceAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Invalid As type parameter";
     private static readonly LocalizableString Message = "Mock.As() should take interfaces only, but '{0}' is not an interface";
@@ -26,25 +26,8 @@ public class AsShouldBeUsedOnlyForInterfaceAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        // Only analyze if Moq is referenced - if we're analyzing Moq usage patterns, Moq should be available
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         // Look for the Mock.As() method and provide it to Analyze to avoid looking it up multiple times.
         ImmutableArray<IMethodSymbol> asMethods = ImmutableArray.CreateRange([
             ..knownSymbols.MockAs,

--- a/src/Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
+++ b/src/Analyzers/CallbackSignatureShouldMatchMockedMethodAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Moq.Analyzers;
 /// Callback signature must match the signature of the mocked method.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyzer
+public class CallbackSignatureShouldMatchMockedMethodAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Bad callback parameters";
     private static readonly LocalizableString Message = "Callback signature for '{0}' must match the signature of the mocked method";
@@ -26,24 +26,8 @@ public class CallbackSignatureShouldMatchMockedMethodAnalyzer : DiagnosticAnalyz
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterOperationAction(
             operationAnalysisContext => Analyze(operationAnalysisContext, knownSymbols),
             OperationKind.Invocation);

--- a/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -8,7 +8,7 @@ namespace Moq.Analyzers;
 /// This analyzer helps catch runtime failures related to constructor mismatches in Moq-based unit tests.
 /// </remarks>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
+public class ConstructorArgumentsShouldMatchAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly DiagnosticDescriptor ClassMustHaveMatchingConstructor = new(
         DiagnosticIds.NoMatchingConstructorRuleId,
@@ -33,13 +33,11 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(ClassMustHaveMatchingConstructor, InterfaceMustNotHaveConstructorParameters);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationStartAction(AnalyzeCompilation);
+        // These are for classes
+        context.RegisterSyntaxNodeAction(context => AnalyzeNewObject(context, knownSymbols), SyntaxKind.ObjectCreationExpression, SyntaxKind.ImplicitObjectCreationExpression);
+        context.RegisterSyntaxNodeAction(context => AnalyzeInstanceCall(context, knownSymbols), SyntaxKind.InvocationExpression);
     }
 
     /// <summary>
@@ -142,28 +140,6 @@ public class ConstructorArgumentsShouldMatchAnalyzer : DiagnosticAnalyzer
         {
             context.ReportDiagnostic(diagnostic);
         }
-    }
-
-    private static void AnalyzeCompilation(CompilationStartAnalysisContext context)
-    {
-        context.CancellationToken.ThrowIfCancellationRequested();
-
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        // We're interested in the few ways to create mocks:
-        //  - new Mock<T>()
-        //  - Mock.Of<T>()
-        //  - MockRepository.Create<T>()
-        //
-        // Ensure Moq is referenced in the compilation
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
-        // These are for classes
-        context.RegisterSyntaxNodeAction(context => AnalyzeNewObject(context, knownSymbols), SyntaxKind.ObjectCreationExpression, SyntaxKind.ImplicitObjectCreationExpression);
-        context.RegisterSyntaxNodeAction(context => AnalyzeInstanceCall(context, knownSymbols), SyntaxKind.InvocationExpression);
     }
 
     private static void AnalyzeInstanceCall(SyntaxNodeAnalysisContext context, MoqKnownSymbols knownSymbols)

--- a/src/Analyzers/EventSetupHandlerShouldMatchEventTypeAnalyzer.cs
+++ b/src/Analyzers/EventSetupHandlerShouldMatchEventTypeAnalyzer.cs
@@ -4,7 +4,7 @@ namespace Moq.Analyzers;
 /// Event setup handler type should match the event delegate type.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
+public class EventSetupHandlerShouldMatchEventTypeAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Event setup handler type should match event delegate type";
     private static readonly LocalizableString Message = "Event setup handler type should match the event delegate type for '{0}'";
@@ -23,23 +23,8 @@ public class EventSetupHandlerShouldMatchEventTypeAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterSyntaxNodeAction(
             syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
             SyntaxKind.InvocationExpression);

--- a/src/Analyzers/InternalTypeMustHaveInternalsVisibleToAnalyzer.cs
+++ b/src/Analyzers/InternalTypeMustHaveInternalsVisibleToAnalyzer.cs
@@ -9,7 +9,7 @@ namespace Moq.Analyzers;
 /// <c>[InternalsVisibleTo("DynamicProxyGenAssembly2")]</c>.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class InternalTypeMustHaveInternalsVisibleToAnalyzer : DiagnosticAnalyzer
+public class InternalTypeMustHaveInternalsVisibleToAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly string DynamicProxyAssemblyName = "DynamicProxyGenAssembly2";
 
@@ -30,24 +30,8 @@ public class InternalTypeMustHaveInternalsVisibleToAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         if (knownSymbols.Mock1 is null)
         {
             return;

--- a/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
+++ b/src/Analyzers/LinqToMocksExpressionShouldBeValidAnalyzer.cs
@@ -6,7 +6,7 @@ namespace Moq.Analyzers;
 /// LINQ to Mocks expressions should be valid and supported.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
+public class LinqToMocksExpressionShouldBeValidAnalyzer : MoqDiagnosticAnalyzerBase
 {
     /// <summary>
     /// Maximum recursion depth for lambda body analysis. Hand-written LINQ-to-Mocks predicates
@@ -37,23 +37,8 @@ public class LinqToMocksExpressionShouldBeValidAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterOperationAction(
             operationContext => AnalyzeInvocation(operationContext, knownSymbols),
             OperationKind.Invocation);

--- a/src/Analyzers/MethodSetupShouldSpecifyReturnValueAnalyzer.cs
+++ b/src/Analyzers/MethodSetupShouldSpecifyReturnValueAnalyzer.cs
@@ -84,7 +84,7 @@ public class MethodSetupShouldSpecifyReturnValueAnalyzer : MoqDiagnosticAnalyzer
     {
         mockedMethod = null!;
 
-        ISymbol? mockedMethodSymbol = TryGetMockedMethodSymbol(setupInvocation);
+        ISymbol? mockedMethodSymbol = MoqVerificationHelpers.TryGetMockedMemberSymbol(setupInvocation);
         if (mockedMethodSymbol is not IMethodSymbol method)
         {
             return false;
@@ -97,32 +97,6 @@ public class MethodSetupShouldSpecifyReturnValueAnalyzer : MoqDiagnosticAnalyzer
 
         mockedMethod = method;
         return true;
-    }
-
-    /// <summary>
-    /// Attempts to resolve the symbol representing the method being referenced in the Setup(...) call.
-    /// </summary>
-    private static ISymbol? TryGetMockedMethodSymbol(IInvocationOperation moqSetupInvocation) =>
-        TryGetSetupArgument(moqSetupInvocation)?.GetReferencedMemberSymbolFromLambda();
-
-    /// <summary>
-    /// Extracts the lambda body operation from the first argument of a Moq Setup invocation.
-    /// </summary>
-    private static IOperation? TryGetSetupArgument(IInvocationOperation moqSetupInvocation)
-    {
-        if (moqSetupInvocation.Arguments.Length == 0)
-        {
-            return null;
-        }
-
-        IOperation argumentOperation = moqSetupInvocation.Arguments[0].Value;
-
-        // Unwrap conversions (Roslyn often wraps lambdas in IConversionOperation)
-        argumentOperation = argumentOperation.WalkDownImplicitConversion();
-
-        return argumentOperation is IAnonymousFunctionOperation lambdaOperation
-            ? lambdaOperation.Body
-            : null;
     }
 
     /// <summary>

--- a/src/Analyzers/MethodSetupShouldSpecifyReturnValueAnalyzer.cs
+++ b/src/Analyzers/MethodSetupShouldSpecifyReturnValueAnalyzer.cs
@@ -8,7 +8,7 @@ namespace Moq.Analyzers;
 /// Returns(), ReturnsAsync(), Throws(), or ThrowsAsync().
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class MethodSetupShouldSpecifyReturnValueAnalyzer : DiagnosticAnalyzer
+public class MethodSetupShouldSpecifyReturnValueAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Method setup should specify a return value";
     private static readonly LocalizableString Message = "Method setup for '{0}' should specify a return value";
@@ -27,24 +27,8 @@ public class MethodSetupShouldSpecifyReturnValueAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterOperationAction(
             operationAnalysisContext => AnalyzeInvocation(operationAnalysisContext, knownSymbols),
             OperationKind.Invocation);

--- a/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
@@ -9,17 +9,8 @@ namespace Moq.Analyzers;
 /// This abstract class provides common functionality for analyzing Moq's MockBehavior, such as registering
 /// compilation start actions and defining the core analysis logic to be implemented by derived classes.
 /// </remarks>
-public abstract class MockBehaviorDiagnosticAnalyzerBase : DiagnosticAnalyzer
+public abstract class MockBehaviorDiagnosticAnalyzerBase : MoqDiagnosticAnalyzerBase
 {
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
-    {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
     /// <summary>
     /// Extracts the mocked type name from the operation for use in diagnostic messages.
     /// </summary>
@@ -110,16 +101,8 @@ public abstract class MockBehaviorDiagnosticAnalyzerBase : DiagnosticAnalyzer
 
     private protected abstract void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols);
 
-    private void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        // Ensure Moq is referenced in the compilation
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         // Look for the MockBehavior type and provide it to Analyze to avoid looking it up multiple times.
         if (knownSymbols.MockBehavior is null)
         {

--- a/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
@@ -11,6 +11,8 @@ namespace Moq.Analyzers;
 /// </remarks>
 public abstract class MockBehaviorDiagnosticAnalyzerBase : MoqDiagnosticAnalyzerBase
 {
+    private protected abstract DiagnosticDescriptor DiagnosticRule { get; }
+
     /// <summary>
     /// Extracts the mocked type name from the operation for use in diagnostic messages.
     /// </summary>
@@ -99,7 +101,12 @@ public abstract class MockBehaviorDiagnosticAnalyzerBase : MoqDiagnosticAnalyzer
             && TryReportMockBehaviorDiagnostic(context, methodMatch, knownSymbols, rule, DiagnosticEditProperties.EditType.Insert, mockedTypeName);
     }
 
-    private protected abstract void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols);
+    private protected abstract void AnalyzeMockBehaviorArgument(
+        OperationAnalysisContext context,
+        IMethodSymbol target,
+        IArgumentOperation? mockArgument,
+        MoqKnownSymbols knownSymbols,
+        string mockedTypeName);
 
     private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
@@ -148,5 +155,25 @@ public abstract class MockBehaviorDiagnosticAnalyzerBase : MoqDiagnosticAnalyzer
         }
 
         AnalyzeCore(context, match, invocation.Arguments, knownSymbols);
+    }
+
+    private void AnalyzeCore(
+        OperationAnalysisContext context,
+        IMethodSymbol target,
+        ImmutableArray<IArgumentOperation> arguments,
+        MoqKnownSymbols knownSymbols)
+    {
+        string mockedTypeName = GetMockedTypeName(context.Operation, target);
+
+        IParameterSymbol? mockParameter = target.Parameters.DefaultIfNotSingle(parameter => parameter.Type.IsInstanceOf(knownSymbols.MockBehavior));
+
+        if (TryHandleMissingMockBehaviorParameter(context, mockParameter, target, knownSymbols, DiagnosticRule, mockedTypeName))
+        {
+            return;
+        }
+
+        IArgumentOperation? mockArgument = arguments.DefaultIfNotSingle(argument => argument.Parameter.IsInstanceOf(mockParameter));
+
+        AnalyzeMockBehaviorArgument(context, target, mockArgument, knownSymbols, mockedTypeName);
     }
 }

--- a/src/Analyzers/MockGetShouldNotTakeLiteralsAnalyzer.cs
+++ b/src/Analyzers/MockGetShouldNotTakeLiteralsAnalyzer.cs
@@ -6,7 +6,7 @@ namespace Moq.Analyzers;
 /// Mock.Get() should not take literals.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class MockGetShouldNotTakeLiteralsAnalyzer : DiagnosticAnalyzer
+public class MockGetShouldNotTakeLiteralsAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Mock.Get() should not take literals";
     private static readonly LocalizableString Message = "Mock.Get() should not take literal '{0}'";
@@ -25,25 +25,8 @@ public class MockGetShouldNotTakeLiteralsAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        // Ensure Moq is referenced in the compilation
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         // Look for the Mock.Get() method
         ImmutableArray<IMethodSymbol> getMethods = knownSymbols.MockGet;
         if (getMethods.IsEmpty)

--- a/src/Analyzers/MockRepositoryVerifyAnalyzer.cs
+++ b/src/Analyzers/MockRepositoryVerifyAnalyzer.cs
@@ -6,7 +6,7 @@ namespace Moq.Analyzers;
 /// MockRepository instances should have Verify() called on them to verify all created mocks.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class MockRepositoryVerifyAnalyzer : DiagnosticAnalyzer
+public class MockRepositoryVerifyAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: MockRepository.Verify() should be called";
     private static readonly LocalizableString Message = "MockRepository '{0}' should have Verify() called";
@@ -25,28 +25,8 @@ public class MockRepositoryVerifyAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    /// <summary>
-    /// Registers the operation action for MockRepository analysis if Moq is referenced.
-    /// </summary>
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        // Ensure Moq is referenced in the compilation
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         // Check that MockRepository type is available
         if (knownSymbols.MockRepository is null)
         {
@@ -57,6 +37,10 @@ public class MockRepositoryVerifyAnalyzer : DiagnosticAnalyzer
             operationContext => AnalyzeVariableDeclaration(operationContext, knownSymbols),
             OperationKind.VariableDeclarator);
     }
+
+    /// <summary>
+    /// Registers the operation action for MockRepository analysis if Moq is referenced.
+    /// </summary>
 
     /// <summary>
     /// Analyzes a variable declaration to find MockRepository instances that may need verification.

--- a/src/Analyzers/MoqDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/MoqDiagnosticAnalyzerBase.cs
@@ -1,0 +1,30 @@
+namespace Moq.Analyzers;
+
+/// <summary>
+/// Provides the common Roslyn analyzer initialization and Moq compilation-start gate.
+/// </summary>
+public abstract class MoqDiagnosticAnalyzerBase : DiagnosticAnalyzer
+{
+    /// <inheritdoc />
+    public sealed override void Initialize(AnalysisContext context)
+    {
+        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
+        context.EnableConcurrentExecution();
+
+        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
+    }
+
+    private protected abstract void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols);
+
+    private void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
+    {
+        MoqKnownSymbols knownSymbols = new(context.Compilation);
+
+        if (!knownSymbols.IsMockReferenced())
+        {
+            return;
+        }
+
+        RegisterCompilationActions(context, knownSymbols);
+    }
+}

--- a/src/Analyzers/NoMethodsInPropertySetupAnalyzer.cs
+++ b/src/Analyzers/NoMethodsInPropertySetupAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Moq.Analyzers;
 /// SetupGet/SetupSet/SetupProperty should be used for properties, not for methods.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
+public class NoMethodsInPropertySetupAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Property setup used for a method";
     private static readonly LocalizableString Message = "SetupGet/SetupSet/SetupProperty should be used for properties, not for methods like '{0}'";
@@ -26,24 +26,8 @@ public class NoMethodsInPropertySetupAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         ImmutableArray<IMethodSymbol> propertySetupMethods = ImmutableArray.CreateRange([
             ..knownSymbols.Mock1SetupGet,
             ..knownSymbols.Mock1SetupSet,

--- a/src/Analyzers/NoMockOfLoggerAnalyzer.cs
+++ b/src/Analyzers/NoMockOfLoggerAnalyzer.cs
@@ -8,7 +8,7 @@ namespace Moq.Analyzers;
 /// ILogger should not be mocked. Use NullLogger or FakeLogger instead.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class NoMockOfLoggerAnalyzer : DiagnosticAnalyzer
+public class NoMockOfLoggerAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: ILogger mocked";
     private static readonly LocalizableString Message = "ILogger should not be mocked; use {0} or FakeLogger from Microsoft.Extensions.Diagnostics.Testing instead";
@@ -27,28 +27,8 @@ public class NoMockOfLoggerAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    /// <summary>
-    /// Registers the operation action for object creation and invocation if Moq is referenced,
-    /// <c>Mock{T}</c> is available, and at least one <c>ILogger</c> type is resolvable.
-    /// </summary>
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        // Ensure Moq is referenced in the compilation
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         // Check that Mock{T} type is available
         if (knownSymbols.Mock1 is null)
         {
@@ -66,6 +46,11 @@ public class NoMockOfLoggerAnalyzer : DiagnosticAnalyzer
             OperationKind.ObjectCreation,
             OperationKind.Invocation);
     }
+
+    /// <summary>
+    /// Registers the operation action for object creation and invocation if Moq is referenced,
+    /// <c>Mock{T}</c> is available, and at least one <c>ILogger</c> type is resolvable.
+    /// </summary>
 
     /// <summary>
     /// Analyzes object creation and invocation operations to report diagnostics for <c>ILogger</c> mocks.

--- a/src/Analyzers/NoSealedClassMocksAnalyzer.cs
+++ b/src/Analyzers/NoSealedClassMocksAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Moq.Analyzers;
 /// Sealed classes cannot be mocked.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
+public class NoSealedClassMocksAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Sealed class mocked";
     private static readonly LocalizableString Message = "Sealed class '{0}' cannot be mocked";
@@ -26,28 +26,8 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    /// <summary>
-    /// Registers the operation action for object creation and invocation if Moq is referenced and Mock{T} is available.
-    /// </summary>
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        // Ensure Moq is referenced in the compilation
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         // Check that Mock{T} type is available
         if (knownSymbols.Mock1 is null)
         {
@@ -59,6 +39,10 @@ public class NoSealedClassMocksAnalyzer : DiagnosticAnalyzer
             OperationKind.ObjectCreation,
             OperationKind.Invocation);
     }
+
+    /// <summary>
+    /// Registers the operation action for object creation and invocation if Moq is referenced and Mock{T} is available.
+    /// </summary>
 
     /// <summary>
     /// Analyzes object creation and invocation operations to report diagnostics for sealed class mocks.

--- a/src/Analyzers/ProtectedSetupShouldUseItExprAnalyzer.cs
+++ b/src/Analyzers/ProtectedSetupShouldUseItExprAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Moq.Analyzers;
 /// Protected member setups using string-based overloads must use ItExpr matchers, not It matchers.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class ProtectedSetupShouldUseItExprAnalyzer : DiagnosticAnalyzer
+public class ProtectedSetupShouldUseItExprAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Protected setup should use ItExpr";
     private static readonly LocalizableString Message = "Protected member setup uses 'It.{0}' which is not compatible with string-based overloads; use an ItExpr matcher instead";
@@ -26,24 +26,8 @@ public class ProtectedSetupShouldUseItExprAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.EnableConcurrentExecution();
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         // Require IProtectedMock<T> and It types to be resolvable
         if (knownSymbols.IProtectedMock1 is null || knownSymbols.It is null)
         {

--- a/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -12,6 +12,7 @@ namespace Moq.Analyzers;
 /// 1. This analyzes direct Mock.Raise() calls on the mock object
 /// 2. Uses proper symbol analysis via MoqKnownSymbols.Mock1Raise for robust detection
 /// 3. Implements immediate event triggering validation (not setup-based)
+/// The shared argument-validation tail lives in EventSyntaxExtensions.AnalyzeEventArgumentsAgainstEventSignature.
 ///
 /// Both analyzers serve critical roles in preventing runtime exceptions by validating
 /// event argument types at compile time, but they target different Moq usage patterns.
@@ -48,39 +49,11 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzer : MoqDiagnosti
         InvocationExpressionSyntax invocation = (InvocationExpressionSyntax)context.Node;
 
         // Check if this is a Raise method call on a Mock<T>
-        if (!IsRaiseMethodCall(context.SemanticModel, invocation, knownSymbols, context.CancellationToken))
+        if (!context.SemanticModel.IsRaiseInvocation(invocation, knownSymbols, context.CancellationToken))
         {
             return;
         }
 
-        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes, out bool senderCanBeOmitted, context.CancellationToken))
-        {
-            return;
-        }
-
-        string eventName = EventSyntaxExtensions.GetEventNameFromSelector(invocation, context.SemanticModel, context.CancellationToken);
-
-        context.ValidateEventArgumentTypes(eventArguments, expectedParameterTypes, senderCanBeOmitted, knownSymbols.EventArgs, invocation, Rule, eventName);
-    }
-
-    private static bool IsRaiseMethodCall(
-        SemanticModel semanticModel,
-        InvocationExpressionSyntax invocation,
-        MoqKnownSymbols knownSymbols,
-        CancellationToken cancellationToken)
-    {
-        // ADR-001 permits this name check only as a pre-filter; the symbol check below is authoritative.
-        if (!invocation.CouldBeInvocationWithMethodName("Raise"))
-        {
-            return false;
-        }
-
-        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(invocation, cancellationToken);
-        if (symbolInfo.Symbol is not IMethodSymbol methodSymbol)
-        {
-            return false;
-        }
-
-        return methodSymbol.IsInstanceOf(knownSymbols.Mock1Raise);
+        context.AnalyzeEventArgumentsAgainstEventSignature(invocation, knownSymbols, Rule);
     }
 }

--- a/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaiseEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -17,7 +17,7 @@ namespace Moq.Analyzers;
 /// event argument types at compile time, but they target different Moq usage patterns.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticAnalyzer
+public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Raise event arguments should match event signature";
     private static readonly LocalizableString Message = "Raise event arguments should match the '{0}' event delegate signature";
@@ -36,24 +36,8 @@ public class RaiseEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticAn
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterSyntaxNodeAction(
             syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
             SyntaxKind.InvocationExpression);

--- a/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -14,6 +14,7 @@ namespace Moq.Analyzers;
 /// 1. This analyzes Raises() method calls that are chained after Setup() calls
 /// 2. Uses symbol-based detection via SemanticModel.IsRaisesInvocation for robust identification
 /// 3. Implements setup-based event triggering validation (not immediate)
+/// The shared argument-validation tail lives in EventSyntaxExtensions.AnalyzeEventArgumentsAgainstEventSignature.
 ///
 ///
 /// Both this analyzer and RaiseEventArgumentsShouldMatchEventSignatureAnalyzer are essential
@@ -56,13 +57,6 @@ public class RaisesEventArgumentsShouldMatchEventSignatureAnalyzer : MoqDiagnost
             return;
         }
 
-        if (!EventSyntaxExtensions.TryGetEventMethodArgumentsFromLambdaSelector(invocation, context.SemanticModel, knownSymbols, out ArgumentSyntax[] eventArguments, out ITypeSymbol[] expectedParameterTypes, out bool senderCanBeOmitted, context.CancellationToken))
-        {
-            return;
-        }
-
-        string eventName = EventSyntaxExtensions.GetEventNameFromSelector(invocation, context.SemanticModel, context.CancellationToken);
-
-        context.ValidateEventArgumentTypes(eventArguments, expectedParameterTypes, senderCanBeOmitted, knownSymbols.EventArgs, invocation, Rule, eventName);
+        context.AnalyzeEventArgumentsAgainstEventSignature(invocation, knownSymbols, Rule);
     }
 }

--- a/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
+++ b/src/Analyzers/RaisesEventArgumentsShouldMatchEventSignatureAnalyzer.cs
@@ -21,7 +21,7 @@ namespace Moq.Analyzers;
 /// subtle runtime failures by catching type mismatches at compile time.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class RaisesEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticAnalyzer
+public class RaisesEventArgumentsShouldMatchEventSignatureAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Raises event arguments should match event signature";
     private static readonly LocalizableString Message = "Raises event arguments should match the '{0}' event delegate signature";
@@ -40,23 +40,8 @@ public class RaisesEventArgumentsShouldMatchEventSignatureAnalyzer : DiagnosticA
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterSyntaxNodeAction(
             syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
             SyntaxKind.InvocationExpression);

--- a/src/Analyzers/RedundantTimesSpecificationAnalyzer.cs
+++ b/src/Analyzers/RedundantTimesSpecificationAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Moq.Analyzers;
 /// Analyzer to detect redundant Times specifications in Moq verification calls.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class RedundantTimesSpecificationAnalyzer : DiagnosticAnalyzer
+public class RedundantTimesSpecificationAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Redundant Times specification";
     private static readonly LocalizableString Message = "Redundant {0} specification can be removed as it is the default for Verify calls";
@@ -26,23 +26,8 @@ public class RedundantTimesSpecificationAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterOperationAction(
             operationContext => AnalyzeInvocation(operationContext, knownSymbols),
             OperationKind.Invocation);

--- a/src/Analyzers/ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer.cs
+++ b/src/Analyzers/ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer.cs
@@ -4,7 +4,7 @@ namespace Moq.Analyzers;
 /// Async method setups should use ReturnsAsync instead of Returns with async lambda.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer : DiagnosticAnalyzer
+public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Invalid Returns usage with async method";
     private static readonly LocalizableString Message = "Async method '{0}' setups should use ReturnsAsync instead of Returns with async lambda";
@@ -23,23 +23,8 @@ public class ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer : DiagnosticAnalyze
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterSyntaxNodeAction(
             syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
             SyntaxKind.InvocationExpression);

--- a/src/Analyzers/ReturnsDelegateShouldReturnTaskAnalyzer.cs
+++ b/src/Analyzers/ReturnsDelegateShouldReturnTaskAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Moq.Analyzers;
 /// Returns() delegate on async method setup should return Task/ValueTask to match the mocked method's return type.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
+public class ReturnsDelegateShouldReturnTaskAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Returns() delegate type mismatch on async method";
     private static readonly LocalizableString Message = "Returns() delegate for async method '{0}' should return '{2}', not '{1}'. Use ReturnsAsync() or wrap with Task.FromResult().";
@@ -26,23 +26,8 @@ public class ReturnsDelegateShouldReturnTaskAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterSyntaxNodeAction(
             syntaxNodeContext => Analyze(syntaxNodeContext, knownSymbols),
             SyntaxKind.InvocationExpression);

--- a/src/Analyzers/SetExplicitMockBehaviorAnalyzer.cs
+++ b/src/Analyzers/SetExplicitMockBehaviorAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
+﻿using Microsoft.CodeAnalysis.Operations;
 
 namespace Moq.Analyzers;
 
@@ -27,30 +26,23 @@ public class SetExplicitMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBas
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
     /// <inheritdoc />
-    [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Should be fixed. Ignoring for now to avoid additional churn as part of larger refactor.")]
-    private protected override void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols)
+    private protected override DiagnosticDescriptor DiagnosticRule => Rule;
+
+    /// <inheritdoc />
+    private protected override void AnalyzeMockBehaviorArgument(
+        OperationAnalysisContext context,
+        IMethodSymbol target,
+        IArgumentOperation? mockArgument,
+        MoqKnownSymbols knownSymbols,
+        string mockedTypeName)
     {
         System.Diagnostics.Debug.Assert(knownSymbols.MockBehavior is not null, "Base registration requires the MockBehavior symbol.");
-
-        // Extract the type name for the diagnostic message
-        string typeName = GetMockedTypeName(context.Operation, target);
-
-        // Check if the target method has a parameter of type MockBehavior
-        IParameterSymbol? mockParameter = target.Parameters.DefaultIfNotSingle(parameter => parameter.Type.IsInstanceOf(knownSymbols.MockBehavior));
-
-        // If the target method doesn't have a MockBehavior parameter, check if there's an overload that does
-        if (TryHandleMissingMockBehaviorParameter(context, mockParameter, target, knownSymbols, Rule, typeName))
-        {
-            return;
-        }
-
-        IArgumentOperation? mockArgument = arguments.DefaultIfNotSingle(argument => argument.Parameter.IsInstanceOf(mockParameter));
 
         // Is the behavior set via a default value?
         if (mockArgument?.ArgumentKind == ArgumentKind.DefaultValue
             && MockBehaviorConstantValues.ConstantValueEquals(mockArgument.Value.WalkDownConversion().ConstantValue, knownSymbols.MockBehaviorDefault))
         {
-            TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Insert, typeName);
+            TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Insert, mockedTypeName);
         }
 
         // NOTE: This logic can't handle indirection (e.g. var x = MockBehavior.Default; new Mock(x);). We can't use the constant value either,
@@ -59,7 +51,7 @@ public class SetExplicitMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBas
         // The operation specifies a MockBehavior; is it MockBehavior.Default?
         if (mockArgument?.DescendantsAndSelf().OfType<IFieldReferenceOperation>().Any(argument => argument.Member.IsInstanceOf(knownSymbols.MockBehaviorDefault)) == true)
         {
-            TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Replace, typeName);
+            TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Replace, mockedTypeName);
         }
     }
 }

--- a/src/Analyzers/SetStrictMockBehaviorAnalyzer.cs
+++ b/src/Analyzers/SetStrictMockBehaviorAnalyzer.cs
@@ -1,5 +1,4 @@
-﻿using System.Diagnostics.CodeAnalysis;
-using Microsoft.CodeAnalysis.Operations;
+﻿using Microsoft.CodeAnalysis.Operations;
 
 namespace Moq.Analyzers;
 
@@ -27,6 +26,9 @@ public class SetStrictMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBase
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
     /// <inheritdoc />
+    private protected override DiagnosticDescriptor DiagnosticRule => Rule;
+
+    /// <inheritdoc />
     /// <remarks>
     /// The original strict analyzer resolved the mocked type name from <paramref name="target"/>'s
     /// type arguments (not the invocation's) and fell back to "Unknown" instead of "T".
@@ -51,25 +53,14 @@ public class SetStrictMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBase
     }
 
     /// <inheritdoc />
-    [SuppressMessage("Design", "MA0051:Method is too long", Justification = "Should be fixed. Ignoring for now to avoid additional churn as part of larger refactor.")]
-    private protected override void AnalyzeCore(OperationAnalysisContext context, IMethodSymbol target, ImmutableArray<IArgumentOperation> arguments, MoqKnownSymbols knownSymbols)
+    private protected override void AnalyzeMockBehaviorArgument(
+        OperationAnalysisContext context,
+        IMethodSymbol target,
+        IArgumentOperation? mockArgument,
+        MoqKnownSymbols knownSymbols,
+        string mockedTypeName)
     {
         System.Diagnostics.Debug.Assert(knownSymbols.MockBehavior is not null, "Base registration requires the MockBehavior symbol.");
-
-        // Extract the mocked type name for the diagnostic message
-        string mockedTypeName = GetMockedTypeName(context.Operation, target);
-
-        // Check if the target method has a parameter of type MockBehavior
-        IParameterSymbol? mockParameter = target.Parameters.DefaultIfNotSingle(parameter => parameter.Type.IsInstanceOf(knownSymbols.MockBehavior));
-
-        // If the target method doesn't have a MockBehavior parameter, check if there's an overload that does
-        if (TryHandleMissingMockBehaviorParameter(context, mockParameter, target, knownSymbols, Rule, mockedTypeName))
-        {
-            // Using a method that doesn't accept a MockBehavior parameter, however there's an overload that does
-            return;
-        }
-
-        IArgumentOperation? mockArgument = arguments.DefaultIfNotSingle(argument => argument.Parameter.IsInstanceOf(mockParameter));
 
         // Is the behavior set via a default value?
         if (mockArgument?.ArgumentKind == ArgumentKind.DefaultValue

--- a/src/Analyzers/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -6,7 +6,7 @@ namespace Moq.Analyzers;
 /// SetupSequence should be used only for overridable members.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnalyzer
+public class SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Invalid SetupSequence parameter";
     private static readonly LocalizableString Message = "SetupSequence should be used only for overridable members, but '{0}' is not overridable";
@@ -25,23 +25,8 @@ public class SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer : Diagno
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterOperationAction(
             operationContext => AnalyzeInvocation(operationContext, knownSymbols),
             OperationKind.Invocation);

--- a/src/Analyzers/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -44,9 +44,7 @@ public class SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer : MoqDia
             return;
         }
 
-        ISymbol? mockedMemberSymbol = MoqVerificationHelpers.TryGetMockedMemberSymbol(invocationOperation);
-        if (mockedMemberSymbol is null
-            || mockedMemberSymbol.IsOverridableOrAllowedMockMember(knownSymbols))
+        if (!MoqVerificationHelpers.TryGetNonOverridableMockedMember(invocationOperation, knownSymbols, out ISymbol? mockedMemberSymbol))
         {
             return;
         }

--- a/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -7,7 +7,7 @@ namespace Moq.Analyzers;
 /// Setup should be used only for overridable members.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnalyzer
+public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Invalid setup parameter";
     private static readonly LocalizableString Message = "Setup should be used only for overridable members, but '{0}' is not overridable";
@@ -26,24 +26,8 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnal
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterOperationAction(
             operationAnalysisContext => AnalyzeInvocation(operationAnalysisContext, knownSymbols),
             OperationKind.Invocation);

--- a/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/SetupShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -1,4 +1,3 @@
-using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Moq.Analyzers;
@@ -40,45 +39,14 @@ public class SetupShouldBeUsedOnlyForOverridableMembersAnalyzer : MoqDiagnosticA
             return;
         }
 
-        if (!IsSetupOnNonOverridableMember(invocationOperation, knownSymbols, out ISymbol? mockedMemberSymbol))
+        IMethodSymbol targetMethod = invocationOperation.TargetMethod;
+        if ((!targetMethod.IsMoqSetupMethod(knownSymbols) && !targetMethod.IsMoqEventSetupMethod(knownSymbols))
+            || !MoqVerificationHelpers.TryGetNonOverridableMockedMember(invocationOperation, knownSymbols, out ISymbol? mockedMemberSymbol))
         {
             return;
         }
 
         Diagnostic diagnostic = invocationOperation.Syntax.CreateDiagnostic(Rule, mockedMemberSymbol.ToDisplayString());
         context.ReportDiagnostic(diagnostic);
-    }
-
-    /// <summary>
-    /// Determines whether the invocation is a Moq Setup call targeting a non-overridable member.
-    /// </summary>
-    /// <param name="invocationOperation">The invocation operation to analyze.</param>
-    /// <param name="knownSymbols">A <see cref="MoqKnownSymbols"/> instance for resolving well-known types.</param>
-    /// <param name="mockedMemberSymbol">When this method returns <see langword="true"/>, contains the non-overridable member symbol.</param>
-    /// <returns><see langword="true"/> if the invocation targets a non-overridable member; otherwise <see langword="false"/>.</returns>
-    private static bool IsSetupOnNonOverridableMember(
-        IInvocationOperation invocationOperation,
-        MoqKnownSymbols knownSymbols,
-        [NotNullWhen(true)] out ISymbol? mockedMemberSymbol)
-    {
-        mockedMemberSymbol = null;
-        IMethodSymbol targetMethod = invocationOperation.TargetMethod;
-
-        // Check if the invoked method is a Moq Setup method.
-        if (!targetMethod.IsMoqSetupMethod(knownSymbols) && !targetMethod.IsMoqEventSetupMethod(knownSymbols))
-        {
-            return false;
-        }
-
-        // Attempt to locate the member reference from the Setup expression argument.
-        ISymbol? candidate = MoqVerificationHelpers.TryGetMockedMemberSymbol(invocationOperation);
-        if (candidate is null
-            || candidate.IsOverridableOrAllowedMockMember(knownSymbols))
-        {
-            return false;
-        }
-
-        mockedMemberSymbol = candidate;
-        return true;
     }
 }

--- a/src/Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
+++ b/src/Analyzers/SetupShouldNotIncludeAsyncResultAnalyzer.cs
@@ -4,7 +4,7 @@
 /// Setup of async method should use ReturnsAsync instead of .Result.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
+public class SetupShouldNotIncludeAsyncResultAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Invalid setup parameter";
     private static readonly LocalizableString Message = "Setup of async method '{0}' should use ReturnsAsync instead of .Result";
@@ -23,23 +23,8 @@ public class SetupShouldNotIncludeAsyncResultAnalyzer : DiagnosticAnalyzer
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         // Check Moq version once per compilation, skip for 4.16.0 or later
         AssemblyIdentity? moqAssembly = context.Compilation.ReferencedAssemblyNames
             .FirstOrDefault(a => a.Name.Equals("Moq", StringComparison.OrdinalIgnoreCase));

--- a/src/Analyzers/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -46,28 +46,26 @@ public class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer : MoqDiagnostic
             return;
         }
 
-        ISymbol? mockedMemberSymbol;
         if (targetMethod.IsInstanceOf(knownSymbols.Mock1VerifySet))
         {
             IArgumentOperation? setterArgument = MoqVerificationHelpers.GetArgumentForParameterOrdinal(invocationOperation, 0);
             IAnonymousFunctionOperation? lambda = setterArgument is not null
                 ? MoqVerificationHelpers.ExtractLambdaFromArgument(setterArgument.Value)
                 : null;
-            mockedMemberSymbol = lambda is not null
+            ISymbol? verifySetMemberSymbol = lambda is not null
                 ? MoqVerificationHelpers.ExtractPropertyFromVerifySetLambda(lambda)
                 : null;
-        }
-        else
-        {
-            mockedMemberSymbol = MoqVerificationHelpers.TryGetMockedMemberSymbol(invocationOperation);
-        }
 
-        if (mockedMemberSymbol == null)
-        {
+            if (verifySetMemberSymbol == null || IsVerifySetMemberAllowed(verifySetMemberSymbol))
+            {
+                return;
+            }
+
+            ReportDiagnostic(context, invocationOperation, verifySetMemberSymbol);
             return;
         }
 
-        if (IsMemberAllowedForVerification(mockedMemberSymbol, targetMethod, knownSymbols))
+        if (!MoqVerificationHelpers.TryGetNonOverridableMockedMember(invocationOperation, knownSymbols, out ISymbol? mockedMemberSymbol))
         {
             return;
         }
@@ -87,15 +85,9 @@ public class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer : MoqDiagnostic
         return !targetMethod.IsInstanceOf(knownSymbols.Mock1VerifyNoOtherCalls);
     }
 
-    private static bool IsMemberAllowedForVerification(ISymbol mockedMemberSymbol, IMethodSymbol targetMethod, MoqKnownSymbols knownSymbols)
+    private static bool IsVerifySetMemberAllowed(ISymbol mockedMemberSymbol)
     {
-        // Special handling for VerifySet: must check property overridability for set accessor
-        if (targetMethod.IsInstanceOf(knownSymbols.Mock1VerifySet))
-        {
-            return mockedMemberSymbol is IPropertySymbol propertySymbol && propertySymbol.IsOverridable();
-        }
-
-        return mockedMemberSymbol.IsOverridableOrAllowedMockMember(knownSymbols);
+        return mockedMemberSymbol is IPropertySymbol propertySymbol && propertySymbol.IsOverridable();
     }
 
     private static void ReportDiagnostic(OperationAnalysisContext context, IInvocationOperation invocationOperation, ISymbol mockedMemberSymbol)

--- a/src/Analyzers/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
+++ b/src/Analyzers/VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer.cs
@@ -6,7 +6,7 @@ namespace Moq.Analyzers;
 /// Verify should be used only for overridable members.
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
-public class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAnalyzer
+public class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer : MoqDiagnosticAnalyzerBase
 {
     private static readonly LocalizableString Title = "Moq: Invalid verify parameter";
     private static readonly LocalizableString Message = "Verify should be used only for overridable members, but '{0}' is not overridable";
@@ -25,23 +25,8 @@ public class VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer : DiagnosticAna
     /// <inheritdoc />
     public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics { get; } = ImmutableArray.Create(Rule);
 
-    /// <inheritdoc />
-    public override void Initialize(AnalysisContext context)
+    private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
-        context.EnableConcurrentExecution();
-        context.ConfigureGeneratedCodeAnalysis(GeneratedCodeAnalysisFlags.None);
-        context.RegisterCompilationStartAction(RegisterCompilationStartAction);
-    }
-
-    private static void RegisterCompilationStartAction(CompilationStartAnalysisContext context)
-    {
-        MoqKnownSymbols knownSymbols = new(context.Compilation);
-
-        if (!knownSymbols.IsMockReferenced())
-        {
-            return;
-        }
-
         context.RegisterOperationAction(
             operationContext => AnalyzeInvocation(operationContext, knownSymbols),
             OperationKind.Invocation);

--- a/src/CodeFixes/MockBehaviorFixerBase.cs
+++ b/src/CodeFixes/MockBehaviorFixerBase.cs
@@ -1,0 +1,36 @@
+using Microsoft.CodeAnalysis.CodeFixes;
+
+namespace Moq.CodeFixes;
+
+/// <summary>
+/// Provides shared registration logic for MockBehavior code fix providers.
+/// </summary>
+public abstract class MockBehaviorFixerBase : CodeFixProvider
+{
+    /// <inheritdoc />
+    public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+    /// <inheritdoc />
+    public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    {
+        SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+        SyntaxNode? nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
+
+        if (!context.TryGetEditProperties(out DiagnosticEditProperties? editProperties))
+        {
+            return;
+        }
+
+        if (nodeToFix is null)
+        {
+            return;
+        }
+
+        RegisterFixes(context, nodeToFix, editProperties);
+    }
+
+    private protected abstract void RegisterFixes(
+        CodeFixContext context,
+        SyntaxNode nodeToFix,
+        DiagnosticEditProperties editProperties);
+}

--- a/src/CodeFixes/SetExplicitMockBehaviorFixer.cs
+++ b/src/CodeFixes/SetExplicitMockBehaviorFixer.cs
@@ -8,30 +8,17 @@ namespace Moq.CodeFixes;
 /// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SetExplicitMockBehaviorFixer))]
 [Shared]
-public class SetExplicitMockBehaviorFixer : CodeFixProvider
+public class SetExplicitMockBehaviorFixer : MockBehaviorFixerBase
 {
     /// <inheritdoc />
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticIds.SetExplicitMockBehavior);
 
     /// <inheritdoc />
-    public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
-
-    /// <inheritdoc />
-    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    private protected override void RegisterFixes(
+        CodeFixContext context,
+        SyntaxNode nodeToFix,
+        DiagnosticEditProperties editProperties)
     {
-        SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        SyntaxNode? nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-
-        if (!context.TryGetEditProperties(out DiagnosticEditProperties? editProperties))
-        {
-            return;
-        }
-
-        if (nodeToFix is null)
-        {
-            return;
-        }
-
         context.RegisterCodeFix(new SetExplicitMockBehaviorCodeAction("Set MockBehavior (Loose)", context.Document, nodeToFix, BehaviorType.Loose, editProperties.TypeOfEdit, editProperties.EditPosition, replaceRequiresDefaultReference: true), context.Diagnostics);
         context.RegisterCodeFix(new SetExplicitMockBehaviorCodeAction("Set MockBehavior (Strict)", context.Document, nodeToFix, BehaviorType.Strict, editProperties.TypeOfEdit, editProperties.EditPosition, replaceRequiresDefaultReference: true), context.Diagnostics);
     }

--- a/src/CodeFixes/SetStrictMockBehaviorFixer.cs
+++ b/src/CodeFixes/SetStrictMockBehaviorFixer.cs
@@ -8,30 +8,17 @@ namespace Moq.CodeFixes;
 /// </summary>
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(SetStrictMockBehaviorFixer))]
 [Shared]
-public class SetStrictMockBehaviorFixer : CodeFixProvider
+public class SetStrictMockBehaviorFixer : MockBehaviorFixerBase
 {
     /// <inheritdoc />
     public override ImmutableArray<string> FixableDiagnosticIds => ImmutableArray.Create(DiagnosticIds.SetStrictMockBehavior);
 
     /// <inheritdoc />
-    public override FixAllProvider? GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
-
-    /// <inheritdoc />
-    public override async Task RegisterCodeFixesAsync(CodeFixContext context)
+    private protected override void RegisterFixes(
+        CodeFixContext context,
+        SyntaxNode nodeToFix,
+        DiagnosticEditProperties editProperties)
     {
-        SyntaxNode? root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
-        SyntaxNode? nodeToFix = root?.FindNode(context.Span, getInnermostNodeForTie: true);
-
-        if (!context.TryGetEditProperties(out DiagnosticEditProperties? editProperties))
-        {
-            return;
-        }
-
-        if (nodeToFix is null)
-        {
-            return;
-        }
-
         context.RegisterCodeFix(new SetExplicitMockBehaviorCodeAction("Set MockBehavior (Strict)", context.Document, nodeToFix, BehaviorType.Strict, editProperties.TypeOfEdit, editProperties.EditPosition, replaceRequiresDefaultReference: false), context.Diagnostics);
     }
 }

--- a/src/Common/EventSyntaxExtensions.cs
+++ b/src/Common/EventSyntaxExtensions.cs
@@ -251,6 +251,43 @@ internal static class EventSyntaxExtensions
     }
 
     /// <summary>
+    /// Runs the shared Raise/Raises event argument validation tail.
+    /// </summary>
+    /// <param name="context">The syntax node analysis context.</param>
+    /// <param name="invocation">The Raise or Raises invocation.</param>
+    /// <param name="knownSymbols">The known Moq symbols for this compilation.</param>
+    /// <param name="rule">The diagnostic rule to report.</param>
+    internal static void AnalyzeEventArgumentsAgainstEventSignature(
+        this SyntaxNodeAnalysisContext context,
+        InvocationExpressionSyntax invocation,
+        MoqKnownSymbols knownSymbols,
+        DiagnosticDescriptor rule)
+    {
+        if (!TryGetEventMethodArgumentsFromLambdaSelector(
+            invocation,
+            context.SemanticModel,
+            knownSymbols,
+            out ArgumentSyntax[] eventArguments,
+            out ITypeSymbol[] expectedParameterTypes,
+            out bool senderCanBeOmitted,
+            context.CancellationToken))
+        {
+            return;
+        }
+
+        string eventName = GetEventNameFromSelector(invocation, context.SemanticModel, context.CancellationToken);
+
+        context.ValidateEventArgumentTypes(
+            eventArguments,
+            expectedParameterTypes,
+            senderCanBeOmitted,
+            knownSymbols.EventArgs,
+            invocation,
+            rule,
+            eventName);
+    }
+
+    /// <summary>
     /// Extracts the event name from the first argument (event selector lambda) of an invocation.
     /// </summary>
     /// <param name="invocation">The method invocation containing the lambda selector.</param>

--- a/src/Common/MoqVerificationHelpers.cs
+++ b/src/Common/MoqVerificationHelpers.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Moq.Analyzers.Common;
@@ -64,6 +65,36 @@ internal static class MoqVerificationHelpers
             : null;
 
         return lambdaOperation?.Body.GetReferencedMemberSymbolFromLambda();
+    }
+
+    /// <summary>
+    /// Extracts the mocked member from a Moq Setup/SetupSequence/Verify invocation and
+    /// determines whether it is a member that Moq cannot mock.
+    /// </summary>
+    /// <param name="moqInvocation">The Setup/SetupSequence/Verify invocation operation.</param>
+    /// <param name="knownSymbols">The known Moq symbols for this compilation.</param>
+    /// <param name="mockedMemberSymbol">
+    /// When this method returns <see langword="true"/>, the non-overridable mocked member.
+    /// </param>
+    /// <returns>
+    /// <see langword="true"/> when the invocation lambda references a member that is not
+    /// overridable/allowed for mocking; otherwise <see langword="false"/>.
+    /// </returns>
+    public static bool TryGetNonOverridableMockedMember(
+        IInvocationOperation moqInvocation,
+        MoqKnownSymbols knownSymbols,
+        [NotNullWhen(true)] out ISymbol? mockedMemberSymbol)
+    {
+        mockedMemberSymbol = null;
+
+        ISymbol? candidate = TryGetMockedMemberSymbol(moqInvocation);
+        if (candidate is null || candidate.IsOverridableOrAllowedMockMember(knownSymbols))
+        {
+            return false;
+        }
+
+        mockedMemberSymbol = candidate;
+        return true;
     }
 
     /// <summary>

--- a/src/Common/SemanticModelExtensions.cs
+++ b/src/Common/SemanticModelExtensions.cs
@@ -103,6 +103,40 @@ internal static class SemanticModelExtensions
     }
 
     /// <summary>
+    /// Determines whether an invocation resolves to <c>Mock&lt;T&gt;.Raise</c>.
+    /// </summary>
+    /// <remarks>
+    /// This intentionally accepts only a fully resolved symbol after the ADR-001 name
+    /// pre-filter. Do not replace this with <see cref="IsMoqFluentInvocation"/>, which
+    /// accepts overload-resolution candidates.
+    /// </remarks>
+    /// <param name="semanticModel">The semantic model.</param>
+    /// <param name="raiseInvocation">The invocation to inspect.</param>
+    /// <param name="knownSymbols">The known Moq symbols for this compilation.</param>
+    /// <param name="cancellationToken">The cancellation token.</param>
+    /// <returns><see langword="true"/> when the invocation is <c>Mock&lt;T&gt;.Raise</c>; otherwise, <see langword="false"/>.</returns>
+    internal static bool IsRaiseInvocation(
+        this SemanticModel semanticModel,
+        InvocationExpressionSyntax raiseInvocation,
+        MoqKnownSymbols knownSymbols,
+        CancellationToken cancellationToken = default)
+    {
+        // ADR-001 permits this name check only as a pre-filter; the symbol check below is authoritative.
+        if (!raiseInvocation.CouldBeInvocationWithMethodName("Raise"))
+        {
+            return false;
+        }
+
+        SymbolInfo symbolInfo = semanticModel.GetSymbolInfo(raiseInvocation, cancellationToken);
+        if (symbolInfo.Symbol is not IMethodSymbol methodSymbol)
+        {
+            return false;
+        }
+
+        return methodSymbol.IsInstanceOf(knownSymbols.Mock1Raise);
+    }
+
+    /// <summary>
     /// Determines whether an invocation can match a method name before semantic binding.
     /// </summary>
     /// <remarks>


### PR DESCRIPTION
## Summary

Behavior-preserving consolidation of duplicated analyzer/code-fix boilerplate. Net -318 lines across 32 files, no diagnostic behavior change.

Fixes #1273, #1274, #1275, #1276.

### Changes

- **#1273** `MoqDiagnosticAnalyzerBase` centralizes the `Initialize` + `EnableConcurrentExecution` + `ConfigureGeneratedCodeAnalysis` + compilation-start boilerplate duplicated across 22 analyzers.
- **#1274** `MoqVerificationHelpers` consolidates the Setup/SetupSequence/Verify "overridable member" duplication; aligns the Moq1203 private-symbol extraction with the shared path.
- **#1275** Raise/Raises event-signature analyzers now share a static helper; `IsRaiseMethodCall` moved to `SemanticModelExtensions`; event-signature matching extracted to `EventSyntaxExtensions`.
- **#1276** MockBehavior analyzer prologue consolidated via a template method (`MockBehaviorDiagnosticAnalyzerBase`); the two MockBehavior fixers share `MockBehaviorFixerBase`.

### Design

- Pure extraction: each analyzer keeps its `DiagnosticDescriptor`, rule id, and registration; only shared mechanics move to the base/helpers.
- Symbol-based detection preserved throughout (`ISymbol`, `SymbolEqualityComparer`, `MoqKnownSymbols`).
- New shared types (`MoqDiagnosticAnalyzerBase`, `MockBehaviorFixerBase`, `MoqVerificationHelpers`, `EventSyntaxExtensions`, `SemanticModelExtensions` additions) are exercised by the existing analyzer/code-fix verifier tests that drive the concrete analyzers.

## Validation Log

```
dotnet build Moq.Analyzers.sln -c Release /p:PedanticMode=true /p:ContinuousIntegrationBuild=true => 0 Warning(s), 0 Error(s)
dotnet test (CallbackSignature* representative slice) => Passed: 353, Failed: 0, Skipped: 0
Full suite validated by CI (build, test ubuntu-arm + windows, analyzer-load-test).
```

- [x] Build clean under PedanticMode (warnings-as-errors)
- [x] Behavior-preserving: no diagnostic id/message/severity/span changes
- [x] Symbol-based detection preserved

## Moq version compatibility

No Moq API surface change. Diagnostic behavior identical across supported Moq versions.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new code-fix support for setting explicit mock behavior more quickly and consistently.
  * Improved validation for event-related mock calls, including `Raise`/`Raises` scenarios.

* **Bug Fixes**
  * Tightened several analyzer checks so misuse of mocks, setups, verifications, callbacks, and return values is flagged more reliably.
  * Reduced false positives around non-overridable members and async setup patterns.

* **Refactor**
  * Updated analyzer and code-fix infrastructure for more consistent behavior and better performance when mock APIs are not in use.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->