### PR TITLE
ci(workflows): harden GitHub Actions

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -3,6 +3,8 @@ name: Copilot setup steps
 # Allow testing of the setup steps from your repository's "Actions" tab.
 on: workflow_dispatch
 
+permissions: {}
+
 jobs:
   # The job MUST be called `copilot-setup-steps` or it will not be picked up by Copilot.
   copilot-setup-steps:

--- a/.github/workflows/dependabot-approve-and-auto-merge.yml
+++ b/.github/workflows/dependabot-approve-and-auto-merge.yml
@@ -1,7 +1,16 @@
 name: Auto-Approve and Auto-Merge Bot PRs
+# SECURITY: This workflow uses pull_request_target, so it runs in the BASE repo
+# context with access to secrets even for fork PRs. Invariants (do not break):
+#   1. NEVER check out or execute PR-head code (no actions/checkout of
+#      github.event.pull_request.head.*, no building/running PR content).
+#   2. NEVER interpolate untrusted PR fields (title, body, branch name) directly
+#      into run: blocks - pass them through env: instead.
+# See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 on:
   pull_request_target:
     types: [opened, synchronize, reopened]
+
+permissions: {}
 
 jobs:
   dependabot:

--- a/.github/workflows/devskim.yml
+++ b/.github/workflows/devskim.yml
@@ -13,6 +13,8 @@ on:
   schedule:
     - cron: '32 8 * * 1'
 
+permissions: {}
+
 jobs:
   lint:
     name: DevSkim

--- a/.github/workflows/label-issues.yml
+++ b/.github/workflows/label-issues.yml
@@ -7,6 +7,8 @@ on:
       - reopened
       - opened
 
+permissions: {}
+
 jobs:
   label_issues:
     name: "Issue: add labels"
@@ -33,7 +35,7 @@ jobs:
             }
 
             // Check if the body or the title contains the words 'dotnet', '.net', 'c#' or 'csharp' (case-insensitive)
-            if ((body != null && body.match(/.net/i)) || (title != null && title.match(/.net/i)) ||
+            if ((body != null && body.match(/\.net/i)) || (title != null && title.match(/\.net/i)) ||
                 (body != null && body.match(/dotnet/i)) || (title != null && title.match(/dotnet/i)) ||
                 (body != null && body.match(/C#/i)) || (title != null && title.match(/C#/i)) ||
                 (body != null && body.match(/csharp/i)) || (title != null && title.match(/csharp/i))) {

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -6,7 +6,16 @@
 # https://github.com/actions/labeler
 
 name: Label PR
+# SECURITY: This workflow uses pull_request_target, so it runs in the BASE repo
+# context with access to secrets even for fork PRs. Invariants (do not break):
+#   1. NEVER check out or execute PR-head code (no actions/checkout of
+#      github.event.pull_request.head.*, no building/running PR content).
+#   2. NEVER interpolate untrusted PR fields (title, body, branch name) directly
+#      into run: blocks - pass them through env: instead.
+# See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 on: [pull_request_target]
+
+permissions: {}
 
 jobs:
   add_label:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,6 @@ on:
     - cron: '0 3 * * *' # Nightly run for performance validation
 
 permissions:
-  security-events: write  # required for CodeQL
   packages: read
   contents: read
   actions: read

--- a/.github/workflows/milestone-tracking.yml
+++ b/.github/workflows/milestone-tracking.yml
@@ -1,4 +1,11 @@
 name: Milestone tracking
+# SECURITY: This workflow uses pull_request_target, so it runs in the BASE repo
+# context with access to secrets even for fork PRs. Invariants (do not break):
+#   1. NEVER check out or execute PR-head code (no actions/checkout of
+#      github.event.pull_request.head.*, no building/running PR content).
+#   2. NEVER interpolate untrusted PR fields (title, body, branch name) directly
+#      into run: blocks - pass them through env: instead.
+# See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 on:
   pull_request_target:
     types: [closed]

--- a/.github/workflows/powershell.yml
+++ b/.github/workflows/powershell.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Run PSScriptAnalyzer
-        uses: microsoft/psscriptanalyzer-action@7a0da25f33985767f15f93140306528900744195
+        uses: microsoft/psscriptanalyzer-action@7a0da25f33985767f15f93140306528900744195 # main, post-v1.1 (PR #9; no tagged release contains this commit)
         with:
           # Check https://github.com/microsoft/action-psscriptanalyzer for more info about the options.
           # The below set up runs PSScriptAnalyzer to your entire repository and runs some basic security rules.

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -1,5 +1,12 @@
 name: Release Drafter
 
+# SECURITY: This workflow uses pull_request_target, so it runs in the BASE repo
+# context with access to secrets even for fork PRs. Invariants (do not break):
+#   1. NEVER check out or execute PR-head code (no actions/checkout of
+#      github.event.pull_request.head.*, no building/running PR content).
+#   2. NEVER interpolate untrusted PR fields (title, body, branch name) directly
+#      into run: blocks - pass them through env: instead.
+# See: https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/
 on:
   push:
     branches:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,12 +2,16 @@ name: Release publish
 
 on:
   workflow_dispatch: # Allow running the workflow manually from the GitHub UI
+    inputs:
+      expected-version:
+        description: 'Package version to publish, without leading v (e.g. 0.4.2); must match the built .nupkg version'
+        required: true
+        type: string
   release:
     types:
       - published # Run the workflow when a new GitHub release is published
 
 permissions:
-  security-events: write  # required for CodeQL
   packages: read
   contents: read
   actions: read
@@ -27,10 +31,9 @@ jobs:
           path: packages
           name: packages
       - name: Verify package version matches release tag
-        if: github.event_name == 'release'
         shell: pwsh
         env:
-          RELEASE_TAG: ${{ github.ref_name }}
+          RELEASE_TAG: ${{ github.event_name == 'release' && github.ref_name || inputs.expected-version }}
         run: |
           $tag = $env:RELEASE_TAG -replace '^v', ''
           $packages = @(Get-ChildItem ./packages/release -Recurse -Include *.nupkg -ErrorAction SilentlyContinue | Where-Object { $_.Name -notlike '*.symbols.*' })


### PR DESCRIPTION
## Summary

Hardens GitHub Actions workflows from issue #1272. Item (a) was not edited because current `origin/main` no longer matched the issue snippet. The workflow already uses a SHA-pinned checkout for v7.0.0.

## Checklist

- [ ] (a) `tech-debt-tracker.yml` checkout replacement not applied. Expected `actions/checkout@v6.0.3`, found `actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0`.
- [x] (b) Added provenance comment to the `microsoft/psscriptanalyzer-action` SHA pin.
- [x] (c) Removed over-scoped top-level `security-events: write` from `main.yml` and `release.yml`.
- [x] (d) Added top-level `permissions: {}` to the five listed workflows.
- [x] (e) Made release dispatch require `expected-version` and run package version verification.
- [x] (f) Escaped the `.net` label regex as `/\.net/i`.
- [x] (g) Added `pull_request_target` guard comments to the four listed workflows.

## Item (b) provenance check

`gh api` could not access the Microsoft organization because of SAML enforcement. Re-ran the check with the unauthenticated GitHub REST API. It returned exactly these tags:

```text
v1.1	6b2948b1944407914a58661c49941824d149734f
v1.0	2044ae068e37d0161fa2127de04c19633882f061
v0.1-alpha	2044ae068e37d0161fa2127de04c19633882f061
```

No listed tag contains the pinned `7a0da25f33985767f15f93140306528900744195` SHA.

## Validation Log

```text
$ which actionlint
/home/richard/.local/bin/actionlint
$ actionlint <changed files>
actionlint ok
$ python3 -c "import yaml,sys; [yaml.safe_load(open(f)) for f in sys.argv[1:]]; print('yaml ok')" <changed files>
yaml ok
```

Extra checks:

```text
$ git grep -nE 'uses:.*@v[0-9]' .github/workflows/
$ node -e regex check
null
.NET
```

Dotnet build and test were not run because this PR only changes workflow YAML.
Moq compatibility: not applicable, no analyzer or test code changed.

Fixes #1272
