### PR TITLE
docs: add CRAP metric explainer

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -320,7 +320,10 @@ ci(workflow): add performance testing to nightly builds
 - **Code Coverage:**  
   Code coverage is generated automatically if you use the `test.runsettings` from above, which produces Cobertura format. If you wish to have a different format, you can specify on the command line. Example:
   `dotnet test --collect:"XPlat Code Coverage" --settings ./build/targets/tests/test.runsettings`  
-  PRs must not reduce coverage for critical paths without justification.
+  PRs must not reduce coverage for critical paths without justification. The
+  generated HTML report also ranks risk hotspots by the CRAP metric; see
+  [`docs/crap-metric.md`](docs/crap-metric.md) for what it means and how to
+  lower it.
 - **Codacy Analysis:**
   Run Codacy CLI analysis on all changed files. Fix all reported issues before submitting the PR.
 - **Evidence Required:**

--- a/docs/crap-metric.md
+++ b/docs/crap-metric.md
@@ -1,0 +1,77 @@
+# The CRAP Metric
+
+CRAP stands for **Change Risk Anti-Patterns**. It is a single number that
+combines how complex a method is with how well it is tested. A high CRAP score
+marks code that is risky to change: complex enough to hide bugs, and not
+covered enough for tests to catch them.
+
+## How it is calculated
+
+For a method `m`:
+
+```text
+CRAP(m) = comp(m)^2 * (1 - cov(m))^3 + comp(m)
+```
+
+- `comp(m)` is the cyclomatic complexity (the number of independent paths
+  through the method).
+- `cov(m)` is the code coverage of the method, from `0` (untested) to `1`
+  (fully covered).
+
+The formula rewards two things: lower complexity and higher coverage. Full
+coverage (`cov = 1`) collapses the score to just `comp(m)`, so a well-tested
+method can never be a hotspot no matter how complex. An untested method
+(`cov = 0`) pays the full `comp^2 + comp` penalty.
+
+Worked examples:
+
+| Complexity | Coverage | CRAP score |
+| ---------- | -------- | ---------- |
+| 5          | 100%     | 5          |
+| 5          | 0%       | 30         |
+| 10         | 80%      | 10.8       |
+| 10         | 0%       | 110        |
+
+A common threshold is **30**: at or above it, a method is a risk hotspot.
+
+## Where it shows up in this repository
+
+Coverage reports are generated automatically by
+[ReportGenerator](https://github.com/danielpalme/ReportGenerator) when you run
+the test suite (see `build/targets/tests/Tests.targets`). The `HtmlInline`
+report includes a **Risk Hotspots** section, and CRAP is one of the metrics it
+ranks methods by.
+
+Generate the report locally:
+
+```shell
+dotnet test --settings ./build/targets/tests/test.runsettings
+```
+
+Then open the HTML report under `artifacts/TestResults/` and look at the Risk
+Hotspots table.
+
+## Why it matters
+
+- **Maintainability.** High-CRAP methods are hard to understand and modify, so
+  every change costs more and carries more risk.
+- **Reliability.** Complex, poorly tested code is where regressions hide.
+- **Onboarding.** New contributors slow down when they hit tangled, untested
+  methods.
+- **Technical debt.** Lowering CRAP is a direct, measurable investment in code
+  quality.
+
+## How to reduce it
+
+Because the score depends on both complexity and coverage, you have two levers:
+
+1. **Add tests.** Cover the method with positive, negative, and boundary cases.
+   Moving from `0%` to full coverage drops the score to the raw complexity
+   value. This is usually the fastest win.
+2. **Reduce complexity.** Extract intention-revealing helper methods, replace
+   nested conditionals with early returns, and split a method that does several
+   things into focused methods. Lower `comp(m)` shrinks the whole score.
+
+Prefer doing both: cover the method first so a refactor is safe, then simplify
+it. This matches the repository's bar of 100% block coverage with explicit
+positive, negative, and boundary tests for all modified code.


### PR DESCRIPTION
## Summary

Adds `docs/crap-metric.md`, the explainer requested in #627.

## Problem

#627 asked for a maintainer-facing explainer of the CRAP (Change Risk Anti-Patterns) metric: what it is and why to reduce it. The maintainer sequenced it after #927's coverage assessment, which is now **closed**.

## Solution

`docs/crap-metric.md` covers:
- **Definition + formula**: `CRAP(m) = comp(m)^2 * (1 - cov(m))^3 + comp(m)`, with a worked-example table and the common threshold of 30.
- **Where it surfaces here**: ReportGenerator's `HtmlInline` Risk Hotspots report, generated by `build/targets/tests/Tests.targets` on every test run.
- **Why it matters**: maintainability, reliability, onboarding, technical debt.
- **How to reduce it**: the two levers (add positive/negative/boundary tests, reduce cyclomatic complexity), and why to do both.

Linked from the CONTRIBUTING.md code-coverage section so contributors find it where they read the report.

## Validation

- `markdownlint-cli2 docs/crap-metric.md CONTRIBUTING.md`: 0 errors.
- Verified CRAP is real in this repo: `build/targets/tests/Tests.targets` line 34 emits `HtmlInline`, whose Risk Hotspots section ranks by CRAP.

## Moq compatibility

N/A (documentation only).

Closes #627.