### PR TITLE
test(analyzers): assert diagnostic metadata and messages

### DIFF
--- a/docs/testing-diagnostic-coverage.md
+++ b/docs/testing-diagnostic-coverage.md
@@ -1,0 +1,42 @@
+# Diagnostic Coverage Testing
+
+Analyzer tests must cover more than the diagnostic location.
+
+Every rule needs descriptor metadata coverage for:
+
+- Id
+- Title
+- Message format
+- Description
+- Category
+- Default severity
+- Default enabled state
+- Help link
+- Rule documentation
+
+Rules with message format arguments also need one positive test that verifies
+the formatted diagnostic message.
+
+Use numbered markup with `DiagnosticResult.WithLocation(0).WithMessage(...)`
+when a test needs both a precise span and an exact message:
+
+```csharp
+DiagnosticResult expected = new DiagnosticResult("Moq1000", DiagnosticSeverity.Warning)
+    .WithLocation(0)
+    .WithMessage("Sealed class 'FooSealed' cannot be mocked");
+
+await Verifier.VerifyAnalyzerAsync(
+    """
+    internal sealed class FooSealed { }
+
+    internal class UnitTest
+    {
+        private void Test()
+        {
+            new Mock<{|#0:FooSealed|}>();
+        }
+    }
+    """,
+    ReferenceAssemblyCatalog.Net80WithNewMoq,
+    expected);
+```

--- a/tests/Moq.Analyzers.Test/DiagnosticDescriptorMetadataTests.cs
+++ b/tests/Moq.Analyzers.Test/DiagnosticDescriptorMetadataTests.cs
@@ -1,0 +1,402 @@
+using System.Reflection;
+
+namespace Moq.Analyzers.Test;
+
+public class DiagnosticDescriptorMetadataTests
+{
+    public static TheoryData<string, DiagnosticDescriptor> DescriptorData()
+    {
+        TheoryData<string, DiagnosticDescriptor> data = [];
+        foreach (DiagnosticDescriptor descriptor in DiscoverDescriptors())
+        {
+            data.Add(descriptor.Id, descriptor);
+        }
+
+        return data;
+    }
+
+    public static TheoryData<string, DiagnosticDescriptor, ExpectedDescriptorMetadata> ExpectedMetadataData()
+    {
+        IReadOnlyDictionary<string, ExpectedDescriptorMetadata> expectedMetadata = GetExpectedMetadata();
+        TheoryData<string, DiagnosticDescriptor, ExpectedDescriptorMetadata> data = [];
+
+        foreach (DiagnosticDescriptor descriptor in DiscoverDescriptors())
+        {
+            Assert.True(
+                expectedMetadata.TryGetValue(descriptor.Id, out ExpectedDescriptorMetadata? expected),
+                $"Missing expected descriptor metadata for {descriptor.Id}.");
+
+            data.Add(descriptor.Id, descriptor, expected);
+        }
+
+        return data;
+    }
+
+    public static ImmutableArray<DiagnosticDescriptor> DiscoverDescriptors()
+    {
+        ImmutableArray<DiagnosticDescriptor>.Builder descriptors = ImmutableArray.CreateBuilder<DiagnosticDescriptor>();
+
+        foreach (Type analyzerType in DiscoverAnalyzerTypes())
+        {
+            DiagnosticAnalyzer analyzer = CreateAnalyzer(analyzerType);
+            descriptors.AddRange(analyzer.SupportedDiagnostics);
+        }
+
+        descriptors.Sort(static (left, right) => string.Compare(left.Id, right.Id, StringComparison.Ordinal));
+        return descriptors.ToImmutable();
+    }
+
+    [Theory]
+    [MemberData(nameof(DescriptorData))]
+    public void DescriptorMetadataShouldBeCompleteAndDocumented(string ruleId, DiagnosticDescriptor descriptor)
+    {
+        Assert.True(IsMoqRuleId(ruleId), $"{ruleId} must match MoqNNNN.");
+        Assert.False(string.IsNullOrWhiteSpace(descriptor.Title.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        Assert.False(string.IsNullOrWhiteSpace(descriptor.MessageFormat.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        Assert.False(string.IsNullOrWhiteSpace(descriptor.Description.ToString(System.Globalization.CultureInfo.InvariantCulture)));
+        Assert.True(IsAllowedCategory(descriptor.Category), $"{descriptor.Id} uses unexpected category '{descriptor.Category}'.");
+        AssertRuleDocMatchesDescriptor(descriptor);
+        AssertHelpLinkMatchesRuleId(descriptor);
+    }
+
+    [Theory]
+    [MemberData(nameof(ExpectedMetadataData))]
+    public void DescriptorMetadataShouldMatchExpectedText(
+        string ruleId,
+        DiagnosticDescriptor descriptor,
+        ExpectedDescriptorMetadata expected)
+    {
+        Assert.Equal(expected.Title, descriptor.Title.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        Assert.Equal(expected.MessageFormat, descriptor.MessageFormat.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        Assert.Equal(expected.Description, descriptor.Description.ToString(System.Globalization.CultureInfo.InvariantCulture));
+        Assert.Equal(expected.Category, descriptor.Category);
+        Assert.Equal(expected.DefaultSeverity, descriptor.DefaultSeverity);
+        Assert.Equal(expected.IsEnabledByDefault, descriptor.IsEnabledByDefault);
+        Assert.Equal(ruleId, expected.RuleId);
+    }
+
+    [Fact]
+    public void RuleDocsShouldMatchDiscoveredDescriptors()
+    {
+        SortedSet<string> descriptorIds = new(DiscoverDescriptors().Select(descriptor => descriptor.Id), StringComparer.Ordinal);
+        SortedSet<string> documentedIds = new(
+            GetRuleDocsDirectory()
+                .EnumerateFiles("Moq*.md")
+                .Select(file => Path.GetFileNameWithoutExtension(file.Name)),
+            StringComparer.Ordinal);
+
+        Assert.Equal(descriptorIds, documentedIds);
+    }
+
+    [Fact]
+    public void ExpectedMetadataShouldCoverDiscoveredDescriptors()
+    {
+        SortedSet<string> descriptorIds = new(DiscoverDescriptors().Select(descriptor => descriptor.Id), StringComparer.Ordinal);
+        SortedSet<string> expectedIds = new(GetExpectedMetadata().Keys, StringComparer.Ordinal);
+
+        Assert.Equal(descriptorIds, expectedIds);
+    }
+
+    private static DiagnosticAnalyzer CreateAnalyzer(Type analyzerType)
+    {
+        DiagnosticAnalyzer? analyzer = (DiagnosticAnalyzer?)Activator.CreateInstance(analyzerType);
+        Assert.NotNull(analyzer);
+        return analyzer;
+    }
+
+    private static ImmutableArray<Type> DiscoverAnalyzerTypes()
+    {
+        Assembly analyzersAssembly = typeof(NoSealedClassMocksAnalyzer).Assembly;
+        return analyzersAssembly
+            .GetTypes()
+            .Where(type =>
+                string.Equals(type.Namespace, "Moq.Analyzers", StringComparison.Ordinal) &&
+                !type.IsAbstract &&
+                typeof(DiagnosticAnalyzer).IsAssignableFrom(type) &&
+                type.GetCustomAttribute<DiagnosticAnalyzerAttribute>() != null)
+            .OrderBy(type => type.Name, StringComparer.Ordinal)
+            .ToImmutableArray();
+    }
+
+    private static void AssertRuleDocMatchesDescriptor(DiagnosticDescriptor descriptor)
+    {
+        FileInfo ruleDoc = new(Path.Combine(GetRuleDocsDirectory().FullName, $"{descriptor.Id}.md"));
+        Assert.True(ruleDoc.Exists, $"Missing rule doc for {descriptor.Id}.");
+
+        string enabledValue = ReadRuleDocTableValue(ruleDoc, "Enabled");
+        string severityValue = ReadRuleDocTableValue(ruleDoc, "Severity");
+        Assert.Equal(descriptor.IsEnabledByDefault.ToString(), enabledValue);
+        Assert.Equal(descriptor.DefaultSeverity.ToString(), severityValue);
+    }
+
+    private static string ReadRuleDocTableValue(FileInfo ruleDoc, string key)
+    {
+        using StreamReader reader = ruleDoc.OpenText();
+        while (reader.ReadLine() is { } line)
+        {
+            string[] cells = line.Split('|', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries);
+            if (cells.Length == 2 && string.Equals(cells[0], key, StringComparison.Ordinal))
+            {
+                return cells[1];
+            }
+        }
+
+        throw new InvalidOperationException($"Could not find '{key}' in {ruleDoc.FullName}.");
+    }
+
+    private static void AssertHelpLinkMatchesRuleId(DiagnosticDescriptor descriptor)
+    {
+        Assert.False(string.IsNullOrWhiteSpace(descriptor.HelpLinkUri));
+        Assert.True(Uri.TryCreate(descriptor.HelpLinkUri, UriKind.Absolute, out Uri? helpUri));
+        Assert.NotNull(helpUri);
+        Assert.Equal("github.com", helpUri.Host);
+        Assert.EndsWith($"/docs/rules/{descriptor.Id}.md", helpUri.AbsolutePath, StringComparison.Ordinal);
+    }
+
+    private static DirectoryInfo GetRuleDocsDirectory()
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory != null)
+        {
+            DirectoryInfo candidate = new(Path.Combine(directory.FullName, "docs", "rules"));
+            if (candidate.Exists)
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new InvalidOperationException("Could not find docs/rules from the test output directory.");
+    }
+
+    private static bool IsMoqRuleId(string ruleId)
+    {
+        return ruleId.Length == 7 &&
+            ruleId.StartsWith("Moq", StringComparison.Ordinal) &&
+            ruleId.Skip(3).All(char.IsDigit);
+    }
+
+    private static bool IsAllowedCategory(string category)
+    {
+        return string.Equals(category, DiagnosticCategory.Usage, StringComparison.Ordinal) ||
+            string.Equals(category, DiagnosticCategory.Correctness, StringComparison.Ordinal) ||
+            string.Equals(category, DiagnosticCategory.BestPractice, StringComparison.Ordinal);
+    }
+
+    private static IReadOnlyDictionary<string, ExpectedDescriptorMetadata> GetExpectedMetadata()
+    {
+        return new Dictionary<string, ExpectedDescriptorMetadata>(StringComparer.Ordinal)
+        {
+            [DiagnosticIds.SealedClassCannotBeMocked] = new(
+                DiagnosticIds.SealedClassCannotBeMocked,
+                "Moq: Sealed class mocked",
+                "Sealed class '{0}' cannot be mocked",
+                "Sealed classes cannot be mocked.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.NoConstructorArgumentsForInterfaceMockRuleId] = new(
+                DiagnosticIds.NoConstructorArgumentsForInterfaceMockRuleId,
+                "Mock<T> construction must not specify parameters for interfaces",
+                "Mocked interface '{0}' cannot have constructor parameters {1}",
+                "Mocked interface cannot have constructor parameters.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.NoMatchingConstructorRuleId] = new(
+                DiagnosticIds.NoMatchingConstructorRuleId,
+                "Mock<T> construction must call an existing type constructor",
+                "Could not find a matching constructor for type '{0}' with arguments {1}",
+                "Could not find a matching constructor for arguments.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.InternalTypeMustHaveInternalsVisibleTo] = new(
+                DiagnosticIds.InternalTypeMustHaveInternalsVisibleTo,
+                "Moq: Internal type requires InternalsVisibleTo",
+                "Internal type '{0}' requires [InternalsVisibleTo(\"DynamicProxyGenAssembly2\")] in its assembly to be mocked",
+                "Mocking internal types requires the assembly to grant access to Castle DynamicProxy via InternalsVisibleTo.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.LoggerShouldNotBeMocked] = new(
+                DiagnosticIds.LoggerShouldNotBeMocked,
+                "Moq: ILogger mocked",
+                "ILogger should not be mocked; use {0} or FakeLogger from Microsoft.Extensions.Diagnostics.Testing instead",
+                "Mocking ILogger is unnecessary and fragile. Use NullLogger.Instance (for ILogger) or NullLogger<T>.Instance (for ILogger<T>) for tests that ignore logging, or FakeLogger from Microsoft.Extensions.Diagnostics.Testing for tests that verify log output.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.BadCallbackParameters] = new(
+                DiagnosticIds.BadCallbackParameters,
+                "Moq: Bad callback parameters",
+                "Callback signature for '{0}' must match the signature of the mocked method",
+                "Callback signature must match the signature of the mocked method.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.PropertySetupUsedForMethod] = new(
+                DiagnosticIds.PropertySetupUsedForMethod,
+                "Moq: Property setup used for a method",
+                "SetupGet/SetupSet/SetupProperty should be used for properties, not for methods like '{0}'",
+                "SetupGet/SetupSet/SetupProperty should be used for properties, not for methods.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.SetupOnlyUsedForOverridableMembers] = new(
+                DiagnosticIds.SetupOnlyUsedForOverridableMembers,
+                "Moq: Invalid setup parameter",
+                "Setup should be used only for overridable members, but '{0}' is not overridable",
+                "Setup should be used only for overridable members.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Error,
+                true),
+            [DiagnosticIds.AsyncUsesReturnsAsyncInsteadOfResult] = new(
+                DiagnosticIds.AsyncUsesReturnsAsyncInsteadOfResult,
+                "Moq: Invalid setup parameter",
+                "Setup of async method '{0}' should use ReturnsAsync instead of .Result",
+                "Setup of async methods should use ReturnsAsync instead of .Result.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Error,
+                true),
+            [DiagnosticIds.RaiseEventArgumentsShouldMatchEventSignature] = new(
+                DiagnosticIds.RaiseEventArgumentsShouldMatchEventSignature,
+                "Moq: Raise event arguments should match event signature",
+                "Raise event arguments should match the '{0}' event delegate signature",
+                "Raise event arguments should match the event delegate signature.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.MethodSetupShouldSpecifyReturnValue] = new(
+                DiagnosticIds.MethodSetupShouldSpecifyReturnValue,
+                "Method setup should specify a return value",
+                "Method setup for '{0}' should specify a return value",
+                "Method setups that return a value should use Returns(), ReturnsAsync(), Throws(), or ThrowsAsync() to specify a return value.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.RaisesEventArgumentsShouldMatchEventSignature] = new(
+                DiagnosticIds.RaisesEventArgumentsShouldMatchEventSignature,
+                "Moq: Raises event arguments should match event signature",
+                "Raises event arguments should match the '{0}' event delegate signature",
+                "Raises event arguments should match the event delegate signature.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.EventSetupHandlerShouldMatchEventType] = new(
+                DiagnosticIds.EventSetupHandlerShouldMatchEventType,
+                "Moq: Event setup handler type should match event delegate type",
+                "Event setup handler type should match the event delegate type for '{0}'",
+                "Event setup handler type should match the event delegate type.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.ReturnsAsyncShouldBeUsedForAsyncMethods] = new(
+                DiagnosticIds.ReturnsAsyncShouldBeUsedForAsyncMethods,
+                "Moq: Invalid Returns usage with async method",
+                "Async method '{0}' setups should use ReturnsAsync instead of Returns with async lambda",
+                "Async method setups should use ReturnsAsync instead of Returns with async lambda.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.SetupSequenceOnlyUsedForOverridableMembers] = new(
+                DiagnosticIds.SetupSequenceOnlyUsedForOverridableMembers,
+                "Moq: Invalid SetupSequence parameter",
+                "SetupSequence should be used only for overridable members, but '{0}' is not overridable",
+                "SetupSequence should be used only for overridable members.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Error,
+                true),
+            [DiagnosticIds.ReturnsDelegateMismatchOnAsyncMethod] = new(
+                DiagnosticIds.ReturnsDelegateMismatchOnAsyncMethod,
+                "Moq: Returns() delegate type mismatch on async method",
+                "Returns() delegate for async method '{0}' should return '{2}', not '{1}'. Use ReturnsAsync() or wrap with Task.FromResult().",
+                "Returns() delegate on async method setup should return Task/ValueTask. Use ReturnsAsync() or wrap with Task.FromResult().",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.VerifyOnlyUsedForOverridableMembers] = new(
+                DiagnosticIds.VerifyOnlyUsedForOverridableMembers,
+                "Moq: Invalid verify parameter",
+                "Verify should be used only for overridable members, but '{0}' is not overridable",
+                "Verify should be used only for overridable members.",
+                DiagnosticCategory.Correctness,
+                DiagnosticSeverity.Error,
+                true),
+            [DiagnosticIds.AsShouldOnlyBeUsedForInterfacesRuleId] = new(
+                DiagnosticIds.AsShouldOnlyBeUsedForInterfacesRuleId,
+                "Moq: Invalid As type parameter",
+                "Mock.As() should take interfaces only, but '{0}' is not an interface",
+                "Mock.As() should take interfaces only.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Error,
+                true),
+            [DiagnosticIds.MockGetShouldNotTakeLiterals] = new(
+                DiagnosticIds.MockGetShouldNotTakeLiterals,
+                "Moq: Mock.Get() should not take literals",
+                "Mock.Get() should not take literal '{0}'",
+                "Mock.Get() should not take literals.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.LinqToMocksExpressionShouldBeValid] = new(
+                DiagnosticIds.LinqToMocksExpressionShouldBeValid,
+                "Moq: Invalid LINQ to Mocks expression",
+                "Invalid member '{0}' in LINQ to Mocks expression",
+                "LINQ to Mocks expression contains non-virtual member that cannot be mocked.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.SetExplicitMockBehavior] = new(
+                DiagnosticIds.SetExplicitMockBehavior,
+                "Moq: Explicitly choose a mock behavior",
+                "Explicitly choose a mocking behavior for {0} instead of relying on the default (Loose) behavior",
+                "Explicitly choose a mocking behavior instead of relying on the default (Loose) behavior.",
+                DiagnosticCategory.BestPractice,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.SetStrictMockBehavior] = new(
+                DiagnosticIds.SetStrictMockBehavior,
+                "Moq: Set MockBehavior to Strict",
+                "Explicitly set the Strict mocking behavior for '{0}'",
+                "Explicitly set the Strict mocking behavior.",
+                DiagnosticCategory.BestPractice,
+                DiagnosticSeverity.Info,
+                true),
+            [DiagnosticIds.RedundantTimesSpecification] = new(
+                DiagnosticIds.RedundantTimesSpecification,
+                "Moq: Redundant Times specification",
+                "Redundant {0} specification can be removed as it is the default for Verify calls",
+                "Redundant Times.AtLeastOnce() specification can be removed as it is the default for Verify calls.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Info,
+                true),
+            [DiagnosticIds.MockRepositoryVerifyNotCalled] = new(
+                DiagnosticIds.MockRepositoryVerifyNotCalled,
+                "Moq: MockRepository.Verify() should be called",
+                "MockRepository '{0}' should have Verify() called",
+                "MockRepository.Verify() should be called to verify all mocks created through the repository.",
+                DiagnosticCategory.BestPractice,
+                DiagnosticSeverity.Warning,
+                true),
+            [DiagnosticIds.ProtectedSetupUsesItMatcherInsteadOfItExpr] = new(
+                DiagnosticIds.ProtectedSetupUsesItMatcherInsteadOfItExpr,
+                "Moq: Protected setup should use ItExpr",
+                "Protected member setup uses 'It.{0}' which is not compatible with string-based overloads; use an ItExpr matcher instead",
+                "Protected member setups using string-based overloads must use ItExpr matchers instead of It matchers.",
+                DiagnosticCategory.Usage,
+                DiagnosticSeverity.Warning,
+                true),
+        };
+    }
+
+    public sealed record ExpectedDescriptorMetadata(
+        string RuleId,
+        string Title,
+        string MessageFormat,
+        string Description,
+        string Category,
+        DiagnosticSeverity DefaultSeverity,
+        bool IsEnabledByDefault);
+}

--- a/tests/Moq.Analyzers.Test/DiagnosticMessageTests.cs
+++ b/tests/Moq.Analyzers.Test/DiagnosticMessageTests.cs
@@ -1,0 +1,316 @@
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Moq.Analyzers.Test;
+
+public class DiagnosticMessageTests
+{
+    public static TheoryData<Type, string, DiagnosticSeverity, string, string, string> FormattedDiagnosticMessageData()
+    {
+        TheoryData<Type, string, DiagnosticSeverity, string, string, string> data = [];
+
+        AddMessageCase<NoSealedClassMocksAnalyzer>(
+            data,
+            DiagnosticIds.SealedClassCannotBeMocked,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal sealed class FooSealed { }", "new Mock<{|#0:FooSealed|}>();"),
+            "Sealed class 'FooSealed' cannot be mocked");
+
+        AddMessageCase<ConstructorArgumentsShouldMatchAnalyzer>(
+            data,
+            DiagnosticIds.NoConstructorArgumentsForInterfaceMockRuleId,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { }", "new Mock<IService>{|#0:(\"value\")|};"),
+            "Mocked interface 'IService' cannot have constructor parameters (\"value\")");
+
+        AddMessageCase<ConstructorArgumentsShouldMatchAnalyzer>(
+            data,
+            DiagnosticIds.NoMatchingConstructorRuleId,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal class Service { public Service(string value) { } }", "new Mock<Service>{|#0:(42)|};"),
+            "Could not find a matching constructor for type 'Service' with arguments (42)");
+
+        AddMessageCase<InternalTypeMustHaveInternalsVisibleToAnalyzer>(
+            data,
+            DiagnosticIds.InternalTypeMustHaveInternalsVisibleTo,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal class InternalService { public virtual void Run() { } }", "new Mock<{|#0:InternalService|}>();"),
+            "Internal type 'InternalService' requires [InternalsVisibleTo(\"DynamicProxyGenAssembly2\")] in its assembly to be mocked");
+
+        AddMessageCase<NoMockOfLoggerAnalyzer>(
+            data,
+            DiagnosticIds.LoggerShouldNotBeMocked,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoqAndLogging,
+            CreateSource("using Microsoft.Extensions.Logging;", "new Mock<{|#0:ILogger|}>();"),
+            "ILogger should not be mocked; use NullLogger.Instance or FakeLogger from Microsoft.Extensions.Diagnostics.Testing instead");
+
+        AddMessageCase<CallbackSignatureShouldMatchMockedMethodAnalyzer>(
+            data,
+            DiagnosticIds.BadCallbackParameters,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { void Do(string value); }", "new Mock<IService>().Setup(x => x.Do(\"value\")).Callback(({|#0:int wrong|}) => { });"),
+            "Callback signature for 'Do' must match the signature of the mocked method");
+
+        AddMessageCase<NoMethodsInPropertySetupAnalyzer>(
+            data,
+            DiagnosticIds.PropertySetupUsedForMethod,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { int Get(); }", "new Mock<IService>().SetupGet(x => {|#0:x.Get()|});"),
+            "SetupGet/SetupSet/SetupProperty should be used for properties, not for methods like 'Get'");
+
+        AddMessageCase<SetupShouldBeUsedOnlyForOverridableMembersAnalyzer>(
+            data,
+            DiagnosticIds.SetupOnlyUsedForOverridableMembers,
+            DiagnosticSeverity.Error,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal class Service { public int Get() => 0; }", "{|#0:new Mock<Service>().Setup(x => x.Get())|};"),
+            "Setup should be used only for overridable members, but 'Service.Get()' is not overridable");
+
+        AddMessageCase<SetupShouldNotIncludeAsyncResultAnalyzer>(
+            data,
+            DiagnosticIds.AsyncUsesReturnsAsyncInsteadOfResult,
+            DiagnosticSeverity.Error,
+            ReferenceAssemblyCatalog.Net80WithOldMoq,
+            CreateSource("internal class Service { public virtual Task<int> GetAsync() => Task.FromResult(0); }", "new Mock<Service>().Setup(x => {|#0:x.GetAsync().Result|});"),
+            "Setup of async method 'GetAsync' should use ReturnsAsync instead of .Result");
+
+        AddMessageCase<RaiseEventArgumentsShouldMatchEventSignatureAnalyzer>(
+            data,
+            DiagnosticIds.RaiseEventArgumentsShouldMatchEventSignature,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { event EventHandler Closed; }", "new Mock<IService>().Raise(x => x.Closed += null, {|#0:42|});"),
+            "Raise event arguments should match the 'IService.Closed' event delegate signature");
+
+        AddMessageCase<MethodSetupShouldSpecifyReturnValueAnalyzer>(
+            data,
+            DiagnosticIds.MethodSetupShouldSpecifyReturnValue,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { int Get(); }", "{|#0:new Mock<IService>().Setup(x => x.Get())|};"),
+            "Method setup for 'IService.Get()' should specify a return value");
+
+        AddMessageCase<RaisesEventArgumentsShouldMatchEventSignatureAnalyzer>(
+            data,
+            DiagnosticIds.RaisesEventArgumentsShouldMatchEventSignature,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { event Action<string> Changed; void Submit(); }", "new Mock<IService>().Setup(x => x.Submit()).Raises(x => x.Changed += null, {|#0:42|});"),
+            "Raises event arguments should match the 'IService.Changed' event delegate signature");
+
+        AddMessageCase<ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer>(
+            data,
+            DiagnosticIds.ReturnsAsyncShouldBeUsedForAsyncMethods,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal class Service { public virtual Task<string> GetAsync() => Task.FromResult(string.Empty); }", "new Mock<Service>().Setup(x => x.GetAsync()).{|#0:Returns(async () => \"value\")|};"),
+            "Async method 'GetAsync' setups should use ReturnsAsync instead of Returns with async lambda");
+
+        AddMessageCase<SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer>(
+            data,
+            DiagnosticIds.SetupSequenceOnlyUsedForOverridableMembers,
+            DiagnosticSeverity.Error,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal class Service { public int Get() => 0; }", "new Mock<Service>().SetupSequence(x => {|#0:x.Get()|});"),
+            "SetupSequence should be used only for overridable members, but 'Service.Get()' is not overridable");
+
+        AddMessageCase<ReturnsDelegateShouldReturnTaskAnalyzer>(
+            data,
+            DiagnosticIds.ReturnsDelegateMismatchOnAsyncMethod,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal class Service { public virtual Task<int> GetAsync() => Task.FromResult(0); }", "new Mock<Service>().Setup(x => x.GetAsync()).{|#0:Returns(() => 42)|};"),
+            "Returns() delegate for async method 'GetAsync' should return 'Task<int>', not 'int'. Use ReturnsAsync() or wrap with Task.FromResult().");
+
+        AddMessageCase<VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer>(
+            data,
+            DiagnosticIds.VerifyOnlyUsedForOverridableMembers,
+            DiagnosticSeverity.Error,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal class Service { public void Do() { } }", "{|#0:new Mock<Service>().Verify(x => x.Do())|};"),
+            "Verify should be used only for overridable members, but 'Do' is not overridable");
+
+        AddMessageCase<AsShouldBeUsedOnlyForInterfaceAnalyzer>(
+            data,
+            DiagnosticIds.AsShouldOnlyBeUsedForInterfacesRuleId,
+            DiagnosticSeverity.Error,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal class Service { }", "new Mock<object>().As<{|#0:Service|}>();"),
+            "Mock.As() should take interfaces only, but 'Service' is not an interface");
+
+        AddMessageCase<MockGetShouldNotTakeLiteralsAnalyzer>(
+            data,
+            DiagnosticIds.MockGetShouldNotTakeLiterals,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource(string.Empty, "Mock.Get({|#0:\"literal\"|});"),
+            "Mock.Get() should not take literal 'literal'");
+
+        AddMessageCase<LinqToMocksExpressionShouldBeValidAnalyzer>(
+            data,
+            DiagnosticIds.LinqToMocksExpressionShouldBeValid,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal class Service { public string Name { get; set; } = string.Empty; }", "Mock.Of<Service>(x => {|#0:x.Name|} == \"value\");"),
+            "Invalid member 'x.Name' in LINQ to Mocks expression");
+
+        AddMessageCase<SetExplicitMockBehaviorAnalyzer>(
+            data,
+            DiagnosticIds.SetExplicitMockBehavior,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { }", "{|#0:new Mock<IService>()|};"),
+            "Explicitly choose a mocking behavior for IService instead of relying on the default (Loose) behavior");
+
+        AddMessageCase<SetStrictMockBehaviorAnalyzer>(
+            data,
+            DiagnosticIds.SetStrictMockBehavior,
+            DiagnosticSeverity.Info,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { }", "{|#0:new Mock<IService>(MockBehavior.Loose)|};"),
+            "Explicitly set the Strict mocking behavior for 'IService'");
+
+        AddMessageCase<RedundantTimesSpecificationAnalyzer>(
+            data,
+            DiagnosticIds.RedundantTimesSpecification,
+            DiagnosticSeverity.Info,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { void Do(); }", "new Mock<IService>().Verify(x => x.Do(), {|#0:Times.AtLeastOnce()|});"),
+            "Redundant Times.AtLeastOnce() specification can be removed as it is the default for Verify calls");
+
+        AddMessageCase<MockRepositoryVerifyAnalyzer>(
+            data,
+            DiagnosticIds.MockRepositoryVerifyNotCalled,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("internal interface IService { }", "var {|#0:repository|} = new MockRepository(MockBehavior.Strict); repository.Create<IService>();"),
+            "MockRepository 'repository' should have Verify() called");
+
+        AddMessageCase<ProtectedSetupShouldUseItExprAnalyzer>(
+            data,
+            DiagnosticIds.ProtectedSetupUsesItMatcherInsteadOfItExpr,
+            DiagnosticSeverity.Warning,
+            ReferenceAssemblyCatalog.Net80WithNewMoq,
+            CreateSource("using Moq.Protected; internal abstract class Service { protected virtual bool Foo(string value) => true; }", "new Mock<Service>().Protected().Setup<bool>(\"Foo\", {|#0:It.IsAny<string>()|}).Returns(true);"),
+            "Protected member setup uses 'It.IsAny' which is not compatible with string-based overloads; use an ItExpr matcher instead");
+
+        return data;
+    }
+
+    [Theory]
+    [MemberData(nameof(FormattedDiagnosticMessageData))]
+    public async Task AnalyzerShouldReportFormattedDiagnosticMessage(
+        Type analyzerType,
+        string ruleId,
+        DiagnosticSeverity severity,
+        string referenceAssemblyGroup,
+        string source,
+        string expectedMessage)
+    {
+        DiagnosticResult expected = new DiagnosticResult(ruleId, severity)
+            .WithLocation(0)
+            .WithMessage(expectedMessage);
+
+        await VerifyAnalyzerAsync(analyzerType, source, referenceAssemblyGroup, expected);
+    }
+
+    [Fact]
+    public void FormattedDiagnosticMessageDataShouldCoverEveryReportableParameterizedDescriptor()
+    {
+        ImmutableHashSet<string> coveredRuleIds = FormattedDiagnosticMessageData()
+            .Select(static row => (string)row[1])
+            .ToImmutableHashSet(StringComparer.Ordinal);
+
+        string[] uncoveredRuleIds = DiagnosticDescriptorMetadataTests.DiscoverDescriptors()
+            .Where(static descriptor => descriptor.MessageFormat.ToString(System.Globalization.CultureInfo.InvariantCulture).Contains('{', StringComparison.Ordinal))
+            .Where(descriptor => !coveredRuleIds.Contains(descriptor.Id))
+            .Where(static descriptor => !IsCompilerBoundEventSetupDiagnostic(descriptor.Id))
+            .Select(static descriptor => descriptor.Id)
+            .ToArray();
+
+        Assert.Empty(uncoveredRuleIds);
+    }
+
+    private static void AddMessageCase<TAnalyzer>(
+        TheoryData<Type, string, DiagnosticSeverity, string, string, string> data,
+        string ruleId,
+        DiagnosticSeverity severity,
+        string referenceAssemblyGroup,
+        string source,
+        string expectedMessage)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        data.Add(typeof(TAnalyzer), ruleId, severity, referenceAssemblyGroup, source, expectedMessage);
+    }
+
+    private static bool IsCompilerBoundEventSetupDiagnostic(string ruleId)
+    {
+        // Moq1205 mismatches are compiler errors before the analyzer can report a diagnostic.
+        return string.Equals(ruleId, DiagnosticIds.EventSetupHandlerShouldMatchEventType, StringComparison.Ordinal);
+    }
+
+    private static string CreateSource(string declarations, string testCode)
+    {
+        return $$"""
+            {{declarations}}
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    {{testCode}}
+                }
+            }
+            """;
+    }
+
+    private static Task VerifyAnalyzerAsync(
+        Type analyzerType,
+        string source,
+        string referenceAssemblyGroup,
+        DiagnosticResult expected)
+    {
+        return analyzerType.Name switch
+        {
+            nameof(NoSealedClassMocksAnalyzer) => VerifyAnalyzerAsync<NoSealedClassMocksAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(ConstructorArgumentsShouldMatchAnalyzer) => VerifyAnalyzerAsync<ConstructorArgumentsShouldMatchAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(InternalTypeMustHaveInternalsVisibleToAnalyzer) => VerifyAnalyzerAsync<InternalTypeMustHaveInternalsVisibleToAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(NoMockOfLoggerAnalyzer) => VerifyAnalyzerAsync<NoMockOfLoggerAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(CallbackSignatureShouldMatchMockedMethodAnalyzer) => VerifyAnalyzerAsync<CallbackSignatureShouldMatchMockedMethodAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(NoMethodsInPropertySetupAnalyzer) => VerifyAnalyzerAsync<NoMethodsInPropertySetupAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(SetupShouldBeUsedOnlyForOverridableMembersAnalyzer) => VerifyAnalyzerAsync<SetupShouldBeUsedOnlyForOverridableMembersAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(SetupShouldNotIncludeAsyncResultAnalyzer) => VerifyAnalyzerAsync<SetupShouldNotIncludeAsyncResultAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(RaiseEventArgumentsShouldMatchEventSignatureAnalyzer) => VerifyAnalyzerAsync<RaiseEventArgumentsShouldMatchEventSignatureAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(MethodSetupShouldSpecifyReturnValueAnalyzer) => VerifyAnalyzerAsync<MethodSetupShouldSpecifyReturnValueAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(RaisesEventArgumentsShouldMatchEventSignatureAnalyzer) => VerifyAnalyzerAsync<RaisesEventArgumentsShouldMatchEventSignatureAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer) => VerifyAnalyzerAsync<ReturnsAsyncShouldBeUsedForAsyncMethodsAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer) => VerifyAnalyzerAsync<SetupSequenceShouldBeUsedOnlyForOverridableMembersAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(ReturnsDelegateShouldReturnTaskAnalyzer) => VerifyAnalyzerAsync<ReturnsDelegateShouldReturnTaskAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer) => VerifyAnalyzerAsync<VerifyShouldBeUsedOnlyForOverridableMembersAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(AsShouldBeUsedOnlyForInterfaceAnalyzer) => VerifyAnalyzerAsync<AsShouldBeUsedOnlyForInterfaceAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(MockGetShouldNotTakeLiteralsAnalyzer) => VerifyAnalyzerAsync<MockGetShouldNotTakeLiteralsAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(LinqToMocksExpressionShouldBeValidAnalyzer) => VerifyAnalyzerAsync<LinqToMocksExpressionShouldBeValidAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(SetExplicitMockBehaviorAnalyzer) => VerifyAnalyzerAsync<SetExplicitMockBehaviorAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(SetStrictMockBehaviorAnalyzer) => VerifyAnalyzerAsync<SetStrictMockBehaviorAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(RedundantTimesSpecificationAnalyzer) => VerifyAnalyzerAsync<RedundantTimesSpecificationAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(MockRepositoryVerifyAnalyzer) => VerifyAnalyzerAsync<MockRepositoryVerifyAnalyzer>(source, referenceAssemblyGroup, expected),
+            nameof(ProtectedSetupShouldUseItExprAnalyzer) => VerifyAnalyzerAsync<ProtectedSetupShouldUseItExprAnalyzer>(source, referenceAssemblyGroup, expected),
+            _ => throw new InvalidOperationException($"No verifier registered for {analyzerType.Name}."),
+        };
+    }
+
+    private static Task VerifyAnalyzerAsync<TAnalyzer>(
+        string source,
+        string referenceAssemblyGroup,
+        DiagnosticResult expected)
+        where TAnalyzer : DiagnosticAnalyzer, new()
+    {
+        return AnalyzerVerifier<TAnalyzer>.VerifyAnalyzerAsync(source, referenceAssemblyGroup, expected);
+    }
+}


### PR DESCRIPTION
Fixes #687
Fixes #694

## Summary
- Add reflection-driven descriptor metadata coverage for every analyzer diagnostic.
- Add formatted message assertions for reportable parameterized diagnostics.
- Add a guard that fails when a new reportable parameterized descriptor lacks message coverage.
- Document the diagnostic message testing convention.

## Descriptor Coverage
Covered descriptors: Moq1000, Moq1001, Moq1002, Moq1003, Moq1004, Moq1100, Moq1101, Moq1200, Moq1201, Moq1202, Moq1203, Moq1204, Moq1205, Moq1206, Moq1207, Moq1208, Moq1210, Moq1300, Moq1301, Moq1302, Moq1400, Moq1410, Moq1420, Moq1500, Moq1600.

Moq1205 is descriptor-covered. It is excluded from formatted message trigger coverage because the mismatch case is a C# compiler error before the analyzer can report.

## Test Count
- 77 new executed test cases across the new diagnostic coverage suites.

## Moq Compatibility
N/A. This is test-only and does not change Moq API detection or analyzer behavior.

## Validation Log

### dotnet format
Passed. Manual run completed with exit code 0. Husky pre-commit also ran dotnet-format successfully in 133,280ms.

```text
Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.
```

### dotnet build

```text
Build succeeded.
    0 Warning(s)
    0 Error(s)

Time Elapsed 00:01:00.86
```

### dotnet test, targeted with runsettings

Command:

```text
dotnet test tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj --settings ./build/targets/tests/test.runsettings --filter "FullyQualifiedName~DiagnosticDescriptorMetadataTests|FullyQualifiedName~DiagnosticMessageTests" --logger "console;verbosity=minimal"
```

Result:

```text
Passed!  - Failed:     0, Passed:    77, Skipped:     0, Total:    77, Duration: 17 s - Moq.Analyzers.Test.dll (net8.0)
2026-07-06T12:51:35: Writing report file '/home/richard/src/GitHub/rjmurillo/moq.analyzers/.wt/diag-msg-cov//artifacts/TestResults/coverage/Cobertura.xml'
2026-07-06T12:51:35: Writing report file '/home/richard/src/GitHub/rjmurillo/moq.analyzers/.wt/diag-msg-cov//artifacts/TestResults/coverage/index.html'
2026-07-06T12:51:35: Writing report file '/home/richard/src/GitHub/rjmurillo/moq.analyzers/.wt/diag-msg-cov//artifacts/TestResults/coverage/SummaryGithub.md'
```

### Full suite attempt

Full `dotnet test --settings ./build/targets/tests/test.runsettings` was attempted twice. `PerfDiff.Tests` passed, then `Moq.Analyzers.Test` stopped producing output and remained active until killed. The final attempt had this last output before termination:

```text
Passed!  - Failed:     0, Passed:     4, Skipped:     0, Total:     4, Duration: 154 ms - PerfDiff.Tests.dll (net8.0)
Test run for /home/richard/src/GitHub/rjmurillo/moq.analyzers/.wt/diag-msg-cov/artifacts/bin/Moq.Analyzers.Test/debug/Moq.Analyzers.Test.dll (.NETCoreApp,Version=v8.0)
A total of 1 test files matched the specified pattern.
```

### Coverage

No production code was modified. Targeted runsettings generated Cobertura at:

```text
artifacts/TestResults/coverage/Cobertura.xml
```

### Codacy

Codacy CLI returned exit code 0 earlier in the session, but two configured tools failed before producing usable findings:

```text
2026/07/06 12:27:16 Running lizard...
2026/07/06 12:27:18 Running opengrep...
2026/07/06 12:27:22 Tool failed to run: failed to run opengrep: fork/exec /home/richard/.cache/codacy/tools/opengrep@1.78.0/opengrep: exec format error
2026/07/06 12:27:22 Running trivy...
2026/07/06 12:27:22 Tool failed to run: failed to install trivy: failed to extract tool: failed to extract archive: EOF
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance on analyzer test coverage, including descriptor metadata, formatted messages, and precise diagnostic location checks.

* **Tests**
  * Added coverage to verify analyzer diagnostic metadata is complete, consistent, and linked to the correct documentation.
  * Added tests for formatted diagnostic messages across multiple analyzers.
  * Added checks to ensure all reportable diagnostic rules are covered by test data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->