### PR TITLE
test: add C# 13 analyzer harness coverage

### DIFF
--- a/Moq.Analyzers.sln
+++ b/Moq.Analyzers.sln
@@ -23,6 +23,8 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "tools", "tools", "{DCB6FCB8
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "PerfDiff", "src\tools\PerfDiff\PerfDiff.csproj", "{8E60A292-C5D3-4396-8837-7555454E44D5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Moq.Analyzers.CSharp13.Test", "tests\Moq.Analyzers.CSharp13.Test\Moq.Analyzers.CSharp13.Test.csproj", "{7CED5384-26BF-4637-89B6-722489637B68}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -117,6 +119,18 @@ Global
 		{8E60A292-C5D3-4396-8837-7555454E44D5}.Release|x64.Build.0 = Release|Any CPU
 		{8E60A292-C5D3-4396-8837-7555454E44D5}.Release|x86.ActiveCfg = Release|Any CPU
 		{8E60A292-C5D3-4396-8837-7555454E44D5}.Release|x86.Build.0 = Release|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Debug|x64.Build.0 = Debug|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Debug|x86.Build.0 = Debug|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Release|x64.ActiveCfg = Release|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Release|x64.Build.0 = Release|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Release|x86.ActiveCfg = Release|Any CPU
+		{7CED5384-26BF-4637-89B6-722489637B68}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
@@ -127,6 +141,7 @@ Global
 		{B18F12DF-A7BA-47AA-A9FB-33370DD80317} = {013D4F80-9978-45DA-9BB8-6638239355E4}
 		{DCB6FCB8-FF92-AC57-0842-1F72A354D6B1} = {827E0CD3-B72D-47B6-A68D-7590B98EB39B}
 		{8E60A292-C5D3-4396-8837-7555454E44D5} = {DCB6FCB8-FF92-AC57-0842-1F72A354D6B1}
+		{7CED5384-26BF-4637-89B6-722489637B68} = {013D4F80-9978-45DA-9BB8-6638239355E4}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8C917BC1-C0DE-4A46-BEE8-32FD66B447B1}

--- a/tests/Moq.Analyzers.CSharp13.Test/ConstructorArgumentsShouldMatchAnalyzerCSharp13Tests.cs
+++ b/tests/Moq.Analyzers.CSharp13.Test/ConstructorArgumentsShouldMatchAnalyzerCSharp13Tests.cs
@@ -1,0 +1,59 @@
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CSharp.Testing;
+using Microsoft.CodeAnalysis.Testing;
+using Moq.Analyzers;
+using Moq.Analyzers.Test.Helpers;
+
+namespace Moq.Analyzers.CSharp13.Test;
+
+public class ConstructorArgumentsShouldMatchAnalyzerCSharp13Tests
+{
+    public static IEnumerable<object[]> ParamsCollectionTestData()
+    {
+        return new object[][]
+        {
+            ["""new Mock<ClassWithParamsCollection>();"""],
+            ["""new Mock<ClassWithParamsCollection>(1, 2, 3);"""],
+            ["""new Mock<ClassWithParamsCollection>(MockBehavior.Default, 1, 2, 3);"""],
+            ["""new Mock<ClassWithParamsCollection>(new List<int> { 1, 2, 3 });"""],
+            ["""new Mock<ClassWithParamsCollection>{|Moq1002:("not an int")|};"""],
+        };
+    }
+
+    [Theory]
+    [MemberData(nameof(ParamsCollectionTestData))]
+    public async Task ShouldAnalyzeCSharp13ParamsCollectionConstructors(string mock)
+    {
+        await VerifyAnalyzerAsync(
+            $$"""
+              using System;
+              using System.Collections.Generic;
+              using Moq;
+
+              internal class ClassWithParamsCollection
+              {
+                  public ClassWithParamsCollection(params List<int> nums) { }
+              }
+
+              internal class UnitTest
+              {
+                  private void Test()
+                  {
+                      {{mock}}
+                  }
+              }
+              """);
+    }
+
+    private static async Task VerifyAnalyzerAsync(string source)
+    {
+        CSharpCodeFixTest<ConstructorArgumentsShouldMatchAnalyzer, EmptyCodeFixProvider, DefaultVerifier> test = new()
+        {
+            TestCode = source,
+            FixedCode = source,
+            ReferenceAssemblies = ReferenceAssemblyCatalog.Catalog[ReferenceAssemblyCatalog.Net90WithNewMoq],
+        };
+
+        await test.RunAsync().ConfigureAwait(false);
+    }
+}

--- a/tests/Moq.Analyzers.CSharp13.Test/Moq.Analyzers.CSharp13.Test.csproj
+++ b/tests/Moq.Analyzers.CSharp13.Test/Moq.Analyzers.CSharp13.Test.csproj
@@ -1,0 +1,32 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- C# 13 params collections require Roslyn 4.13+. Keep the project on net8.0 while using a newer test compiler. -->
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" VersionOverride="4.13.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" VersionOverride="4.13.0" />
+    <PackageReference Update="Polyfill" ExcludeAssets="compile" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="$(RepoRoot)/src/Analyzers/Moq.Analyzers.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Compile Include="$(RepoRoot)/tests/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalog.cs" Link="Helpers/ReferenceAssemblyCatalog.cs" />
+  </ItemGroup>
+
+  <Target Name="RemovePolyfillSourcesFromCSharp13Tests" BeforeTargets="CoreCompile">
+    <ItemGroup>
+      <!-- Moq.Analyzers already exposes Polyfill through the project reference. Compiling it again causes duplicate BCL shim types. -->
+      <Compile Remove="$(NuGetPackageRoot)polyfill/**/*.cs" />
+    </ItemGroup>
+  </Target>
+
+</Project>

--- a/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
+++ b/tests/Moq.Analyzers.Test/ConstructorArgumentsShouldMatchAnalyzerTests.cs
@@ -17,6 +17,10 @@ public partial class ConstructorArgumentsShouldMatchAnalyzerTests
             ["""new Mock<ClassWithParams>(MockBehavior.Default, "42", DateTime.Now, DateTime.Now);"""],
             ["""new Mock<ClassWithParams>("42", DateTime.Now, DateTime.Now);"""],
 
+            // Params-array tail with a non-convertible argument must still be flagged.
+            ["""new Mock<ClassWithParams>{|Moq1002:(DateTime.Now, 42)|};"""],
+            ["""new Mock<ClassWithParams>{|Moq1002:(MockBehavior.Default, DateTime.Now, 42)|};"""],
+
             ["""new Mock<Foo>(false, 0);"""],
             ["""new Mock<Foo>(MockBehavior.Default, true, 1);"""],
             ["""Mock<Foo> targetTypedMock = new(false, 0);"""],

--- a/tests/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalog.cs
+++ b/tests/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalog.cs
@@ -31,6 +31,12 @@ public static class ReferenceAssemblyCatalog
     public static string Net80WithNewMoq => nameof(Net80WithNewMoq);
 
     /// <summary>
+    /// Gets the name of the reference assembly group for .NET 9.0 with Moq (4.18.4).
+    /// Use this when a test snippet needs a C# 13 language feature, such as params collections.
+    /// </summary>
+    public static string Net90WithNewMoq => nameof(Net90WithNewMoq);
+
+    /// <summary>
     /// Gets the name of the reference assembly group for .NET 8.0 with Moq (4.18.4) and Microsoft.Extensions.Logging.Abstractions.
     /// </summary>
     public static string Net80WithNewMoqAndLogging => nameof(Net80WithNewMoqAndLogging);
@@ -40,7 +46,7 @@ public static class ReferenceAssemblyCatalog
     /// </summary>
     /// <remarks>
     /// The key is the name of the reference assembly group (<see cref="Net80"/>, <see cref="Net80WithOldMoq"/>,
-    /// <see cref="Net80WithNewMoq"/>, and <see cref="Net80WithNewMoqAndLogging"/>).
+    /// <see cref="Net80WithNewMoq"/>, <see cref="Net90WithNewMoq"/>, and <see cref="Net80WithNewMoqAndLogging"/>).
     /// </remarks>
     public static IReadOnlyDictionary<string, ReferenceAssemblies> Catalog { get; } = new Dictionary<string, ReferenceAssemblies>(StringComparer.Ordinal)
     {
@@ -54,6 +60,9 @@ public static class ReferenceAssemblyCatalog
         // This must be 4.12.0 or later in order to have the new `Mock.Of<T>(MockBehavior)` method (see https://github.com/devlooped/moq/commit/1561c006c87a0894c5257a1e541da44e40e33dd3).
         // 4.18.4 is currently the most downloaded version of Moq.
         { nameof(Net80WithNewMoq), ReferenceAssemblies.Net.Net80.AddPackages([new PackageIdentity("Moq", "4.18.4")]) },
+
+        // .NET 9.0 reference assemblies select a C# 13-capable test compiler surface while the test project remains net8.0.
+        { nameof(Net90WithNewMoq), ReferenceAssemblies.Net.Net90.AddPackages([new PackageIdentity("Moq", "4.18.4")]) },
 
         // Moq 4.18.4 with Microsoft.Extensions.Logging.Abstractions for ILogger-related analyzer tests.
         {

--- a/tests/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalogTests.cs
+++ b/tests/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalogTests.cs
@@ -1,0 +1,31 @@
+using Microsoft.CodeAnalysis.Testing;
+
+namespace Moq.Analyzers.Test.Helpers;
+
+public class ReferenceAssemblyCatalogTests
+{
+    [Fact]
+    public async Task Net90WithNewMoq_CompilesMoqSnippet()
+    {
+        ReferenceAssemblies referenceAssemblies = ReferenceAssemblyCatalog.Catalog[ReferenceAssemblyCatalog.Net90WithNewMoq];
+        ImmutableArray<MetadataReference> references = await referenceAssemblies.ResolveAsync(LanguageNames.CSharp, CancellationToken.None);
+        MetadataReference[] metadataReferences = [.. references];
+        SyntaxTree tree = CSharpSyntaxTree.ParseText(
+            """
+            using Moq;
+
+            internal class UnitTest
+            {
+                private readonly Mock<object> mock = new();
+            }
+            """);
+        CSharpCompilation compilation = CSharpCompilation.Create(
+            "Net90WithNewMoqSmokeTest",
+            [tree],
+            metadataReferences,
+            new CSharpCompilationOptions(OutputKind.DynamicallyLinkedLibrary));
+
+        Diagnostic[] errors = [.. compilation.GetDiagnostics().Where(diagnostic => diagnostic.Severity == DiagnosticSeverity.Error)];
+        Assert.Empty(errors);
+    }
+}


### PR DESCRIPTION
Fixes #1287

## Summary
- Add `ReferenceAssemblyCatalog.Net90WithNewMoq` for Moq 4.18.4 on .NET 9 reference assemblies.
- Add an isolated `Moq.Analyzers.CSharp13.Test` project that stays on `net8.0` but overrides Roslyn packages to 4.13.0.
- Backfill the #1241 regression test for `ConstructorArgumentsShouldMatchAnalyzer` with `public ClassWithParamsCollection(params List<int> nums)`.

## Approach
I verified `ReferenceAssemblies.Net.Net90` exists in the pinned analyzer testing package. Empirically, net9 reference assemblies alone did not compile `params List<int>` in the main test project because Roslyn 4.8 emitted CS0225, `The params parameter must be a single dimensional array`.

I kept the existing `Moq.Analyzers.Test` project on `net8.0` and Roslyn 4.8. The new C# 13-only test project also targets `net8.0`, but uses Roslyn 4.13.0 and the shared `Net90WithNewMoq` catalog entry. This is the least invasive path that compiles the C# 13 repro without changing the main test harness.

## Backfilled #1241 test
`ConstructorArgumentsShouldMatchAnalyzerCSharp13Tests` covers:
- no diagnostic for `new Mock<ClassWithParamsCollection>()`
- no diagnostic for expanded `int` params
- no diagnostic for `MockBehavior.Default` plus expanded `int` params
- no diagnostic for collection-form `new List<int> { 1, 2, 3 }`
- `Moq1002` for `"not an int"`

## Moq compatibility
The new reference assembly group uses Moq 4.18.4, matching `Net80WithNewMoq`. Existing Moq 4.8.2 coverage remains unchanged.

## Validation Log
- `dotnet format --verify-no-changes --verbosity minimal`: exit 0. Workspace load warning only.
- `dotnet build -c Release --nologo`: succeeded, 0 warnings, 0 errors.
- `dotnet test tests/Moq.Analyzers.CSharp13.Test/Moq.Analyzers.CSharp13.Test.csproj -c Release --no-build --nologo`: Passed 5, Failed 0, Skipped 0.
- `dotnet test tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj -c Release --no-build --nologo --filter "FullyQualifiedName~ConstructorArgumentsShouldMatchAnalyzerTests|FullyQualifiedName~ReferenceAssemblyCatalogTests"`: Passed 525, Failed 0, Skipped 0.
- `dotnet test tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj -c Release --no-build --nologo`: Passed 4325, Failed 0, Skipped 0, Duration 29m49s.
- `dotnet test tests/Moq.Analyzers.Test/Moq.Analyzers.Test.csproj -c Release --no-build --settings ./build/targets/tests/test.runsettings --nologo`: Passed 4325, Failed 0, Skipped 0, Duration 25m46s.
- Coverage: overall line 74.7% (2779/3719), branch 62.9% (1542/2450). `Moq.Analyzers` line 90.9%, branch 79.8%. `ConstructorArgumentsShouldMatchAnalyzer` line 87.1%, branch 73.4%.
- Codacy CLI: `lizard` completed with exit 0. SARIF contained 42 repo-wide existing results and 0 results in changed files.
- Codacy CLI blocked tools: `semgrep` is not supported by this Codacy CLI, `opengrep` failed with `exec format error` after reinstall, and `trivy@0.59.1` failed because the configured GitHub release URL returned 404.