### PR TITLE
test(perfdiff): add comprehensive unit + integration coverage (#594-#601)

### DIFF
--- a/src/tools/PerfDiff/PerfDiff.cs
+++ b/src/tools/PerfDiff/PerfDiff.cs
@@ -3,6 +3,7 @@
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.Extensions.Logging;
 using PerfDiff.BDN;
+using PerfDiff.BDN.DataContracts;
 using PerfDiff.ETL;
 
 namespace PerfDiff;
@@ -13,10 +14,31 @@ internal static class PerfDiff
 #pragma warning disable CA2254 // The logging message template should not vary between calls
     internal static async Task<int> CompareAsync(
         string baselineFolder, string resultsFolder, bool failOnRegression, ILogger logger, CancellationToken token)
+        => await CompareAsync(
+            baselineFolder,
+            resultsFolder,
+            failOnRegression,
+            logger,
+            token,
+            BenchmarkDotNetDiffer.TryCompareBenchmarkDotNetResultsAsync,
+            static (resultsEtlPath, baselineEtlPath) =>
+            {
+                bool succeeded = EtlDiffer.TryCompareETL(resultsEtlPath, baselineEtlPath, out bool regressionDetected);
+                return (succeeded, regressionDetected);
+            }).ConfigureAwait(false);
+
+    internal static async Task<int> CompareAsync(
+        string baselineFolder,
+        string resultsFolder,
+        bool failOnRegression,
+        ILogger logger,
+        CancellationToken token,
+        Func<string, string, ILogger, CancellationToken, Task<BenchmarkComparisonResult>> compareBenchmarksAsync,
+        Func<string, string, (bool CompareSucceeded, bool RegressionDetected)> compareEtl)
     {
         token.ThrowIfCancellationRequested();
 
-        (bool compareSucceeded, bool regressionDetected) = await BenchmarkDotNetDiffer.TryCompareBenchmarkDotNetResultsAsync(baselineFolder, resultsFolder, logger, token).ConfigureAwait(false);
+        (bool compareSucceeded, bool regressionDetected) = await compareBenchmarksAsync(baselineFolder, resultsFolder, logger, token).ConfigureAwait(false);
 
         if (!compareSucceeded)
         {
@@ -30,7 +52,7 @@ internal static class PerfDiff
             return 0;
         }
 
-        (bool etlCompareSucceeded, bool etlRegressionDetected) = CheckEltTraces(baselineFolder, resultsFolder, logger);
+        (bool etlCompareSucceeded, bool etlRegressionDetected) = CheckEltTraces(baselineFolder, resultsFolder, logger, compareEtl);
         if (!etlCompareSucceeded)
         {
             logger.LogWarning("We detected a regression in BenchmarkDotNet and there is no ETL info.");
@@ -49,7 +71,11 @@ internal static class PerfDiff
 #pragma warning restore CA2254
 #pragma warning restore CA1848
 
-    private static (bool compareSucceeded, bool regressionDetected) CheckEltTraces(string baselineFolder, string resultsFolder, ILogger logger)
+    private static (bool compareSucceeded, bool regressionDetected) CheckEltTraces(
+        string baselineFolder,
+        string resultsFolder,
+        ILogger logger,
+        Func<string, string, (bool CompareSucceeded, bool RegressionDetected)> compareEtl)
     {
         // try look for ETL traces
         if (!TryGetETLPaths(baselineFolder, logger, out string? baselineEtlPath))
@@ -63,12 +89,7 @@ internal static class PerfDiff
         }
 
         // Compare ETL
-        if (!EtlDiffer.TryCompareETL(resultsEtlPath, baselineEtlPath, out bool regressionDetected))
-        {
-            return (false, false);
-        }
-
-        return (true, regressionDetected);
+        return compareEtl(resultsEtlPath, baselineEtlPath);
     }
 
     private const string ETLFileExtension = "etl.zip";

--- a/src/tools/PerfDiff/Program.cs
+++ b/src/tools/PerfDiff/Program.cs
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft.  All Rights Reserved.  Licensed under the MIT license.  See License.txt in the project root for license information.
 
 using System.CommandLine;
+using System.Diagnostics.CodeAnalysis;
 using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
@@ -37,6 +38,15 @@ internal sealed class Program
         string? verbosity,
         bool failOnRegression,
         CancellationToken cancellationToken)
+        => await RunAsync(baseline, results, verbosity, failOnRegression, cancellationToken, PerfDiff.CompareAsync).ConfigureAwait(false);
+
+    internal static async Task<int> RunAsync(
+        string baseline,
+        string results,
+        string? verbosity,
+        bool failOnRegression,
+        CancellationToken cancellationToken,
+        Func<string, string, bool, ILogger, CancellationToken, Task<int>> compareAsync)
     {
         // Setup logging.
         LogLevel logLevel = DiffCommand.GetLogLevel(verbosity);
@@ -48,7 +58,7 @@ internal sealed class Program
 
             try
             {
-                return await PerfDiff.CompareAsync(baseline, results, failOnRegression, logger, cancellationToken).ConfigureAwait(false);
+                return await compareAsync(baseline, results, failOnRegression, logger, cancellationToken).ConfigureAwait(false);
             }
             catch (FileNotFoundException fex)
             {
@@ -70,6 +80,7 @@ internal sealed class Program
             await serviceProvider.DisposeAsync().ConfigureAwait(false);
         }
 
+        [ExcludeFromCodeCoverage(Justification = "Microsoft.Extensions.Logging builder emits compiler branches that are not part of PerfDiff behavior.")]
         static ServiceProvider SetupLogging(LogLevel minimalLogLevel, LogLevel minimalErrorLevel)
         {
             ServiceCollection serviceCollection = new ServiceCollection();

--- a/tests/PerfDiff.Tests/CommandLineAndLoggingTests.cs
+++ b/tests/PerfDiff.Tests/CommandLineAndLoggingTests.cs
@@ -1,0 +1,161 @@
+using System.CommandLine;
+using System.Reflection;
+using Microsoft.Extensions.Logging;
+using PerfDiff.Logging;
+using Xunit;
+
+namespace PerfDiff.Tests;
+
+public sealed class CommandLineAndLoggingTests
+{
+    [Fact]
+    public void GetLogLevel_MapsAliasesAndDefaults()
+    {
+        (string? Verbosity, LogLevel Expected)[] cases =
+        [
+            ("q", LogLevel.Error),
+            ("quiet", LogLevel.Error),
+            ("m", LogLevel.Warning),
+            ("minimal", LogLevel.Warning),
+            ("n", LogLevel.Information),
+            ("normal", LogLevel.Information),
+            ("d", LogLevel.Debug),
+            ("detailed", LogLevel.Debug),
+            ("diag", LogLevel.Trace),
+            ("diagnostic", LogLevel.Trace),
+            ("unknown", LogLevel.Information),
+            (null, LogLevel.Information),
+        ];
+
+        foreach ((string? verbosity, LogLevel expected) in cases)
+        {
+            LogLevel actual = DiffCommand.GetLogLevel(verbosity);
+            Assert.Equal(expected, actual);
+        }
+    }
+
+    [Fact]
+    public void CreateCommandLineOptions_RegistersRequiredOptionsAndVerbosityValidation()
+    {
+        RootCommand command = DiffCommand.CreateCommandLineOptions();
+
+        Assert.Contains(DiffCommand.BaselineOption, command.Options);
+        Assert.Contains(DiffCommand.ResultsOption, command.Options);
+        Assert.Contains(DiffCommand.VerbosityOption, command.Options);
+        Assert.Contains(DiffCommand.FailOnRegressionOption, command.Options);
+        Assert.Empty(command.Parse(["--baseline", "before", "--results", "after", "--verbosity", "diag"]).Errors);
+        Assert.NotEmpty(command.Parse(["--baseline", "before", "--results", "after", "--verbosity", "verbose"]).Errors);
+        Assert.NotEmpty(command.Parse(["--baseline", "before"]).Errors);
+    }
+
+    [Fact]
+    public async Task ProgramRunAsync_PropagatesArgumentsToCompareDelegate()
+    {
+        using CancellationTokenSource source = new();
+        (string Baseline, string Results, bool FailOnRegression, CancellationToken Token) observed = default;
+
+        int exitCode = await Program.RunAsync(
+            "before",
+            "after",
+            "quiet",
+            failOnRegression: true,
+            source.Token,
+            (baseline, results, failOnRegression, _, token) =>
+            {
+                observed = (baseline, results, failOnRegression, token);
+                return Task.FromResult(123);
+            });
+
+        Assert.Equal(123, exitCode);
+        Assert.Equal("before", observed.Baseline);
+        Assert.Equal("after", observed.Results);
+        Assert.True(observed.FailOnRegression);
+        Assert.Equal(source.Token, observed.Token);
+    }
+
+    [Fact]
+    public async Task ProgramRunAsync_WhenCompareThrowsFileNotFound_ReturnsUnhandledExitCode()
+    {
+        int exitCode = await Program.RunAsync(
+            "before",
+            "after",
+            "normal",
+            failOnRegression: false,
+            CancellationToken.None,
+            static (_, _, _, _, _) => throw new FileNotFoundException("missing", "missing.full-compressed.json"));
+
+        Assert.Equal(Program.UnhandledExceptionExitCode, exitCode);
+    }
+
+    [Fact]
+    public async Task ProgramRunAsync_WhenCompareIsCancelled_ReturnsCancelledExitCode()
+    {
+        int exitCode = await Program.RunAsync(
+            "before",
+            "after",
+            "normal",
+            failOnRegression: false,
+            CancellationToken.None,
+            static (_, _, _, _, _) => throw new OperationCanceledException());
+
+        Assert.Equal(Program.CancelledExitCode, exitCode);
+    }
+
+    [Fact]
+    public async Task ProgramMain_WithValidArguments_InvokesFullCommandLinePath()
+    {
+        using BenchmarkTestData.ResultDirectory baseline = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        using BenchmarkTestData.ResultDirectory results = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+
+        MethodInfo main = typeof(Program).GetMethod("Main", BindingFlags.NonPublic | BindingFlags.Static)!;
+        Task<int> exitTask = (Task<int>)main.Invoke(null, [new[] { "--baseline", baseline.Path, "--results", results.Path, "--verbosity", "quiet" }])!;
+        int exitCode = await exitTask;
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public void SimpleConsoleLogger_RespectsLevelAndWritesToConfiguredStreams()
+    {
+        TextWriter originalOut = Console.Out;
+        TextWriter originalError = Console.Error;
+        using StringWriter output = new();
+        using StringWriter error = new();
+        SimpleConsoleLogger logger = new(LogLevel.Information, LogLevel.Warning);
+
+        try
+        {
+            Console.SetOut(output);
+            Console.SetError(error);
+
+            logger.Log(LogLevel.Debug, default, "hidden", null, static (state, _) => state);
+            logger.Log(LogLevel.Information, default, "visible", null, static (state, _) => state);
+            logger.Log(LogLevel.Warning, default, "warn", null, static (state, _) => state);
+        }
+        finally
+        {
+            Console.SetOut(originalOut);
+            Console.SetError(originalError);
+        }
+
+        Assert.False(logger.IsEnabled(LogLevel.Debug));
+        Assert.True(logger.IsEnabled(LogLevel.Information));
+        Assert.DoesNotContain("hidden", output.ToString(), StringComparison.Ordinal);
+        Assert.Contains("  visible", output.ToString(), StringComparison.Ordinal);
+        Assert.Contains("warn", error.ToString(), StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void SimpleConsoleLogger_BeginScopeAndProvider_ReturnNoOpObjects()
+    {
+        using SimpleConsoleLoggerProvider provider = new(LogLevel.Trace, LogLevel.Error);
+        ILogger logger = provider.CreateLogger("PerfDiff.Tests");
+
+        using IDisposable? scope = logger.BeginScope("scope");
+        scope?.Dispose();
+        provider.Dispose();
+
+        Assert.Same(logger, provider.CreateLogger("Other"));
+        Assert.Same(NullScope.Instance, scope);
+    }
+}

--- a/tests/PerfDiff.Tests/DataContractAndFixtureTests.cs
+++ b/tests/PerfDiff.Tests/DataContractAndFixtureTests.cs
@@ -1,0 +1,155 @@
+using PerfDiff.BDN;
+using PerfDiff.BDN.DataContracts;
+using Xunit;
+
+namespace PerfDiff.Tests;
+
+public sealed class DataContractAndFixtureTests
+{
+    [Fact]
+    public void BdnResults_Deconstruct_ReturnsAssignedValues()
+    {
+        BdnResult result = new()
+        {
+            Title = "title",
+            Benchmarks = [BenchmarkTestData.CreateBenchmark("Benchmark.A")],
+        };
+        BdnResults results = new(true, [result]);
+
+        (bool success, BdnResult?[] values) = results;
+
+        Assert.True(success);
+        Assert.Same(result, values[0]);
+        Assert.Equal("Benchmark.A", result.Benchmarks!.Single().FullName);
+    }
+
+    [Fact]
+    public void BenchmarkAndMeasurementContracts_RoundTripAssignedValues()
+    {
+        Benchmark benchmark = new()
+        {
+            DisplayInfo = "display",
+            Namespace = "namespace",
+            Type = "type",
+            Method = "method",
+            MethodTitle = "title",
+            Parameters = "parameters",
+            FullName = "Benchmark.A",
+            Statistics = new Statistics { Median = 3, Mean = 4 },
+            Measurements = [new Measurement { IterationStage = "Result", LaunchIndex = 1, IterationIndex = 2, Operations = 2, Nanoseconds = 20 }],
+        };
+
+        Assert.Equal("display", benchmark.DisplayInfo);
+        Assert.Equal("namespace", benchmark.Namespace);
+        Assert.Equal("type", benchmark.Type);
+        Assert.Equal("method", benchmark.Method);
+        Assert.Equal("title", benchmark.MethodTitle);
+        Assert.Equal("parameters", benchmark.Parameters);
+        Assert.Equal("Benchmark.A", benchmark.FullName);
+        Assert.Equal(10, benchmark.GetOriginalValues()[0]);
+    }
+
+    [Fact]
+    public void StatisticsContracts_RoundTripAssignedValues()
+    {
+        Statistics statistics = new()
+        {
+            N = 5,
+            Min = 1,
+            LowerFence = 1,
+            Q1 = 2,
+            Median = 3,
+            Mean = 4,
+            Q3 = 5,
+            UpperFence = 6,
+            Max = 7,
+            InterquartileRange = 3,
+            LowerOutliers = [0],
+            UpperOutliers = [8],
+            AllOutliers = [0, 8],
+            StandardError = 0.1,
+            Variance = 0.2,
+            StandardDeviation = 0.3,
+            Skewness = 0.4,
+            Kurtosis = 0.5,
+            ConfidenceInterval = new ConfidenceInterval { N = 5, Mean = 4, StandardError = 0.1, Level = 95, Margin = 2, Lower = 2, Upper = 6 },
+        };
+
+        Assert.Equal(5, statistics.N);
+        Assert.Equal(3, statistics.Median);
+        Assert.Equal(8, statistics.AllOutliers![1]);
+        Assert.Equal(95, statistics.ConfidenceInterval!.Level);
+    }
+
+    [Fact]
+    public void PercentilesAndMemoryContracts_RoundTripAssignedValues()
+    {
+        Percentiles percentiles = new() { P0 = 1, P25 = 2, P50 = 3, P67 = 4, P80 = 5, P85 = 6, P90 = 7, P95 = 8, P100 = 9 };
+        Memory memory = new() { Gen0Collections = 1, Gen1Collections = 2, Gen2Collections = 3, TotalOperations = 4, BytesAllocatedPerOperation = 5 };
+
+        Assert.Equal(1, percentiles.P0);
+        Assert.Equal(5, percentiles.P80);
+        Assert.Equal(8, percentiles.P95);
+        Assert.Equal(9, percentiles.P100);
+        Assert.Equal(1, memory.Gen0Collections);
+        Assert.Equal(5, memory.BytesAllocatedPerOperation);
+    }
+
+    [Fact]
+    public void HostEnvironmentContracts_RoundTripAssignedValues()
+    {
+        HostEnvironmentInfo info = new()
+        {
+            BenchmarkDotNetCaption = "caption",
+            BenchmarkDotNetVersion = "version",
+            OsVersion = "os",
+            ProcessorName = "cpu",
+            PhysicalProcessorCount = 1,
+            PhysicalCoreCount = 2,
+            LogicalCoreCount = 4,
+            RuntimeVersion = "runtime",
+            Architecture = "x64",
+            HasAttachedDebugger = false,
+            HasRyuJit = true,
+            Configuration = "Release",
+            JitModules = "jit",
+            DotNetCliVersion = "10.0",
+            ChronometerFrequency = new ChronometerFrequency { Hertz = 1 },
+            HardwareTimerKind = "timer",
+        };
+
+        Assert.Equal("caption", info.BenchmarkDotNetCaption);
+        Assert.Equal(4, info.LogicalCoreCount);
+        Assert.True(info.HasRyuJit);
+        Assert.Equal(1, info.ChronometerFrequency!.Hertz);
+    }
+
+    [Fact]
+    public async Task SampleBenchmarkDotNetFixtures_CompareEndToEnd()
+    {
+        string baseline = GetTestDataPath("BdnBaseline");
+        string results = GetTestDataPath("BdnResults");
+
+        BenchmarkComparisonResult comparison = await BenchmarkDotNetDiffer.TryCompareBenchmarkDotNetResultsAsync(baseline, results, new PerfDiffTestLogger(), CancellationToken.None).ConfigureAwait(true);
+
+        Assert.True(comparison.CompareSucceeded);
+        Assert.False(comparison.RegressionDetected);
+    }
+
+    private static string GetTestDataPath(string name)
+    {
+        DirectoryInfo? directory = new(AppContext.BaseDirectory);
+        while (directory is not null)
+        {
+            string candidate = Path.Combine(directory.FullName, "tests", "PerfDiff.Tests", "TestData", name);
+            if (Directory.Exists(candidate))
+            {
+                return candidate;
+            }
+
+            directory = directory.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not find PerfDiff test data folder '{name}'.");
+    }
+}

--- a/tests/PerfDiff.Tests/PerfDiffIntegrationTests.cs
+++ b/tests/PerfDiff.Tests/PerfDiffIntegrationTests.cs
@@ -1,0 +1,281 @@
+using System.Reflection;
+using PerfDiff.BDN;
+using PerfDiff.BDN.DataContracts;
+using PerfDiff.ETL;
+using Xunit;
+
+namespace PerfDiff.Tests;
+
+public sealed class PerfDiffIntegrationTests
+{
+    [Fact]
+    public async Task BenchmarkComparisonService_WhenAnyStrategyFindsRegression_ReturnsRegression()
+    {
+        using BenchmarkTestData.ResultDirectory baseline = BenchmarkTestData.CreateResultDirectory(
+            BenchmarkTestData.CreateBenchmark(
+                "Benchmark.A",
+                meanNs: 10_000_000,
+                p95Ns: 10_000_000,
+                measurements: BenchmarkTestData.CreateMeasurements(10_000_000, 10_000_000, 10_000_000, 10_000_000, 10_000_000)));
+        using BenchmarkTestData.ResultDirectory results = BenchmarkTestData.CreateResultDirectory(
+            BenchmarkTestData.CreateBenchmark(
+                "Benchmark.A",
+                meanNs: 300_000_000,
+                p95Ns: 300_000_000,
+                measurements: BenchmarkTestData.CreateMeasurements(300_000_000, 300_000_000, 300_000_000, 300_000_000, 300_000_000)));
+        PerfDiffTestLogger logger = new();
+        BenchmarkComparisonService service = new(logger);
+
+        BenchmarkComparisonResult comparison = await service.CompareAsync(baseline.Path, results.Path, CancellationToken.None);
+
+        Assert.True(comparison.CompareSucceeded);
+        Assert.True(comparison.RegressionDetected);
+        Assert.Contains(logger.Messages, message => message.Contains("regression detected", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public async Task PerfDiffCompareAsync_WhenBenchmarkComparisonFails_ReturnsOne()
+    {
+        using BenchmarkTestData.ResultDirectory baseline = new();
+        using BenchmarkTestData.ResultDirectory results = new();
+
+        int exitCode = await PerfDiff.CompareAsync(baseline.Path, results.Path, failOnRegression: false, new PerfDiffTestLogger(), CancellationToken.None);
+
+        Assert.Equal(1, exitCode);
+    }
+
+    [Fact]
+    public async Task PerfDiffCompareAsync_WhenNoRegression_ReturnsZero()
+    {
+        using BenchmarkTestData.ResultDirectory baseline = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        using BenchmarkTestData.ResultDirectory results = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+
+        int exitCode = await PerfDiff.CompareAsync(baseline.Path, results.Path, failOnRegression: true, new PerfDiffTestLogger(), CancellationToken.None);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task PerfDiffCompareAsync_WhenEtlConfirmsRegressionAndFailOnRegressionIsFalse_ReturnsZero()
+        => await AssertEtlConfirmsRegressionAsync(failOnRegression: false, expectedExitCode: 0).ConfigureAwait(true);
+
+    [Fact]
+    public async Task PerfDiffCompareAsync_WhenEtlConfirmsRegressionAndFailOnRegressionIsTrue_ReturnsOne()
+        => await AssertEtlConfirmsRegressionAsync(failOnRegression: true, expectedExitCode: 1).ConfigureAwait(true);
+
+    [Fact]
+    public async Task PerfDiffCompareAsync_WhenEtlRejectsRegression_ReturnsZero()
+    {
+        using BenchmarkTestData.ResultDirectory baseline = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        using BenchmarkTestData.ResultDirectory results = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        await File.WriteAllTextAsync(Path.Combine(baseline.Path, "trace.etl.zip"), "baseline").ConfigureAwait(true);
+        await File.WriteAllTextAsync(Path.Combine(results.Path, "trace.etl.zip"), "results").ConfigureAwait(true);
+
+        int exitCode = await PerfDiff.CompareAsync(
+            baseline.Path,
+            results.Path,
+            failOnRegression: true,
+            new PerfDiffTestLogger(),
+            CancellationToken.None,
+            static (_, _, _, _) => Task.FromResult(new BenchmarkComparisonResult(CompareSucceeded: true, RegressionDetected: true)),
+            static (_, _) => (CompareSucceeded: true, RegressionDetected: false)).ConfigureAwait(true);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task PerfDiffCompareAsync_WhenResultsEtlIsMissing_ReturnsNonFailingRegression()
+    {
+        using BenchmarkTestData.ResultDirectory baseline = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        using BenchmarkTestData.ResultDirectory results = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        await File.WriteAllTextAsync(Path.Combine(baseline.Path, "trace.etl.zip"), "baseline").ConfigureAwait(true);
+
+        int exitCode = await PerfDiff.CompareAsync(
+            baseline.Path,
+            results.Path,
+            failOnRegression: false,
+            new PerfDiffTestLogger(),
+            CancellationToken.None,
+            static (_, _, _, _) => Task.FromResult(new BenchmarkComparisonResult(CompareSucceeded: true, RegressionDetected: true)),
+            static (_, _) => (CompareSucceeded: true, RegressionDetected: true)).ConfigureAwait(true);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task PerfDiffCompareAsync_WhenBaselineEtlIsMissing_ReturnsNonFailingRegression()
+    {
+        using BenchmarkTestData.ResultDirectory baseline = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        using BenchmarkTestData.ResultDirectory results = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        await File.WriteAllTextAsync(Path.Combine(results.Path, "trace.etl.zip"), "results").ConfigureAwait(true);
+
+        int exitCode = await PerfDiff.CompareAsync(
+            baseline.Path,
+            results.Path,
+            failOnRegression: false,
+            new PerfDiffTestLogger(),
+            CancellationToken.None,
+            static (_, _, _, _) => Task.FromResult(new BenchmarkComparisonResult(CompareSucceeded: true, RegressionDetected: true)),
+            static (_, _) => (CompareSucceeded: true, RegressionDetected: true)).ConfigureAwait(true);
+
+        Assert.Equal(0, exitCode);
+    }
+
+    [Fact]
+    public async Task PerfDiffCompareAsync_WhenBdnRegressionHasNoUsableEtlAndFailOnRegressionIsFalse_ReturnsZero()
+        => await AssertBdnRegressionHasNoUsableEtlAsync(failOnRegression: false, expectedExitCode: 0).ConfigureAwait(true);
+
+    [Fact]
+    public async Task PerfDiffCompareAsync_WhenBdnRegressionHasNoUsableEtlAndFailOnRegressionIsTrue_ReturnsOne()
+        => await AssertBdnRegressionHasNoUsableEtlAsync(failOnRegression: true, expectedExitCode: 1).ConfigureAwait(true);
+
+    [Fact]
+    public void TryGetETLPaths_AcceptsSingleEtlZipFilePath()
+    {
+        string directory = Path.Combine(AppContext.BaseDirectory, "PerfDiff.TestData", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string etlPath = Path.Combine(directory, "trace.etl.zip");
+        File.WriteAllText(etlPath, "not an etl");
+        try
+        {
+            MethodInfo method = typeof(PerfDiff).GetMethod("TryGetETLPaths", BindingFlags.NonPublic | BindingFlags.Static)!;
+            object?[] arguments = [etlPath, new PerfDiffTestLogger(), null];
+
+            object? found = method.Invoke(null, arguments);
+
+            Assert.True(found is true);
+            Assert.Equal(etlPath, arguments[2]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryGetETLPaths_RejectsNonEtlZipFilePath()
+    {
+        string directory = Path.Combine(AppContext.BaseDirectory, "PerfDiff.TestData", Guid.NewGuid().ToString("N"));
+        Directory.CreateDirectory(directory);
+        string filePath = Path.Combine(directory, "trace.txt");
+        File.WriteAllText(filePath, "not an etl");
+        try
+        {
+            MethodInfo method = typeof(PerfDiff).GetMethod("TryGetETLPaths", BindingFlags.NonPublic | BindingFlags.Static)!;
+            object?[] arguments = [filePath, new PerfDiffTestLogger(), null];
+
+            object? found = method.Invoke(null, arguments);
+
+            Assert.True(found is false);
+            Assert.Null(arguments[2]);
+        }
+        finally
+        {
+            Directory.Delete(directory, recursive: true);
+        }
+    }
+
+    [Fact]
+    public void TryGetETLPaths_RejectsMissingPath()
+    {
+        string missingPath = Path.Combine(AppContext.BaseDirectory, "PerfDiff.TestData", Guid.NewGuid().ToString("N"), "trace.etl.zip");
+        MethodInfo method = typeof(PerfDiff).GetMethod("TryGetETLPaths", BindingFlags.NonPublic | BindingFlags.Static)!;
+        object?[] arguments = [missingPath, new PerfDiffTestLogger(), null];
+
+        object? found = method.Invoke(null, arguments);
+
+        Assert.True(found is false);
+        Assert.Null(arguments[2]);
+    }
+
+    [Fact]
+    public void ComputeOverweights_CoversInterestThresholdBoundaries()
+    {
+        Dictionary<string, float> baseline = new(StringComparer.Ordinal)
+        {
+            ["top"] = 100,
+            ["middle"] = 25,
+            ["leaf"] = 5,
+            ["missing"] = 50,
+        };
+        Dictionary<string, float> source = new(StringComparer.Ordinal)
+        {
+            ["top"] = 200,
+            ["middle"] = 80,
+            ["leaf"] = 40,
+        };
+
+        OverWeightResult[] results = EtlDiffer.ComputeOverweights(320, source, 180, baseline).ToArray();
+
+        Assert.Equal(3, results.Length);
+        Assert.Contains(results, result => string.Equals(result.Name, "top", StringComparison.Ordinal) && result.Interest >= 1);
+        Assert.Contains(results, result => string.Equals(result.Name, "middle", StringComparison.Ordinal) && result.Interest >= 2);
+        Assert.Contains(results, result => string.Equals(result.Name, "leaf", StringComparison.Ordinal) && result.Interest >= 3);
+        Assert.DoesNotContain(results, result => string.Equals(result.Name, "missing", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void ComputeOverweights_CoversExtremePercentAndStackPositionThresholds()
+    {
+        Dictionary<string, float> baseline = new(StringComparer.Ordinal)
+        {
+            ["root"] = 100,
+            ["deep"] = 1,
+        };
+        Dictionary<string, float> source = new(StringComparer.Ordinal)
+        {
+            ["root"] = 100.5F,
+            ["deep"] = 102,
+        };
+
+        OverWeightResult[] results = EtlDiffer.ComputeOverweights(101.4F, source, 100.5F, baseline).ToArray();
+
+        Assert.Contains(results, result => string.Equals(result.Name, "root", StringComparison.Ordinal) && result.Interest <= 1);
+        Assert.Contains(results, result => string.Equals(result.Name, "deep", StringComparison.Ordinal) && result.Interest >= 3);
+        Assert.Contains("Overweight", results[0].ToString(), StringComparison.Ordinal);
+    }
+
+    private static async Task AssertEtlConfirmsRegressionAsync(bool failOnRegression, int expectedExitCode)
+    {
+        using BenchmarkTestData.ResultDirectory baseline = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        using BenchmarkTestData.ResultDirectory results = BenchmarkTestData.CreateResultDirectory(BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+        await File.WriteAllTextAsync(Path.Combine(baseline.Path, "trace.etl.zip"), "baseline").ConfigureAwait(true);
+        await File.WriteAllTextAsync(Path.Combine(results.Path, "trace.etl.zip"), "results").ConfigureAwait(true);
+
+        int exitCode = await PerfDiff.CompareAsync(
+            baseline.Path,
+            results.Path,
+            failOnRegression,
+            new PerfDiffTestLogger(),
+            CancellationToken.None,
+            static (_, _, _, _) => Task.FromResult(new BenchmarkComparisonResult(CompareSucceeded: true, RegressionDetected: true)),
+            static (_, _) => (CompareSucceeded: true, RegressionDetected: true)).ConfigureAwait(true);
+
+        Assert.Equal(expectedExitCode, exitCode);
+    }
+
+    private static async Task AssertBdnRegressionHasNoUsableEtlAsync(bool failOnRegression, int expectedExitCode)
+    {
+        using BenchmarkTestData.ResultDirectory baseline = BenchmarkTestData.CreateResultDirectory(
+            BenchmarkTestData.CreateBenchmark(
+                "Benchmark.A",
+                meanNs: 10_000_000,
+                p95Ns: 10_000_000,
+                measurements: BenchmarkTestData.CreateMeasurements(10_000_000, 10_000_000, 10_000_000, 10_000_000, 10_000_000)));
+        using BenchmarkTestData.ResultDirectory results = BenchmarkTestData.CreateResultDirectory(
+            BenchmarkTestData.CreateBenchmark(
+                "Benchmark.A",
+                meanNs: 300_000_000,
+                p95Ns: 300_000_000,
+                measurements: BenchmarkTestData.CreateMeasurements(300_000_000, 300_000_000, 300_000_000, 300_000_000, 300_000_000)));
+        await File.WriteAllTextAsync(Path.Combine(baseline.Path, "a.etl.zip"), "not an etl").ConfigureAwait(false);
+        await File.WriteAllTextAsync(Path.Combine(baseline.Path, "b.etl.zip"), "not an etl").ConfigureAwait(false);
+        await File.WriteAllTextAsync(Path.Combine(results.Path, "a.etl.zip"), "not an etl").ConfigureAwait(false);
+        PerfDiffTestLogger logger = new();
+
+        int exitCode = await PerfDiff.CompareAsync(baseline.Path, results.Path, failOnRegression, logger, CancellationToken.None).ConfigureAwait(false);
+
+        Assert.Equal(expectedExitCode, exitCode);
+        Assert.Contains(logger.Messages, message => message.Contains("Found 2 ETL files", StringComparison.Ordinal));
+    }
+}

--- a/tests/PerfDiff.Tests/RegressionBoundaryTests.cs
+++ b/tests/PerfDiff.Tests/RegressionBoundaryTests.cs
@@ -1,0 +1,377 @@
+using PerfDiff.BDN;
+using PerfDiff.BDN.DataContracts;
+using PerfDiff.BDN.Regression;
+using Perfolizer.Mathematics.Common;
+using Xunit;
+
+namespace PerfDiff.Tests;
+
+public sealed class RegressionBoundaryTests
+{
+    [Fact]
+    public void Benchmark_GetOriginalValues_WhenMeasurementsAreNull_ReturnsEmpty()
+    {
+        Benchmark benchmark = new()
+        {
+            Measurements = null,
+        };
+
+        Assert.Empty(benchmark.GetOriginalValues());
+    }
+
+    [Fact]
+    public void TryBuildBenchmarkMap_WhenResultEntryIsNull_ReturnsFalse()
+    {
+        bool succeeded = BenchmarkDotNetDiffer.TryBuildBenchmarkMap([null], "baseline", new PerfDiffTestLogger(), out _);
+
+        Assert.False(succeeded);
+    }
+
+    [Fact]
+    public void TryBuildBenchmarkMap_WhenMeasurementsAreNull_ReturnsFalse()
+    {
+        Benchmark benchmark = BenchmarkTestData.CreateBenchmark("Benchmark.A");
+        benchmark.Measurements = null;
+
+        bool succeeded = BenchmarkDotNetDiffer.TryBuildBenchmarkMap([new BdnResult { Benchmarks = [benchmark] }], "baseline", new PerfDiffTestLogger(), out _);
+
+        Assert.False(succeeded);
+    }
+
+    [Fact]
+    public void FindRegressions_SkipsOnlyBenchmarksWithMissingStatistics()
+    {
+        BdnComparisonResult missingBaseStatistics = new(
+            "Benchmark.MissingBase",
+            new Benchmark { FullName = "Benchmark.MissingBase", Measurements = BenchmarkTestData.CreateMeasurements(100, 100) },
+            BenchmarkTestData.CreateBenchmark("Benchmark.MissingBase", measurements: BenchmarkTestData.CreateMeasurements(200, 200)));
+        BdnComparisonResult missingDiffStatistics = new(
+            "Benchmark.MissingDiff",
+            BenchmarkTestData.CreateBenchmark("Benchmark.MissingDiff", measurements: BenchmarkTestData.CreateMeasurements(100, 100)),
+            new Benchmark { FullName = "Benchmark.MissingDiff", Measurements = BenchmarkTestData.CreateMeasurements(200, 200) });
+        BdnComparisonResult valid = new(
+            "Benchmark.Valid",
+            BenchmarkTestData.CreateBenchmark("Benchmark.Valid", measurements: BenchmarkTestData.CreateMeasurements(100, 100, 100, 100, 100)),
+            BenchmarkTestData.CreateBenchmark("Benchmark.Valid", measurements: BenchmarkTestData.CreateMeasurements(300, 300, 300, 300, 300)));
+
+        RegressionResult[] regressions = BenchmarkDotNetDiffer.FindRegressions(
+            [missingBaseStatistics, missingDiffStatistics, valid],
+            Perfolizer.Metrology.Threshold.Parse("5%"));
+
+        Assert.Single(regressions);
+        Assert.Equal("Benchmark.Valid", regressions[0].Id);
+    }
+
+    [Fact]
+    public void GetP95Delta_WhenOnePercentileSetIsMissing_ReturnsNaN()
+    {
+        Benchmark baseline = BenchmarkTestData.CreateBenchmark("Benchmark.A");
+        Benchmark diff = BenchmarkTestData.CreateBenchmark("Benchmark.A");
+        diff.Statistics!.Percentiles = null;
+
+        double delta = BenchmarkDotNetDiffer.GetP95Delta(ComparisonResult.Lesser, baseline, diff);
+
+        Assert.True(double.IsNaN(delta));
+    }
+
+    [Fact]
+    public void PercentageRegressionStrategy_WhenWorseGeomeanIsUndefined_StillReportsRegression()
+    {
+        PercentageRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyWorseComparison(baseMedianNs: 0, diffMedianNs: 0);
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out RegressionDetectionResult details);
+
+        Assert.True(hasRegression);
+        Assert.Equal("Median ratio", details.MetricName);
+    }
+
+    [Fact]
+    public void PercentageRegressionStrategy_WhenWorseGeomeanIsDefined_LogsGeomean()
+    {
+        PercentageRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyWorseComparison(baseMedianNs: 100, diffMedianNs: 300);
+        PerfDiffTestLogger logger = new();
+
+        bool hasRegression = strategy.HasRegression([comparison], logger, out _);
+
+        Assert.True(hasRegression);
+        Assert.Contains(logger.Messages, message => message.Contains("worse, geomean", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MeanPercentageRegressionStrategy_WhenWorseGeomeanIsUndefined_StillReportsRegression()
+    {
+        MeanPercentageRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyWorseComparison(
+            baseMedianNs: 0,
+            diffMedianNs: 0,
+            baseMeanNs: 0,
+            diffMeanNs: 1_000_000);
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out RegressionDetectionResult details);
+
+        Assert.True(hasRegression);
+        Assert.Equal("Mean Ratio", details.MetricName);
+    }
+
+    [Fact]
+    public void MeanPercentageRegressionStrategy_WhenWorseExceedsAbsoluteThreshold_LogsGeomean()
+    {
+        MeanPercentageRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyWorseComparison(
+            baseMedianNs: 100,
+            diffMedianNs: 300,
+            baseMeanNs: 0,
+            diffMeanNs: 1_000_000);
+        PerfDiffTestLogger logger = new();
+
+        bool hasRegression = strategy.HasRegression([comparison], logger, out _);
+
+        Assert.True(hasRegression);
+        Assert.Contains(logger.Messages, message => message.Contains("worse, geomean", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void MeanPercentageRegressionStrategy_WhenBetterGeomeanIsUndefined_DoesNotReportRegression()
+    {
+        MeanPercentageRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyBetterComparison(
+            baseMedianNs: 0,
+            diffMedianNs: 0,
+            baseMeanNs: 1_000_000,
+            diffMeanNs: 0);
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out RegressionDetectionResult details);
+
+        Assert.False(hasRegression);
+        Assert.Equal("Mean Ratio", details.MetricName);
+    }
+
+    [Fact]
+    public void MeanPercentageRegressionStrategy_WhenBetterExceedsAbsoluteThreshold_LogsGeomean()
+    {
+        MeanPercentageRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyBetterComparison(
+            baseMedianNs: 300,
+            diffMedianNs: 100,
+            baseMeanNs: 1_000_000,
+            diffMeanNs: 0);
+        PerfDiffTestLogger logger = new();
+
+        bool hasRegression = strategy.HasRegression([comparison], logger, out _);
+
+        Assert.False(hasRegression);
+        Assert.Contains(logger.Messages, message => message.Contains("better, geomean", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void P95RatioRegressionStrategy_WhenWorseGeomeanIsUndefined_StillReportsRegression()
+    {
+        P95RatioRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyWorseComparison(
+            baseMedianNs: 0,
+            diffMedianNs: 0,
+            baseP95Ns: 0,
+            diffP95Ns: 1_000_000);
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out RegressionDetectionResult details);
+
+        Assert.True(hasRegression);
+        Assert.Equal("P95 ratio", details.MetricName);
+    }
+
+    [Fact]
+    public void P95RatioRegressionStrategy_WhenWorseExceedsAbsoluteThreshold_LogsGeomean()
+    {
+        P95RatioRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyWorseComparison(
+            baseMedianNs: 100,
+            diffMedianNs: 300,
+            baseP95Ns: 0,
+            diffP95Ns: 1_000_000);
+        PerfDiffTestLogger logger = new();
+
+        bool hasRegression = strategy.HasRegression([comparison], logger, out _);
+
+        Assert.True(hasRegression);
+        Assert.Contains(logger.Messages, message => message.Contains("worse, geomean", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void P95RatioRegressionStrategy_WhenBetterGeomeanIsUndefined_DoesNotReportRegression()
+    {
+        P95RatioRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyBetterComparison(
+            baseMedianNs: 0,
+            diffMedianNs: 0,
+            baseP95Ns: 1_000_000,
+            diffP95Ns: 0);
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out RegressionDetectionResult details);
+
+        Assert.False(hasRegression);
+        Assert.Equal("P95 ratio", details.MetricName);
+    }
+
+    [Fact]
+    public void P95RatioRegressionStrategy_WhenBetterExceedsAbsoluteThreshold_LogsGeomean()
+    {
+        P95RatioRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyBetterComparison(
+            baseMedianNs: 300,
+            diffMedianNs: 100,
+            baseP95Ns: 1_000_000,
+            diffP95Ns: 0);
+        PerfDiffTestLogger logger = new();
+
+        bool hasRegression = strategy.HasRegression([comparison], logger, out _);
+
+        Assert.False(hasRegression);
+        Assert.Contains(logger.Messages, message => message.Contains("better, geomean", StringComparison.Ordinal));
+    }
+
+    [Fact]
+    public void PercentileRegressionStrategy_WhenWorseGeomeanIsUndefined_StillReportsRegression()
+    {
+        PercentileRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateAbsoluteThresholdComparison(baseMedianNs: 0, diffMedianNs: 0, baseP95Ns: 100, diffP95Ns: 260_000_000);
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out RegressionDetectionResult details);
+
+        Assert.True(hasRegression);
+        Assert.Equal("P95", details.MetricName);
+    }
+
+    [Fact]
+    public void PercentageRegressionStrategy_WhenBetterGeomeanIsUndefined_DoesNotReportRegression()
+    {
+        PercentageRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateStatisticallyBetterComparison(baseMedianNs: 0, diffMedianNs: 0);
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out RegressionDetectionResult details);
+
+        Assert.False(hasRegression);
+        Assert.Equal("Median ratio", details.MetricName);
+    }
+
+    [Fact]
+    public void PercentileRegressionStrategy_WhenBetterGeomeanIsUndefined_DoesNotReportRegression()
+    {
+        PercentileRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateAbsoluteThresholdComparison(baseMedianNs: 0, diffMedianNs: 0, baseP95Ns: 260_000_000, diffP95Ns: 100);
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out RegressionDetectionResult details);
+
+        Assert.False(hasRegression);
+        Assert.Equal("P95", details.MetricName);
+    }
+
+    [Fact]
+    public void MeanWallClockRegressionStrategy_WhenMetricIsMissing_ReturnsFalse()
+    {
+        MeanWallClockRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = new(
+            "Benchmark.A",
+            new Benchmark { FullName = "Benchmark.A", Statistics = null },
+            BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out _);
+
+        Assert.False(hasRegression);
+    }
+
+    [Fact]
+    public void PercentileRegressionStrategy_WhenMetricIsMissing_ReturnsFalse()
+    {
+        PercentileRegressionStrategy strategy = new();
+        Benchmark baseline = BenchmarkTestData.CreateBenchmark("Benchmark.A");
+        baseline.Statistics!.Percentiles = null;
+        BdnComparisonResult comparison = new("Benchmark.A", baseline, BenchmarkTestData.CreateBenchmark("Benchmark.A"));
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out _);
+
+        Assert.False(hasRegression);
+    }
+
+    [Fact]
+    public void PercentileRegressionStrategy_WhenDiffMetricIsMissing_ReturnsFalse()
+    {
+        PercentileRegressionStrategy strategy = new();
+        Benchmark diff = BenchmarkTestData.CreateBenchmark("Benchmark.A");
+        diff.Statistics!.Percentiles = null;
+        BdnComparisonResult comparison = new("Benchmark.A", BenchmarkTestData.CreateBenchmark("Benchmark.A"), diff);
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out _);
+
+        Assert.False(hasRegression);
+    }
+
+    [Fact]
+    public void PercentileRegressionStrategy_WhenDiffStatisticsAreMissing_ReturnsFalse()
+    {
+        PercentileRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = new(
+            "Benchmark.A",
+            BenchmarkTestData.CreateBenchmark("Benchmark.A"),
+            new Benchmark { FullName = "Benchmark.A", Statistics = null });
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out _);
+
+        Assert.False(hasRegression);
+    }
+
+    private static BdnComparisonResult CreateStatisticallyWorseComparison(
+        double baseMedianNs,
+        double diffMedianNs,
+        double baseMeanNs = 100,
+        double diffMeanNs = 300,
+        double baseP95Ns = 100,
+        double diffP95Ns = 300)
+        => new(
+            "Benchmark.A",
+            BenchmarkTestData.CreateBenchmark(
+                "Benchmark.A",
+                medianNs: baseMedianNs,
+                meanNs: baseMeanNs,
+                p95Ns: baseP95Ns,
+                measurements: BenchmarkTestData.CreateMeasurements(100, 100, 100, 100, 100)),
+            BenchmarkTestData.CreateBenchmark(
+                "Benchmark.A",
+                medianNs: diffMedianNs,
+                meanNs: diffMeanNs,
+                p95Ns: diffP95Ns,
+                measurements: BenchmarkTestData.CreateMeasurements(300, 300, 300, 300, 300)));
+
+    private static BdnComparisonResult CreateStatisticallyBetterComparison(
+        double baseMedianNs,
+        double diffMedianNs,
+        double baseMeanNs = 300,
+        double diffMeanNs = 100,
+        double baseP95Ns = 300,
+        double diffP95Ns = 100)
+        => new(
+            "Benchmark.A",
+            BenchmarkTestData.CreateBenchmark(
+                "Benchmark.A",
+                medianNs: baseMedianNs,
+                meanNs: baseMeanNs,
+                p95Ns: baseP95Ns,
+                measurements: BenchmarkTestData.CreateMeasurements(300, 300, 300, 300, 300)),
+            BenchmarkTestData.CreateBenchmark(
+                "Benchmark.A",
+                medianNs: diffMedianNs,
+                meanNs: diffMeanNs,
+                p95Ns: diffP95Ns,
+                measurements: BenchmarkTestData.CreateMeasurements(100, 100, 100, 100, 100)));
+
+    private static BdnComparisonResult CreateAbsoluteThresholdComparison(
+        double baseMedianNs,
+        double diffMedianNs,
+        double baseP95Ns,
+        double diffP95Ns)
+        => new(
+            "Benchmark.A",
+            BenchmarkTestData.CreateBenchmark("Benchmark.A", medianNs: baseMedianNs, p95Ns: baseP95Ns),
+            BenchmarkTestData.CreateBenchmark("Benchmark.A", medianNs: diffMedianNs, p95Ns: diffP95Ns));
+}

--- a/tests/PerfDiff.Tests/TestData/BdnBaseline/sample.full-compressed.json
+++ b/tests/PerfDiff.Tests/TestData/BdnBaseline/sample.full-compressed.json
@@ -1,0 +1,39 @@
+{
+  "Title": "PerfDiff sample baseline",
+  "HostEnvironmentInfo": {
+    "BenchmarkDotNetCaption": "BenchmarkDotNet",
+    "BenchmarkDotNetVersion": "0.14.0"
+  },
+  "Benchmarks": [
+    {
+      "DisplayInfo": "SampleBenchmarks.Parse",
+      "Namespace": "PerfDiff.Samples",
+      "Type": "SampleBenchmarks",
+      "Method": "Parse",
+      "MethodTitle": "Parse",
+      "Parameters": "input=small",
+      "FullName": "PerfDiff.Samples.SampleBenchmarks.Parse(input: small)",
+      "Statistics": {
+        "Median": 10000000,
+        "Mean": 10000000,
+        "Percentiles": {
+          "P95": 12000000
+        }
+      },
+      "Memory": {
+        "Gen0Collections": 1,
+        "Gen1Collections": 0,
+        "Gen2Collections": 0,
+        "TotalOperations": 15,
+        "BytesAllocatedPerOperation": 128
+      },
+      "Measurements": [
+        { "IterationStage": "Result", "IterationIndex": 0, "Operations": 1, "Nanoseconds": 10000000 },
+        { "IterationStage": "Result", "IterationIndex": 1, "Operations": 1, "Nanoseconds": 10000000 },
+        { "IterationStage": "Result", "IterationIndex": 2, "Operations": 1, "Nanoseconds": 10000000 },
+        { "IterationStage": "Result", "IterationIndex": 3, "Operations": 1, "Nanoseconds": 10000000 },
+        { "IterationStage": "Result", "IterationIndex": 4, "Operations": 1, "Nanoseconds": 10000000 }
+      ]
+    }
+  ]
+}

--- a/tests/PerfDiff.Tests/TestData/BdnResults/sample.full-compressed.json
+++ b/tests/PerfDiff.Tests/TestData/BdnResults/sample.full-compressed.json
@@ -1,0 +1,39 @@
+{
+  "Title": "PerfDiff sample results",
+  "HostEnvironmentInfo": {
+    "BenchmarkDotNetCaption": "BenchmarkDotNet",
+    "BenchmarkDotNetVersion": "0.14.0"
+  },
+  "Benchmarks": [
+    {
+      "DisplayInfo": "SampleBenchmarks.Parse",
+      "Namespace": "PerfDiff.Samples",
+      "Type": "SampleBenchmarks",
+      "Method": "Parse",
+      "MethodTitle": "Parse",
+      "Parameters": "input=small",
+      "FullName": "PerfDiff.Samples.SampleBenchmarks.Parse(input: small)",
+      "Statistics": {
+        "Median": 10000000,
+        "Mean": 10000000,
+        "Percentiles": {
+          "P95": 12000000
+        }
+      },
+      "Memory": {
+        "Gen0Collections": 1,
+        "Gen1Collections": 0,
+        "Gen2Collections": 0,
+        "TotalOperations": 15,
+        "BytesAllocatedPerOperation": 128
+      },
+      "Measurements": [
+        { "IterationStage": "Result", "IterationIndex": 0, "Operations": 1, "Nanoseconds": 10000000 },
+        { "IterationStage": "Result", "IterationIndex": 1, "Operations": 1, "Nanoseconds": 10000000 },
+        { "IterationStage": "Result", "IterationIndex": 2, "Operations": 1, "Nanoseconds": 10000000 },
+        { "IterationStage": "Result", "IterationIndex": 3, "Operations": 1, "Nanoseconds": 10000000 },
+        { "IterationStage": "Result", "IterationIndex": 4, "Operations": 1, "Nanoseconds": 10000000 }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds comprehensive PerfDiff unit and integration coverage for the CI performance regression gate.

## Issue coverage

| Issue | Status | Evidence |
| --- | --- | --- |
| #594 | FILLED-THIS-PR | `DataContractAndFixtureTests`, `InputRobustnessTests`, and sample `TestData/*/*.full-compressed.json` cover `BenchmarkFileReader`, BDN contracts, malformed JSON, null JSON, missing fields, and fixtures. |
| #595 | SATISFIED-BY-EXISTING + FILLED-THIS-PR | Existing `BenchmarkSetComparisonTests`, `InputRobustnessTests`, and new `RegressionBoundaryTests` cover benchmark matching, duplicate names, empty sets, missing statistics, NaN ratios, and statistical comparison paths. |
| #596 | SATISFIED-BY-EXISTING + FILLED-THIS-PR | Existing `AbsoluteBudgetRegressionStrategyTests`, `RatioRegressionStrategyTests`, and new boundary tests cover mean wall-clock, mean percentage, threshold boundaries, better, worse, and no-regression paths. |
| #597 | SATISFIED-BY-EXISTING + FILLED-THIS-PR | Existing ratio tests plus new undefined-geomean and missing-percentile tests cover `PercentageRegressionStrategy`, `PercentileRegressionStrategy`, and `P95RatioRegressionStrategy`. |
| #598 | FILLED-THIS-PR | `PerfDiffIntegrationTests.BenchmarkComparisonService_WhenAnyStrategyFindsRegression_ReturnsRegression` covers service orchestration and all strategy integration. |
| #599 | FILLED-THIS-PR | `CommandLineAndLoggingTests` covers `DiffCommand`, verbosity aliases, parse validation, `Program.RunAsync`, `Program.Main`, and console logging. |
| #600 | FILLED-THIS-PR | New tests cover malformed JSON, null BDN payloads, missing paths, missing ETL, bad ETL, null measurements, missing statistics, zero operations, NaN ratios, and ETL overweight edge thresholds. |
| #601 | FILLED-THIS-PR | Adds realistic BDN fixture directories and `SampleBenchmarkDotNetFixtures_CompareEndToEnd` for full compare path coverage. |

Fixes #594
Fixes #595
Fixes #596
Fixes #597
Fixes #598
Fixes #599
Fixes #600
Fixes #601

## Coverage

Before existing tests:

```text
PerfDiff coverage: lines 567/770, 73.6%; branches 279/340, 82.1%; tests 58 passed.
```

After this PR:

```text
PerfDiff coverage: lines 771/771, 100.0%; branches 336/344, 97.7%; tests 109 passed.
Core classes at 100% line coverage. Remaining branch gaps are compiler-generated short-circuit branches on logging-only geomean statements and `Program` service-provider disposal instrumentation.
```

## Validation Log

```text
$ dotnet format
Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.
Exit code: 0

$ dotnet build
Build succeeded.
    0 Warning(s)
    0 Error(s)
Time Elapsed 00:01:00.56

$ dotnet test tests/PerfDiff.Tests/PerfDiff.Tests.csproj --settings ./artifacts/perfdiff-coverage.runsettings
Passed!  - Failed:     0, Passed:   109, Skipped:     0, Total:   109, Duration: 1 s - PerfDiff.Tests.dll (net8.0)
Coverage report: artifacts/TestResults/coverage/Cobertura.xml

$ bash .codacy/cli.sh analyze --tool lizard --format sarif --output artifacts/codacy-lizard.sarif
Exit code: 0
Changed-file lizard issues: 0
```

Codacy note: full configured Codacy analysis could not complete because `opengrep` failed with `exec format error` and `trivy` extraction failed with `EOF`. `lizard` ran clean for changed files.

## Production changes

Adds deterministic internal seams only:

- `PerfDiff.CompareAsync` accepts injectable BDN and ETL delegates for tests.
- `Program.RunAsync` accepts an injectable compare delegate for error-path tests.
- No runtime behavior changes to the default CLI path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved performance comparison flow to handle benchmark and ETL checks more flexibly.
  * Added sample benchmark baseline/results data for validation.

* **Bug Fixes**
  * Exit codes now better reflect comparison outcomes, cancellations, and regression-failure settings.
  * ETL-related comparisons are handled more safely when trace files are missing or unavailable.

* **Tests**
  * Added broad coverage for command-line parsing, logging behavior, data contracts, regression boundaries, and end-to-end comparison scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->