### PR TITLE
docs(instructions): mandate pattern-guarded symbol casts + forward-language regression tests

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -98,6 +98,10 @@ If you encounter a diagnostic span test failure, or are unsure about any Roslyn 
 - Example: `Setup()` → `ISetup<T>` → `.Raises()` → `IRaise<T>` → `.Returns()` → `IReturns<T>`
 - **Register ALL interfaces in the chain**, not just endpoint types
 
+### Symbol-Cast Crash Safety (MANDATORY)
+
+Never cast an `ITypeSymbol`/`ISymbol` to a derived interface (`IArrayTypeSymbol`, `INamedTypeSymbol`, ...) with a direct `(T)` cast. Use a pattern test with a graceful early-return, or the analyzer throws `InvalidCastException` → Roslyn `AD0001` → the analyzer is disabled for the session. Example of the exact defect (#1241): `(IArrayTypeSymbol)paramsParameter.Type` throws on C# 13 `params List<int>` because `Type` is an `INamedTypeSymbol`; `IsParams` does not imply array. Fix pattern: `if (x.Type is not IArrayTypeSymbol arr) { return; }`. Any crash-path fix tied to a new C# feature must ship a regression test at the triggering language version (use the isolated `Moq.Analyzers.CSharp13.Test` project when the default harness pins an older version). See `.github/instructions/csharp.instructions.md` and issue #1321.
+
 ### Diagnostic Investigation Pattern
 
 When tests fail after removing string-based detection:

--- a/.github/instructions/csharp.instructions.md
+++ b/.github/instructions/csharp.instructions.md
@@ -124,6 +124,27 @@ If tests fail after adding/modifying symbol-based detection:
 - **Method Chain Returns**: Different interfaces at each chain position
 - **Missing Symbol Registration**: String fallback masks missing symbols
 
+## Crash Safety: Symbol Casts and Forward Language Versions (MANDATORY)
+
+An analyzer that throws is worse than a missing diagnostic: Roslyn reports `AD0001` and **disables the analyzer for the rest of the session**. New C# language features are the most common trigger, because the test harness compiles at the language version its pinned reference-assembly group allows, so future constructs execute against code no test ever exercised.
+
+### Never cast a symbol type without a pattern guard
+
+Casts from `ITypeSymbol`/`ISymbol` to a derived interface (`IArrayTypeSymbol`, `INamedTypeSymbol`, `IPointerTypeSymbol`, ...) **MUST** use a pattern test with a graceful early-return, never a direct `(T)` cast or `as` + unchecked dereference.
+
+- ❌ `var element = ((IArrayTypeSymbol)paramsParameter.Type).ElementType;`
+- ✅ `if (paramsParameter.Type is not IArrayTypeSymbol arrayType) { return; }` then use `arrayType.ElementType`.
+
+**Concrete failure this rule prevents (#1241):** `ConstructorArgumentsShouldMatchAnalyzer` cast `(IArrayTypeSymbol)paramsParameter.Type`. On a host compiling **C# 13 params collections** (`params List<int>`, `params ReadOnlySpan<int>`), `Type` is an `INamedTypeSymbol`, the cast throws `InvalidCastException`, and the analyzer dies with `AD0001`. `IsParams` does **not** imply array. The same shape recurs for any assumption that a symbol subtype is fixed.
+
+Program defensively: when a code path assumes an invariant about a symbol's shape, guard it (pattern test + early-return, or `Debug.Assert` for truly-impossible states).
+
+### Ship a regression test at the language version that triggers the crash
+
+Any crash-path fix tied to a specific language feature **MUST** include a regression test compiled at the C# version that reproduces it. If the default harness pins an older language version (e.g. the `net8.0` group pins C# 12, so `params List<int>` fails `CS0225`), use the isolated newest-language test project (`Moq.Analyzers.CSharp13.Test`, Roslyn 4.13 — kept separate so shipping analyzers keep their netstandard2.0 + Roslyn 4.8 API ceiling). A fix without a test at the triggering language version does not close the defect.
+
+For the broader structural guardrails (a first-class "latest language version" test leg, an automated unguarded-cast guard, a scheduled newest-SDK CI probe), see issue [#1321](https://github.com/rjmurillo/moq.analyzers/issues/1321).
+
 ## Test Data & Sample Inputs/Outputs
 
 ### What Constitutes Good Test Data?


### PR DESCRIPTION
## Summary

Implements acceptance criterion 2 of #1321: encode in contributor/AI instructions the two rules that would have prevented the #1241 crash class.

## Problem

Analyzers repeatedly break on new C# language features and ship untested (the harness pins an older language version). #1241: an unguarded `(IArrayTypeSymbol)paramsParameter.Type` cast threw `InvalidCastException` on C# 13 `params List<int>`, causing `AD0001` and disabling the analyzer. Nothing in the guidance required (a) pattern-guarding symbol-type casts or (b) a regression test at the triggering language version.

## Solution

Add a **Symbol-Cast Crash Safety (MANDATORY)** rule to:
- `.github/copilot-instructions.md` (broadly loaded, concise) — near the existing Symbol-Based Detection section.
- `.github/instructions/csharp.instructions.md` (C#-scoped, full rule with the concrete #1241 before/after example).

The rules:
1. Never cast `ITypeSymbol`/`ISymbol` to a derived interface (`IArrayTypeSymbol`, `INamedTypeSymbol`, ...) with a direct `(T)` cast; use `is` pattern test + graceful early-return. `IsParams` does not imply array.
2. Any crash-path fix tied to a new C# feature must ship a regression test at the language version that triggers it (use the isolated `Moq.Analyzers.CSharp13.Test` project when the default harness pins older).

## Scope

Docs/instructions only. The larger structural guardrails in #1321 (a first-class "latest language version" test leg, an automated unguarded-cast guard, a scheduled newest-SDK CI probe) require design/scoping and remain tracked in #1321, so this PR **addresses** but does not close it.

## Validation

- `markdownlint-cli2` on both files: 0 errors.
- Ground-truthed against `src/`: the current `ConstructorArgumentsShouldMatchAnalyzer.GetParamsElementType` already uses `is IArrayTypeSymbol arrayType` + early-return, and no unguarded symbol-derived casts remain in `src/`. The rule codifies the existing-correct pattern.

## Moq compatibility

N/A (documentation only).

Addresses #1321.