### PR TITLE
perf(analyzers): defer report-path allocations

### DIFF
--- a/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
+++ b/src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs
@@ -227,22 +227,34 @@ public class ConstructorArgumentsShouldMatchAnalyzer : MoqDiagnosticAnalyzerBase
     /// <summary>
     /// Checks if the provided arguments match any of the constructors of the mocked class.
     /// </summary>
-    /// <param name="constructors">The constructors.</param>
+    /// <param name="mockedClass">The mocked class.</param>
     /// <param name="arguments">The arguments.</param>
     /// <param name="context">The context.</param>
+    /// <param name="anyConstructorsFound">
+    /// <see langword="true" /> when at least one constructor was found; otherwise <see langword="false" />.
+    /// </param>
     /// <returns>
     /// <see langword="true" /> if a suitable constructor was found; otherwise <see langword="false" />.
     /// If the construction method is a parenthesized lambda expression, <see langword="null" /> is returned.
     /// </returns>
     /// <remarks>Handles <see langword="params" /> and optional parameters.</remarks>
     private static bool? AnyConstructorsFound(
-        IMethodSymbol[] constructors,
+        ITypeSymbol mockedClass,
         FilteredArgumentList arguments,
-        SyntaxNodeAnalysisContext context)
+        SyntaxNodeAnalysisContext context,
+        out bool anyConstructorsFound)
     {
-        for (int constructorIndex = 0; constructorIndex < constructors.Length; constructorIndex++)
+        anyConstructorsFound = false;
+
+        foreach (ISymbol member in mockedClass.GetMembers(WellKnownMemberNames.InstanceConstructorName))
         {
-            if (IsConstructorMatch(constructors[constructorIndex], arguments, context))
+            if (member is not IMethodSymbol constructor || !constructor.IsConstructor())
+            {
+                continue;
+            }
+
+            anyConstructorsFound = true;
+            if (IsConstructorMatch(constructor, arguments, context))
             {
                 return true;
             }
@@ -460,15 +472,6 @@ public class ConstructorArgumentsShouldMatchAnalyzer : MoqDiagnosticAnalyzerBase
         return definition.MetadataName is "Span`1" or "ReadOnlySpan`1";
     }
 
-    private static (bool IsEmpty, Location Location) ConstructorIsEmpty(
-        IMethodSymbol[] constructors,
-        ArgumentListSyntax? argumentList,
-        SyntaxNodeAnalysisContext context)
-    {
-        Location location = argumentList?.GetLocation() ?? context.Node.GetLocation();
-        return (constructors.Length == 0, location);
-    }
-
     private static void VerifyMockAttempt(
                     SyntaxNodeAnalysisContext context,
                     MoqKnownSymbols knownSymbols,
@@ -525,29 +528,13 @@ public class ConstructorArgumentsShouldMatchAnalyzer : MoqDiagnosticAnalyzerBase
         ArgumentListSyntax? argumentList,
         FilteredArgumentList arguments)
     {
-        IMethodSymbol[] constructors = mockedClass
-            .GetMembers(WellKnownMemberNames.InstanceConstructorName)
-            .OfType<IMethodSymbol>()
-            .Where(methodSymbol => methodSymbol.IsConstructor())
-            .ToArray();
-
-        string argumentsString = arguments.FormatArguments();
-
-        // Bail out early if there are no arguments on constructors or no constructors at all
-        (bool IsEmpty, Location Location) constructorIsEmpty = ConstructorIsEmpty(constructors, argumentList, context);
-        if (constructorIsEmpty.IsEmpty)
-        {
-            Diagnostic diagnostic = constructorIsEmpty.Location.CreateDiagnostic(ClassMustHaveMatchingConstructor, mockedClass.ToDisplayString(), argumentsString);
-            context.ReportDiagnostic(diagnostic);
-            return;
-        }
-
         // We have constructors, now we need to check if the arguments match any of them
         // If the value is null it means we want to ignore and not create a diagnostic
-        bool? matchingCtorFound = AnyConstructorsFound(constructors, arguments, context);
-        if (matchingCtorFound.HasValue && !matchingCtorFound.Value)
+        bool? matchingCtorFound = AnyConstructorsFound(mockedClass, arguments, context, out bool anyConstructorsFound);
+        if (!anyConstructorsFound || (matchingCtorFound.HasValue && !matchingCtorFound.Value))
         {
-            Diagnostic diagnostic = constructorIsEmpty.Location.CreateDiagnostic(ClassMustHaveMatchingConstructor, mockedClass.ToDisplayString(), argumentsString);
+            Location location = argumentList?.GetLocation() ?? context.Node.GetLocation();
+            Diagnostic diagnostic = location.CreateDiagnostic(ClassMustHaveMatchingConstructor, mockedClass.ToDisplayString(), arguments.FormatArguments());
             context.ReportDiagnostic(diagnostic);
         }
     }

--- a/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
@@ -48,31 +48,25 @@ public abstract class MockBehaviorDiagnosticAnalyzerBase : MoqDiagnosticAnalyzer
     /// Attempts to report a diagnostic for a MockBehavior parameter issue, with the mocked type name.
     /// </summary>
     /// <param name="context">The operation analysis context.</param>
-    /// <param name="method">The method to check for MockBehavior parameter.</param>
-    /// <param name="knownSymbols">The known Moq symbols.</param>
+    /// <param name="parameterMatch">The MockBehavior parameter to edit.</param>
     /// <param name="rule">The diagnostic rule to report.</param>
     /// <param name="editType">The type of edit for the code fix.</param>
-    /// <param name="mockedTypeName">The mocked type name to format into the diagnostic message.</param>
+    /// <param name="mockedTypeNameSource">The method whose type arguments name the mocked type.</param>
     /// <returns>True if a diagnostic was reported; otherwise, false.</returns>
     internal bool TryReportMockBehaviorDiagnostic(
         OperationAnalysisContext context,
-        IMethodSymbol method,
-        MoqKnownSymbols knownSymbols,
+        IParameterSymbol parameterMatch,
         DiagnosticDescriptor rule,
         DiagnosticEditProperties.EditType editType,
-        string mockedTypeName)
+        IMethodSymbol mockedTypeNameSource)
     {
-        if (!method.TryGetParameterOfType(knownSymbols.MockBehavior!, out IParameterSymbol? parameterMatch, cancellationToken: context.CancellationToken))
-        {
-            return false;
-        }
-
         ImmutableDictionary<string, string?> properties = new DiagnosticEditProperties
         {
             TypeOfEdit = editType,
             EditPosition = parameterMatch.Ordinal,
         }.ToImmutableDictionary();
 
+        string mockedTypeName = GetMockedTypeName(context.Operation, mockedTypeNameSource);
         context.ReportDiagnostic(context.Operation.CreateDiagnostic(rule, properties, mockedTypeName));
         return true;
     }
@@ -82,31 +76,47 @@ public abstract class MockBehaviorDiagnosticAnalyzerBase : MoqDiagnosticAnalyzer
     /// with the mocked type name.
     /// </summary>
     /// <param name="context">The operation analysis context.</param>
-    /// <param name="mockParameter">The MockBehavior parameter (should be null to trigger overload check).</param>
     /// <param name="target">The target method to check for overloads.</param>
     /// <param name="knownSymbols">The known Moq symbols.</param>
     /// <param name="rule">The diagnostic rule to report.</param>
-    /// <param name="mockedTypeName">The mocked type name to format into the diagnostic message.</param>
+    /// <param name="mockedTypeNameSource">The method whose type arguments name the mocked type.</param>
     /// <returns>True if a diagnostic was reported; otherwise, false.</returns>
     internal bool TryHandleMissingMockBehaviorParameter(
         OperationAnalysisContext context,
-        IParameterSymbol? mockParameter,
         IMethodSymbol target,
         MoqKnownSymbols knownSymbols,
         DiagnosticDescriptor rule,
-        string mockedTypeName)
+        IMethodSymbol mockedTypeNameSource)
     {
-        return mockParameter is null
-            && target.TryGetOverloadWithParameterOfType(knownSymbols.MockBehavior!, out IMethodSymbol? methodMatch, out _, cancellationToken: context.CancellationToken)
-            && TryReportMockBehaviorDiagnostic(context, methodMatch, knownSymbols, rule, DiagnosticEditProperties.EditType.Insert, mockedTypeName);
+        return target.TryGetOverloadWithParameterOfType(knownSymbols.MockBehavior!, out _, out IParameterSymbol? parameterMatch, cancellationToken: context.CancellationToken)
+            && TryReportMockBehaviorDiagnostic(context, parameterMatch, rule, DiagnosticEditProperties.EditType.Insert, mockedTypeNameSource);
     }
 
     private protected abstract void AnalyzeMockBehaviorArgument(
         OperationAnalysisContext context,
         IMethodSymbol target,
+        IParameterSymbol mockParameter,
         IArgumentOperation? mockArgument,
-        MoqKnownSymbols knownSymbols,
-        string mockedTypeName);
+        MoqKnownSymbols knownSymbols);
+
+    private protected bool ContainsFieldReference(IOperation operation, IFieldSymbol? field)
+    {
+        System.Diagnostics.Debug.Assert(field is not null, "MockBehavior field symbols are required once the MockBehavior type is resolved.");
+        if (operation is IFieldReferenceOperation fieldReference && fieldReference.Member.IsInstanceOf(field!))
+        {
+            return true;
+        }
+
+        foreach (IOperation child in operation.ChildOperations)
+        {
+            if (ContainsFieldReference(child, field))
+            {
+                return true;
+            }
+        }
+
+        return false;
+    }
 
     private protected override void RegisterCompilationActions(CompilationStartAnalysisContext context, MoqKnownSymbols knownSymbols)
     {
@@ -163,17 +173,16 @@ public abstract class MockBehaviorDiagnosticAnalyzerBase : MoqDiagnosticAnalyzer
         ImmutableArray<IArgumentOperation> arguments,
         MoqKnownSymbols knownSymbols)
     {
-        string mockedTypeName = GetMockedTypeName(context.Operation, target);
-
         IParameterSymbol? mockParameter = target.Parameters.DefaultIfNotSingle(parameter => parameter.Type.IsInstanceOf(knownSymbols.MockBehavior));
 
-        if (TryHandleMissingMockBehaviorParameter(context, mockParameter, target, knownSymbols, DiagnosticRule, mockedTypeName))
+        if (mockParameter is null)
         {
+            TryHandleMissingMockBehaviorParameter(context, target, knownSymbols, DiagnosticRule, target);
             return;
         }
 
         IArgumentOperation? mockArgument = arguments.DefaultIfNotSingle(argument => argument.Parameter.IsInstanceOf(mockParameter));
 
-        AnalyzeMockBehaviorArgument(context, target, mockArgument, knownSymbols, mockedTypeName);
+        AnalyzeMockBehaviorArgument(context, target, mockParameter, mockArgument, knownSymbols);
     }
 }

--- a/src/Analyzers/SetExplicitMockBehaviorAnalyzer.cs
+++ b/src/Analyzers/SetExplicitMockBehaviorAnalyzer.cs
@@ -32,9 +32,9 @@ public class SetExplicitMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBas
     private protected override void AnalyzeMockBehaviorArgument(
         OperationAnalysisContext context,
         IMethodSymbol target,
+        IParameterSymbol mockParameter,
         IArgumentOperation? mockArgument,
-        MoqKnownSymbols knownSymbols,
-        string mockedTypeName)
+        MoqKnownSymbols knownSymbols)
     {
         System.Diagnostics.Debug.Assert(knownSymbols.MockBehavior is not null, "Base registration requires the MockBehavior symbol.");
 
@@ -42,16 +42,18 @@ public class SetExplicitMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBas
         if (mockArgument?.ArgumentKind == ArgumentKind.DefaultValue
             && MockBehaviorConstantValues.ConstantValueEquals(mockArgument.Value.WalkDownConversion().ConstantValue, knownSymbols.MockBehaviorDefault))
         {
-            TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Insert, mockedTypeName);
+            TryReportMockBehaviorDiagnostic(context, mockParameter, Rule, DiagnosticEditProperties.EditType.Insert, target);
+            return;
         }
 
         // NOTE: This logic can't handle indirection (e.g. var x = MockBehavior.Default; new Mock(x);). We can't use the constant value either,
         // as Loose and Default share the same enum value: `1`. Being more accurate I believe requires data flow analysis.
         //
         // The operation specifies a MockBehavior; is it MockBehavior.Default?
-        if (mockArgument?.DescendantsAndSelf().OfType<IFieldReferenceOperation>().Any(argument => argument.Member.IsInstanceOf(knownSymbols.MockBehaviorDefault)) == true)
+        if (mockArgument is not null
+            && ContainsFieldReference(mockArgument, knownSymbols.MockBehaviorDefault))
         {
-            TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Replace, mockedTypeName);
+            TryReportMockBehaviorDiagnostic(context, mockParameter, Rule, DiagnosticEditProperties.EditType.Replace, target);
         }
     }
 }

--- a/src/Analyzers/SetStrictMockBehaviorAnalyzer.cs
+++ b/src/Analyzers/SetStrictMockBehaviorAnalyzer.cs
@@ -56,16 +56,16 @@ public class SetStrictMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBase
     private protected override void AnalyzeMockBehaviorArgument(
         OperationAnalysisContext context,
         IMethodSymbol target,
+        IParameterSymbol mockParameter,
         IArgumentOperation? mockArgument,
-        MoqKnownSymbols knownSymbols,
-        string mockedTypeName)
+        MoqKnownSymbols knownSymbols)
     {
         System.Diagnostics.Debug.Assert(knownSymbols.MockBehavior is not null, "Base registration requires the MockBehavior symbol.");
 
         // Is the behavior set via a default value?
         if (mockArgument?.ArgumentKind == ArgumentKind.DefaultValue
             && MockBehaviorConstantValues.ConstantValueEquals(mockArgument.Value.WalkDownConversion().ConstantValue, knownSymbols.MockBehaviorDefault)
-            && TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Insert, mockedTypeName))
+            && TryReportMockBehaviorDiagnostic(context, mockParameter, Rule, DiagnosticEditProperties.EditType.Insert, target))
         {
             return;
         }
@@ -73,10 +73,11 @@ public class SetStrictMockBehaviorAnalyzer : MockBehaviorDiagnosticAnalyzerBase
         // NOTE: This logic can't handle indirection (e.g. var x = MockBehavior.Default; new Mock(x);)
         //
         // The operation specifies a MockBehavior; is it MockBehavior.Strict?
-        if (!MockBehaviorConstantValues.ConstantValueEquals(mockArgument?.Value.WalkDownConversion().ConstantValue ?? default, knownSymbols.MockBehaviorStrict)
-            && mockArgument?.DescendantsAndSelf().OfType<IFieldReferenceOperation>().Any(argument => argument.Member.IsInstanceOf(knownSymbols.MockBehaviorStrict)) != true)
+        if (mockArgument is null
+            || (!MockBehaviorConstantValues.ConstantValueEquals(mockArgument.Value.WalkDownConversion().ConstantValue, knownSymbols.MockBehaviorStrict)
+                && !ContainsFieldReference(mockArgument, knownSymbols.MockBehaviorStrict)))
         {
-            TryReportMockBehaviorDiagnostic(context, target, knownSymbols, Rule, DiagnosticEditProperties.EditType.Replace, mockedTypeName);
+            TryReportMockBehaviorDiagnostic(context, mockParameter, Rule, DiagnosticEditProperties.EditType.Replace, target);
         }
     }
 }

--- a/src/Common/EventSyntaxExtensions.cs
+++ b/src/Common/EventSyntaxExtensions.cs
@@ -24,7 +24,6 @@ internal static class EventSyntaxExtensions
     /// </param>
     /// <param name="invocation">The invocation expression for error reporting.</param>
     /// <param name="rule">The diagnostic rule to report.</param>
-    /// <param name="eventName">The event name to include in diagnostic messages.</param>
     internal static void ValidateEventArgumentTypes(
         this SyntaxNodeAnalysisContext context,
         ArgumentSyntax[] eventArguments,
@@ -32,18 +31,13 @@ internal static class EventSyntaxExtensions
         bool senderCanBeOmitted,
         INamedTypeSymbol? eventArgsType,
         InvocationExpressionSyntax invocation,
-        DiagnosticDescriptor rule,
-        string? eventName = null)
+        DiagnosticDescriptor rule)
     {
+        string? eventName = null;
         int offset = 0;
 
-        // The sender may only be omitted when the EventArgs symbol is available to model Moq's
-        // sender-supplying overload. That symbol is a precondition of EventHandler-shaped detection,
-        // so this guard also keeps the offset == 1 path from dereferencing a null EventArgs type.
         if (senderCanBeOmitted && eventArgsType != null && eventArguments.Length == expectedParameterTypes.Length - 1)
         {
-            // Moq's Raise/Raises(..., EventArgs) overloads supply the mock object as the sender for
-            // EventHandler-shaped delegates. Validate the arguments against the post-sender parameters.
             System.Diagnostics.Debug.Assert(expectedParameterTypes.Length > 0, "EventHandler-shaped delegates have a sender parameter.");
             offset = 1;
         }
@@ -53,7 +47,7 @@ internal static class EventSyntaxExtensions
                 ? invocation.GetLocation()
                 : eventArguments[expectedParameterTypes.Length].GetLocation();
 
-            context.ReportDiagnostic(CreateEventDiagnostic(location, rule, eventName));
+            context.ReportDiagnostic(CreateEventDiagnostic(location, rule, GetEventNameForDiagnostic(invocation, context.SemanticModel, context.CancellationToken, ref eventName)));
             return;
         }
 
@@ -65,8 +59,6 @@ internal static class EventSyntaxExtensions
             bool hasConversion;
             if (argumentType == null)
             {
-                // A null-typed argument (e.g. a bare null literal) is treated as convertible to any
-                // reference parameter, matching the prior behavior.
                 hasConversion = true;
             }
             else if (offset == 1)
@@ -87,7 +79,7 @@ internal static class EventSyntaxExtensions
 
             if (!hasConversion)
             {
-                context.ReportDiagnostic(CreateEventDiagnostic(eventArguments[i].GetLocation(), rule, eventName));
+                context.ReportDiagnostic(CreateEventDiagnostic(eventArguments[i].GetLocation(), rule, GetEventNameForDiagnostic(invocation, context.SemanticModel, context.CancellationToken, ref eventName)));
             }
         }
     }
@@ -275,16 +267,13 @@ internal static class EventSyntaxExtensions
             return;
         }
 
-        string eventName = GetEventNameFromSelector(invocation, context.SemanticModel, context.CancellationToken);
-
         context.ValidateEventArgumentTypes(
             eventArguments,
             expectedParameterTypes,
             senderCanBeOmitted,
             knownSymbols.EventArgs,
             invocation,
-            rule,
-            eventName);
+            rule);
     }
 
     /// <summary>
@@ -326,6 +315,16 @@ internal static class EventSyntaxExtensions
         return eventName != null
             ? location.CreateDiagnostic(rule, eventName)
             : location.CreateDiagnostic(rule);
+    }
+
+    private static string? GetEventNameForDiagnostic(
+        InvocationExpressionSyntax invocation,
+        SemanticModel semanticModel,
+        CancellationToken cancellationToken,
+        ref string? eventName)
+    {
+        eventName ??= GetEventNameFromSelector(invocation, semanticModel, cancellationToken);
+        return eventName;
     }
 
     /// <summary>

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -19,6 +19,7 @@ public partial class ConstructorArgumentsShouldMatchAnalyzerTests
 
             ["""new Mock<Foo>(false, 0);"""],
             ["""new Mock<Foo>(MockBehavior.Default, true, 1);"""],
+            ["""Mock<Foo> targetTypedMock = new(false, 0);"""],
 
             ["""new Mock<Foo>(MockBehavior.Default, new List<string>());"""],
             ["""new Mock<Foo>(new List<string>());"""],
@@ -27,6 +28,7 @@ public partial class ConstructorArgumentsShouldMatchAnalyzerTests
             ["""new Mock<Foo>{|Moq1002:(1, true)|};"""],
             ["""new Mock<Foo>{|Moq1002:(MockBehavior.Default, 2, true)|};"""],
             ["""new Mock<Foo>{|Moq1002:("1", 3)|};"""],
+            ["""Mock<Foo> targetTypedMock = new{|Moq1002:("1")|};"""],
             ["""new Mock<Foo>{|Moq1002:(MockBehavior.Default, "2", 6)|};"""],
             ["""new Mock<Foo>{|Moq1002:(new int[] { 1, 2, 3 })|};"""],
             ["""new Mock<Foo>{|Moq1002:(MockBehavior.Default, 4, true)|};"""],

--- a/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorAnalyzerTests.cs
@@ -13,6 +13,7 @@ public class SetExplicitMockBehaviorAnalyzerTests
             // new Mock<T>() patterns
             ["""{|Moq1400:new Mock<ISample>()|};"""],
             ["""{|Moq1400:new Mock<ISample>(MockBehavior.Default)|};"""],
+            ["""{|Moq1400:new Mock<ISample>(MockBehavior.Default | MockBehavior.Strict)|};"""],
             ["""new Mock<ISample>(MockBehavior.Loose);"""],
             ["""new Mock<ISample>(MockBehavior.Strict);"""],
             ["""MockBehavior GetBehavior() => MockBehavior.Strict; MockBehavior behavior = GetBehavior(); new Mock<ISample>(behavior);"""],
@@ -120,5 +121,77 @@ public class SetExplicitMockBehaviorAnalyzerTests
 
         // CompilerDiagnostics.None suppresses CS1001/CS1026/CS1002/CS0117 from the incomplete code.
         await Verifier.VerifyAnalyzerAsync(source, referenceAssemblyGroup, CompilerDiagnostics.None);
+    }
+
+    [Fact]
+    public async Task ShouldReportWhenConstructorUsesDefaultMockBehaviorParameter()
+    {
+        const string source = """
+            namespace Moq
+            {
+                public enum MockBehavior
+                {
+                    Strict = 0,
+                    Loose = 1,
+                    Default = 1,
+                }
+
+                public class Mock<T>
+                {
+                    public Mock(MockBehavior behavior = MockBehavior.Default) { }
+                }
+            }
+
+            public interface ISample
+            {
+                void Method();
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    {|Moq1400:new Moq.Mock<ISample>()|};
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source, ReferenceAssemblyCatalog.Net80);
+    }
+
+    [Fact]
+    public async Task ShouldNotReportWhenConstructorHasNoMockBehaviorOverload()
+    {
+        const string source = """
+            namespace Moq
+            {
+                public enum MockBehavior
+                {
+                    Strict = 0,
+                    Loose = 1,
+                    Default = 1,
+                }
+
+                public class Mock<T>
+                {
+                    public Mock(int value) { }
+                }
+            }
+
+            public interface ISample
+            {
+                void Method();
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    new Moq.Mock<ISample>(1);
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source, ReferenceAssemblyCatalog.Net80);
     }
 }

--- a/tests/Moq.Analyzers.Test/SetStrictMockBehaviorAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetStrictMockBehaviorAnalyzerTests.cs
@@ -14,6 +14,7 @@ public class SetStrictMockBehaviorAnalyzerTests
             ["""{|Moq1410:new Mock<ISample>(MockBehavior.Default)|};"""],
             ["""{|Moq1410:new Mock<ISample>(MockBehavior.Loose)|};"""],
             ["""new Mock<ISample>(MockBehavior.Strict);"""],
+            ["""new Mock<ISample>(MockBehavior.Strict | MockBehavior.Loose);"""],
             ["""const MockBehavior behavior = MockBehavior.Strict; new Mock<ISample>(behavior);"""],
             ["""MockBehavior GetBehavior() => MockBehavior.Strict; MockBehavior behavior = GetBehavior(); {|Moq1410:new Mock<ISample>(behavior)|};"""],
 
@@ -72,5 +73,41 @@ public class SetStrictMockBehaviorAnalyzerTests
         await Verifier.VerifyAnalyzerAsync(
             DoppelgangerTestHelper.CreateTestCode(mockCode),
             ReferenceAssemblyCatalog.Net80WithNewMoq);
+    }
+
+    [Fact]
+    public async Task ShouldReportWhenConstructorUsesDefaultMockBehaviorParameter()
+    {
+        const string source = """
+            namespace Moq
+            {
+                public enum MockBehavior
+                {
+                    Strict = 0,
+                    Loose = 1,
+                    Default = 1,
+                }
+
+                public class Mock<T>
+                {
+                    public Mock(MockBehavior behavior = MockBehavior.Default) { }
+                }
+            }
+
+            public interface ISample
+            {
+                void Method();
+            }
+
+            internal class UnitTest
+            {
+                private void Test()
+                {
+                    {|Moq1410:new Moq.Mock<ISample>()|};
+                }
+            }
+            """;
+
+        await Verifier.VerifyAnalyzerAsync(source, ReferenceAssemblyCatalog.Net80);
     }
 }


### PR DESCRIPTION
Fixes #1260

## Summary
- Moq1001/Moq1002: `VerifyClassMockAttempt` now streams constructor symbols and calls `FilteredArgumentList.FormatArguments()` only when reporting Moq1002.
- Moq1202/Moq1204: Raise/Raises event-name formatting now runs only when reporting an event-argument diagnostic.
- Moq1400/Moq1410: mocked type-name formatting now runs only after the analyzer decides to report. The field-reference scan now uses direct recursive traversal instead of LINQ over descendants.

## Behavior preservation
- No diagnostic IDs, locations, spans, severities, or messages were intentionally changed.
- Existing analyzer tests for ConstructorArgumentsShouldMatch, Raise/Raises event arguments, SetExplicitMockBehavior, and SetStrictMockBehavior remain the behavior guard.
- Added seven regression cases: constructor target-typed boundaries, MockBehavior flag boundaries, optional-default MockBehavior positives, and no-overload negative coverage.

## Moq compatibility
- Affected tests run against the repository reference assembly groups for old and new Moq versions.
- Mock.Of<T>(MockBehavior) coverage remains scoped to the new Moq reference assembly group because that API was added in Moq 4.12.0.

## Coverage notes
- Production diff coverage from `artifacts/TestResults/coverage/Cobertura.xml`: PASS.
- Changed executable lines in `ConstructorArgumentsShouldMatchAnalyzer.cs`, `MockBehaviorDiagnosticAnalyzerBase.cs`, `SetExplicitMockBehaviorAnalyzer.cs`, `SetStrictMockBehaviorAnalyzer.cs`, and `EventSyntaxExtensions.cs` have no uncovered lines and no partial branch coverage.

## Validation Log

```text
$ dotnet format --verify-no-changes
DOTNET_FORMAT_EXIT=0
Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.
```

```text
$ dotnet build --configuration Release
DOTNET_BUILD_RELEASE_EXIT=0
Build succeeded.
    0 Warning(s)
    0 Error(s)
```

```text
$ dotnet test --no-build --configuration Release --settings ./build/targets/tests/test.runsettings --filter "FullyQualifiedName~ConstructorArgumentsShouldMatchAnalyzerTests|FullyQualifiedName~RaiseEventArgumentsShouldMatchEventSignatureAnalyzerTests|FullyQualifiedName~RaisesEventArgumentsShouldMatchEventSignatureAnalyzerTests|FullyQualifiedName~SetExplicitMockBehaviorAnalyzerTests|FullyQualifiedName~SetStrictMockBehaviorAnalyzerTests"
DOTNET_TEST_TARGETED_RELEASE_EXIT=0
Passed!  - Failed:     0, Passed:  1144, Skipped:     0, Total:  1144, Duration: 2 m 31 s - Moq.Analyzers.Test.dll (net8.0)
Writing report file 'artifacts/TestResults/coverage/Cobertura.xml'
```

```text
Production diff coverage against origin/main plus working tree
src/Analyzers/ConstructorArgumentsShouldMatchAnalyzer.cs: executable_added_lines=9, uncovered=[], partial_branches=[]
src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs: executable_added_lines=12, uncovered=[], partial_branches=[]
src/Analyzers/SetExplicitMockBehaviorAnalyzer.cs: executable_added_lines=5, uncovered=[], partial_branches=[]
src/Analyzers/SetStrictMockBehaviorAnalyzer.cs: executable_added_lines=5, uncovered=[], partial_branches=[]
src/Common/EventSyntaxExtensions.cs: executable_added_lines=6, uncovered=[], partial_branches=[]
PRODUCTION_DIFF_COVERAGE_STATUS=PASS
```

```text
$ which codacy-cli; which codacy; dotnet tool list --local | grep -i codacy
No Codacy CLI was available in PATH or local dotnet tools, so local Codacy analysis was not run.
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for mock constructor arguments, including clearer reporting when no suitable constructor exists.
  * Refined mock behavior diagnostics to more reliably detect and fix both `MockBehavior.Default` and `MockBehavior.Strict` usage.
  * Enhanced event argument validation so diagnostics more clearly report argument-count and type mismatches against the event signature.
* **Tests**
  * Expanded analyzer test coverage for target-typed constructors and combined mock behavior values, including new scenarios for default/strict behavior handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->