### PR TITLE
fix: harden analyzer helper edges

### DIFF
--- a/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
+++ b/src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using Microsoft.CodeAnalysis.Operations;
 
 namespace Moq.Analyzers;
@@ -88,7 +89,14 @@ public abstract class MockBehaviorDiagnosticAnalyzerBase : MoqDiagnosticAnalyzer
         DiagnosticDescriptor rule,
         IMethodSymbol mockedTypeNameSource)
     {
-        return target.TryGetOverloadWithParameterOfType(knownSymbols.MockBehavior!, out _, out IParameterSymbol? parameterMatch, cancellationToken: context.CancellationToken)
+        INamedTypeSymbol? mockBehavior = knownSymbols.MockBehavior;
+        if (mockBehavior is null)
+        {
+            Debug.Assert(false, "knownSymbols.MockBehavior must be non-null: registration is gated on it.");
+            return false;
+        }
+
+        return target.TryGetOverloadWithParameterOfType(mockBehavior, out _, out IParameterSymbol? parameterMatch, cancellationToken: context.CancellationToken)
             && TryReportMockBehaviorDiagnostic(context, parameterMatch, rule, DiagnosticEditProperties.EditType.Insert, mockedTypeNameSource);
     }
 

--- a/src/Analyzers/tools/uninstall.ps1
+++ b/src/Analyzers/tools/uninstall.ps1
@@ -1,4 +1,4 @@
-﻿param($installPath, $toolsPath, $package, $project)
+param($installPath, $toolsPath, $package, $project)
 
 if($project.Object.SupportsPackageDependencyResolution)
 {
@@ -57,7 +57,7 @@ foreach($analyzersPath in $analyzersPaths)
                 }
                 catch
                 {
-
+                    Write-Warning "Failed to remove analyzer reference '$($analyzerFilePath.FullName)': $($_.Exception.Message)"
                 }
             }
         }

--- a/src/Common/IOperationExtensions.cs
+++ b/src/Common/IOperationExtensions.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.CodeAnalysis.Operations;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace Moq.Analyzers.Common;
 
@@ -11,7 +11,7 @@ internal static class IOperationExtensions
     /// <returns>The inner non conversion operation or the starting operation if it wasn't a conversion operation.</returns>
     public static IOperation WalkDownConversion(this IOperation operation)
     {
-        while (operation is IConversionOperation conversionOperation)
+        while (operation is IConversionOperation { Operand: not null } conversionOperation)
         {
             operation = conversionOperation.Operand;
         }

--- a/src/Common/MoqVerificationHelpers.cs
+++ b/src/Common/MoqVerificationHelpers.cs
@@ -38,8 +38,7 @@ internal static class MoqVerificationHelpers
         {
             if (op is IExpressionStatementOperation exprStmt)
             {
-                IAssignmentOperation? assignOp = exprStmt.Operation as IAssignmentOperation
-                    ?? exprStmt.Operation as ISimpleAssignmentOperation;
+                IAssignmentOperation? assignOp = exprStmt.Operation as IAssignmentOperation;
 
                 if (assignOp?.Target is IPropertyReferenceOperation propRef)
                 {

--- a/tests/Moq.Analyzers.Test/Common/IOperationExtensionsTests.cs
+++ b/tests/Moq.Analyzers.Test/Common/IOperationExtensionsTests.cs
@@ -77,6 +77,16 @@ class C
     }
 
     [Fact]
+    public void WalkDownConversion_ConversionWithNullOperand_ReturnsSelf()
+    {
+        IOperation operation = System.Reflection.DispatchProxy.Create<IConversionOperation, NullOperandConversionProxy>();
+
+        IOperation result = operation.WalkDownConversion();
+
+        Assert.Same(operation, result);
+    }
+
+    [Fact]
     public void WalkDownImplicitConversion_NonConversionOperation_ReturnsSelf()
     {
         const string code = @"
@@ -679,5 +689,13 @@ class C
             .FirstOrDefault();
         Assert.NotNull(lambda);
         return lambda!;
+    }
+
+    private class NullOperandConversionProxy : System.Reflection.DispatchProxy
+    {
+        protected override object? Invoke(System.Reflection.MethodInfo? targetMethod, object?[]? args)
+        {
+            return targetMethod?.ReturnType.IsValueType == true ? Activator.CreateInstance(targetMethod.ReturnType) : null;
+        }
     }
 }

--- a/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorAnalyzerTests.cs
@@ -194,4 +194,41 @@ public class SetExplicitMockBehaviorAnalyzerTests
 
         await Verifier.VerifyAnalyzerAsync(source, ReferenceAssemblyCatalog.Net80);
     }
+
+    [Fact]
+    public void TryHandleMissingMockBehaviorParameter_MissingMockBehaviorSymbol_ReturnsFalse()
+    {
+        (SemanticModel model, _) = CompilationHelper.CreateCompilation("class C { }");
+        SetExplicitMockBehaviorAnalyzer analyzer = new SetExplicitMockBehaviorAnalyzer();
+        System.Reflection.MethodInfo? method = typeof(MockBehaviorDiagnosticAnalyzerBase).GetMethod(
+            "TryHandleMissingMockBehaviorParameter",
+            System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+        Assert.NotNull(method);
+
+        Type knownSymbolsType = method.GetParameters()[2].ParameterType;
+        object knownSymbols = knownSymbolsType
+            .GetConstructor(
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic,
+                binder: null,
+                [typeof(Compilation)],
+                modifiers: null)!
+            .Invoke([model.Compilation]);
+
+#pragma warning disable ECS0900 // Reflection boxes OperationAnalysisContext to cover the unreachable guard path.
+#if DEBUG
+        System.Reflection.TargetInvocationException exception = Assert.Throws<System.Reflection.TargetInvocationException>(
+            () => method!.Invoke(
+                analyzer,
+                [default(Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext), null, knownSymbols, null, null]));
+        Assert.Equal(
+            "Microsoft.VisualStudio.TestPlatform.TestHost.DebugAssertException",
+            exception.InnerException?.GetType().FullName);
+#else
+        object? result = method!.Invoke(
+            analyzer,
+            [default(Microsoft.CodeAnalysis.Diagnostics.OperationAnalysisContext), null, knownSymbols, null, null]);
+        Assert.False(Assert.IsType<bool>(result));
+#endif
+#pragma warning restore ECS0900
+    }
 }


### PR DESCRIPTION
Related to #1278. Deferred follow-up: #1322.

## Summary
- Shipped #1278 items (a), (c), (d), and (f).
- Deferred items (b) and (e) to #1322 because release shipping-dll coverage proved their changed lines unreachable through analyzer verifier tests.
- Re-derived locations after #1277 and #1317. Item (d) had one remaining `MockBehavior!` site after those PRs.
- Moq compatibility: N/A behavioral. No diagnostic IDs, messages, severities, or Moq API assumptions changed.

## Shipped items
- [x] (a) `WalkDownConversion` now requires `{ Operand: not null }` before unwrapping a conversion.
- [x] (c) Removed the unreachable `ISimpleAssignmentOperation` fallback after `IAssignmentOperation`.
- [x] (d) Replaced the remaining `knownSymbols.MockBehavior!` with a local nullable guard plus `Debug.Assert(false, ...)` and a `false` return.
- [x] (f) Replaced the empty PowerShell `catch` with a `Write-Warning` and preserved LF line endings.

## Deferred
- [ ] (b) Deferred to #1322. A Moq1202 verifier probe tried to force a diagnostic with a selector that did not resolve to an event symbol. The analyzer produced no diagnostic, because the event type must resolve before event arguments are compared. The defensive false branch added by the `[NotNullWhen]` refactor is not reachable through shipping analyzer paths.
- [ ] (e) Deferred to #1322. `KnownSymbols.EventHandler1` is only read by `IsEventHandlerDelegate`, and `rg -n "IsEventHandlerDelegate" src/` finds no production caller. Caching that getter changes a line that cannot be covered through shipping assemblies. This needs a cache-vs-remove decision outside this PR.

## Tests added
- `WalkDownConversion_ConversionWithNullOperand_ReturnsSelf`
- `TryHandleMissingMockBehaviorParameter_MissingMockBehaviorSymbol_ReturnsFalse`

## Release coverage evidence
Coverage run used the CI-equivalent command:

```text
dotnet test --no-build --configuration Release --settings ./build/targets/tests/test.runsettings
```

Merged report: `artifacts/TestResults/coverage/Cobertura.xml`.

Changed shipping lines from `git diff --unified=0 origin/main`:

```text
src/Common/IOperationExtensions.cs: coverable changed lines 1/1 covered; uncovered=[]; noncoverable=[1]
  line 14: hits=2
src/Common/MoqVerificationHelpers.cs: coverable changed lines 1/1 covered; uncovered=[]; noncoverable=[]
  line 41: hits=2
src/Analyzers/MockBehaviorDiagnosticAnalyzerBase.cs: coverable changed lines 4/4 covered; uncovered=[]; noncoverable=[1, 94, 95, 97, 98]
  line 92: hits=2
  line 93: hits=2
  line 96: hits=2
  line 99: hits=2
ZERO_UNCOVERED_CHANGED_LINES=True
overall line-rate=74.92% branch-rate=63.42%
```

## Validation Log

```text
$ dotnet format --verify-no-changes --verbosity minimal
Warnings were encountered while loading the workspace. Set the verbosity option to the 'diagnostic' level to log warnings.
Exit code: 0
```

```text
$ dotnet build -c Release
Build succeeded.
    0 Warning(s)
    0 Error(s)
Time Elapsed 00:02:29.01
```

```text
$ dotnet test --no-build --configuration Release --settings ./build/targets/tests/test.runsettings
PerfDiff.Tests: Passed!  - Failed: 0, Passed: 109, Skipped: 0, Total: 109, Duration: 844 ms
Moq.Analyzers.CSharp13.Test: Passed!  - Failed: 0, Passed: 5, Skipped: 0, Total: 5, Duration: 15 s
Moq.Analyzers.Test: Passed!  - Failed: 0, Passed: 4327, Skipped: 0, Total: 4327, Duration: 41 m 9 s
```

```text
$ pwsh -NoProfile -Command "\$e=\$null;[System.Management.Automation.Language.Parser]::ParseFile('src/Analyzers/tools/uninstall.ps1',[ref]\$null,[ref]\$e)>\$null;\$e"
pwsh parse exit=0

$ git ls-files --eol src/Analyzers/tools/uninstall.ps1
i/lf    w/lf    attr/text eol=lf      src/Analyzers/tools/uninstall.ps1
```

```text
$ git diff --check
diff-check exit=0
```

```text
Codacy CLI availability check:
- `dotnet tool list --local`: no Codacy tool
- `dotnet tool list -g | rg -i 'codacy'`: no Codacy tool
- `command -v codacy-cli codacy codacy-analysis-cli`: no PATH command
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved analyzer stability when required symbols are unavailable.
  * Fixed conversion handling so nested conversions no longer fail on empty operands.
  * Better uninstall feedback now shows a warning if an analyzer reference cannot be removed.

* **Tests**
  * Added coverage for conversion handling with a missing operand.
  * Added coverage for missing mock behavior symbol handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->