### PR TITLE
fix(perf): P95 gate requires mean corroboration (#1328)

### DIFF
--- a/src/tools/PerfDiff/BDN/Regression/P95RatioRegressionStrategy.cs
+++ b/src/tools/PerfDiff/BDN/Regression/P95RatioRegressionStrategy.cs
@@ -20,8 +20,16 @@ public sealed class P95RatioRegressionStrategy : IBenchmarkRegressionStrategy
                 "P95 ratio",
                 GetP95Ratio,
                 result => BenchmarkDotNetDiffer.GetP95Delta(result.Conclusion, result.BaseResult, result.DiffResult),
-                stabilityDeltaSelector: result => BenchmarkDotNetDiffer.GetMeanDelta(result.Conclusion, result.BaseResult, result.DiffResult)),
+                stabilityDeltaSelector: GetStabilityDelta),
             out details);
+
+    private static double GetStabilityDelta(RegressionResult result)
+    {
+        double p95Delta = BenchmarkDotNetDiffer.GetP95Delta(result.Conclusion, result.BaseResult, result.DiffResult);
+        return double.IsNaN(p95Delta)
+            ? double.NaN
+            : BenchmarkDotNetDiffer.GetMeanDelta(result.Conclusion, result.BaseResult, result.DiffResult);
+    }
 
     private static double GetP95Ratio(RegressionResult result)
     {

--- a/src/tools/PerfDiff/BDN/Regression/P95RatioRegressionStrategy.cs
+++ b/src/tools/PerfDiff/BDN/Regression/P95RatioRegressionStrategy.cs
@@ -6,7 +6,8 @@ using Perfolizer.Mathematics.Common;
 namespace PerfDiff.BDN.Regression;
 
 /// <summary>
-/// Detects P95-ratio regressions only when the stable worse-set aggregate exceeds the 5% gate.
+/// Detects P95-ratio regressions only when the mean-corroborated stable worse-set aggregate exceeds the 5% gate.
+/// Tail-only jitter cannot trigger this gate because each P95 change must also have a mean change outside the mean noise band.
 /// </summary>
 public sealed class P95RatioRegressionStrategy : IBenchmarkRegressionStrategy
 {
@@ -18,7 +19,8 @@ public sealed class P95RatioRegressionStrategy : IBenchmarkRegressionStrategy
             new RegressionRatioMetricConfig(
                 "P95 ratio",
                 GetP95Ratio,
-                result => BenchmarkDotNetDiffer.GetP95Delta(result.Conclusion, result.BaseResult, result.DiffResult)),
+                result => BenchmarkDotNetDiffer.GetP95Delta(result.Conclusion, result.BaseResult, result.DiffResult),
+                stabilityDeltaSelector: result => BenchmarkDotNetDiffer.GetMeanDelta(result.Conclusion, result.BaseResult, result.DiffResult)),
             out details);
 
     private static double GetP95Ratio(RegressionResult result)

--- a/src/tools/PerfDiff/BDN/Regression/RegressionRatioMetricConfig.cs
+++ b/src/tools/PerfDiff/BDN/Regression/RegressionRatioMetricConfig.cs
@@ -1,3 +1,4 @@
+using System.Diagnostics;
 using PerfDiff.BDN.DataContracts;
 
 namespace PerfDiff.BDN.Regression;
@@ -7,7 +8,8 @@ internal sealed class RegressionRatioMetricConfig(
     Func<RegressionResult, double> ratioSelector,
     Func<RegressionResult, double> deltaSelector,
     string thresholdText = RegressionStrategyHelper.AggregateRatioRegressionThresholdText,
-    double aggregateThreshold = RegressionStrategyHelper.AggregateRatioRegressionThreshold)
+    double aggregateThreshold = RegressionStrategyHelper.AggregateRatioRegressionThreshold,
+    Func<RegressionResult, double>? stabilityDeltaSelector = null)
 {
     internal string MetricName { get; } = metricName;
 
@@ -15,7 +17,17 @@ internal sealed class RegressionRatioMetricConfig(
 
     internal Func<RegressionResult, double> DeltaSelector { get; } = deltaSelector;
 
+    internal Func<RegressionResult, double> StabilityDeltaSelector { get; } = GetStabilityDeltaSelector(deltaSelector, stabilityDeltaSelector);
+
     internal string ThresholdText { get; } = thresholdText;
 
     internal double AggregateThreshold { get; } = aggregateThreshold;
+
+    private static Func<RegressionResult, double> GetStabilityDeltaSelector(
+        Func<RegressionResult, double> deltaSelector,
+        Func<RegressionResult, double>? stabilityDeltaSelector)
+    {
+        Debug.Assert(deltaSelector != null, "A delta selector is required.");
+        return stabilityDeltaSelector ?? deltaSelector;
+    }
 }

--- a/src/tools/PerfDiff/BDN/Regression/RegressionStrategyHelper.cs
+++ b/src/tools/PerfDiff/BDN/Regression/RegressionStrategyHelper.cs
@@ -102,10 +102,10 @@ public static class RegressionStrategyHelper
         Threshold relativeThreshold = Threshold.Parse(config.ThresholdText);
         RegressionResult[] notSame = BenchmarkDotNetDiffer.FindRegressions(comparison, relativeThreshold);
 
-        List<RegressionResult> better = GetStableResults(notSame, ComparisonResult.Greater, config.DeltaSelector);
+        List<RegressionResult> better = GetStableResults(notSame, ComparisonResult.Greater, config.StabilityDeltaSelector);
         LogRatioResults(better, logger, config, "less");
 
-        List<RegressionResult> worse = GetStableResults(notSame, ComparisonResult.Lesser, config.DeltaSelector);
+        List<RegressionResult> worse = GetStableResults(notSame, ComparisonResult.Lesser, config.StabilityDeltaSelector);
         LogRatioResults(worse, logger, config, "more");
 
         bool aggregateRegression = IsAggregateRatioRegression(worse, config.RatioSelector, config.AggregateThreshold, out _);

--- a/tests/PerfDiff.Tests/RatioRegressionStrategyTests.cs
+++ b/tests/PerfDiff.Tests/RatioRegressionStrategyTests.cs
@@ -81,6 +81,130 @@ public sealed class RatioRegressionStrategyTests
     }
 
     [Fact]
+    public void P95RatioRegressionStrategy_WhenP95RegressesButMeanDeltaIsBelowNoiseBand_ReturnsFalse()
+    {
+        P95RatioRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateComparison(
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(0.5),
+                meanNs: Milliseconds(0.50),
+                p95Ns: Milliseconds(0.50)),
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(0.7),
+                meanNs: Milliseconds(0.55),
+                p95Ns: Milliseconds(1.10)));
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out _);
+
+        Assert.True(BenchmarkDotNetDiffer.GetP95Delta(ComparisonResult.Lesser, comparison.BaseResult, comparison.DiffResult) > RegressionStrategyHelper.AbsoluteNoiseFloorNs);
+        Assert.False(RegressionStrategyHelper.ExceedsRatioNoiseFloor(
+            new RegressionResult("Benchmark.A", comparison.BaseResult, comparison.DiffResult, ComparisonResult.Lesser),
+            result => BenchmarkDotNetDiffer.GetMeanDelta(result.Conclusion, result.BaseResult, result.DiffResult)));
+        Assert.False(hasRegression);
+    }
+
+    [Fact]
+    public void P95RatioRegressionStrategy_WhenP95AndMeanRegressBeyondNoiseBand_ReturnsTrue()
+    {
+        P95RatioRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateComparison(
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(5),
+                meanNs: Milliseconds(5),
+                p95Ns: Milliseconds(5),
+                standardDeviationNs: Milliseconds(0.05)),
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(6),
+                meanNs: Milliseconds(6),
+                p95Ns: Milliseconds(6),
+                standardDeviationNs: Milliseconds(0.05)));
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out _);
+
+        Assert.True(hasRegression);
+    }
+
+    [Fact]
+    public void P95RatioRegressionStrategy_WhenMeanDeltaEqualsNoiseBand_ReturnsFalse()
+    {
+        P95RatioRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateComparison(
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(10),
+                meanNs: Milliseconds(10),
+                p95Ns: Milliseconds(10),
+                standardDeviationNs: Milliseconds(1)),
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(12),
+                meanNs: Milliseconds(12),
+                p95Ns: Milliseconds(12)));
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out _);
+
+        Assert.False(hasRegression);
+    }
+
+    [Fact]
+    public void P95RatioRegressionStrategy_WhenP95AggregateGeomeanEqualsThreshold_ReturnsFalse()
+    {
+        P95RatioRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateComparison(
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(10),
+                meanNs: Milliseconds(10),
+                p95Ns: Milliseconds(10)),
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(11),
+                meanNs: Milliseconds(11),
+                p95Ns: Milliseconds(10.5)));
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out _);
+
+        Assert.False(hasRegression);
+    }
+
+    [Fact]
+    public void MeanPercentageRegressionStrategy_WithP95CorroborationFixtures_KeepsMeanBehavior()
+    {
+        MeanPercentageRegressionStrategy strategy = new();
+        BdnComparisonResult meanRegression = CreateComparison(
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(5),
+                meanNs: Milliseconds(5),
+                p95Ns: Milliseconds(5),
+                standardDeviationNs: Milliseconds(0.05)),
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(6),
+                meanNs: Milliseconds(6),
+                p95Ns: Milliseconds(6),
+                standardDeviationNs: Milliseconds(0.05)));
+        BdnComparisonResult meanNoise = CreateComparison(
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(0.5),
+                meanNs: Milliseconds(0.50),
+                p95Ns: Milliseconds(0.50)),
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(0.7),
+                meanNs: Milliseconds(0.55),
+                p95Ns: Milliseconds(1.10)));
+
+        bool regressionDetected = strategy.HasRegression([meanRegression], new PerfDiffTestLogger(), out _);
+        bool noiseDetected = strategy.HasRegression([meanNoise], new PerfDiffTestLogger(), out _);
+
+        Assert.True(regressionDetected);
+        Assert.False(noiseDetected);
+    }
+
+    [Fact]
+    public void RegressionRatioMetricConfig_WhenStabilityDeltaSelectorIsOmitted_UsesDeltaSelector()
+    {
+        Func<RegressionResult, double> deltaSelector = _ => 42D;
+        RegressionRatioMetricConfig config = new("Test ratio", _ => 1D, deltaSelector);
+
+        Assert.Same(deltaSelector, config.StabilityDeltaSelector);
+    }
+
+    [Fact]
     public void MeanPercentageRegressionStrategy_WithInfiniteMedianRatio_ReturnsFalse()
     {
         MeanPercentageRegressionStrategy strategy = new();
@@ -259,6 +383,28 @@ public sealed class RatioRegressionStrategyTests
             meanNs: meanNs,
             p95Ns: p95Ns,
             measurements: BenchmarkTestData.CreateMeasurements(meanNs, meanNs, meanNs, meanNs, meanNs));
+
+    private static Benchmark BenchmarkWithMeasuredStatistics(
+        double measurementNs,
+        double meanNs,
+        double p95Ns,
+        double standardDeviationNs = 0)
+        => new()
+        {
+            FullName = "Benchmark.A",
+            Statistics = new Statistics
+            {
+                N = 5,
+                Median = measurementNs,
+                Mean = meanNs,
+                StandardDeviation = standardDeviationNs,
+                Percentiles = new Percentiles
+                {
+                    P95 = p95Ns,
+                },
+            },
+            Measurements = BenchmarkTestData.CreateMeasurements(measurementNs, measurementNs, measurementNs, measurementNs, measurementNs),
+        };
 
     private static double Milliseconds(double value) => value * TimeUnitConstants.NanoSecondsToMilliseconds;
 }

--- a/tests/PerfDiff.Tests/RatioRegressionStrategyTests.cs
+++ b/tests/PerfDiff.Tests/RatioRegressionStrategyTests.cs
@@ -125,6 +125,28 @@ public sealed class RatioRegressionStrategyTests
     }
 
     [Fact]
+    public void P95RatioRegressionStrategy_WhenPercentilesMissingButMeanDeltaExceedsFloor_ReturnsFalseWithoutThrowing()
+    {
+        P95RatioRegressionStrategy strategy = new();
+        BdnComparisonResult comparison = CreateComparison(
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(5),
+                meanNs: Milliseconds(5),
+                p95Ns: Milliseconds(5)),
+            BenchmarkWithMeasuredStatistics(
+                measurementNs: Milliseconds(6),
+                meanNs: Milliseconds(6),
+                p95Ns: Milliseconds(6),
+                hasPercentiles: false));
+
+        bool hasRegression = strategy.HasRegression([comparison], new PerfDiffTestLogger(), out _);
+
+        Assert.True(BenchmarkDotNetDiffer.GetMeanDelta(ComparisonResult.Lesser, comparison.BaseResult, comparison.DiffResult) > RegressionStrategyHelper.AbsoluteNoiseFloorNs);
+        Assert.True(double.IsNaN(BenchmarkDotNetDiffer.GetP95Delta(ComparisonResult.Lesser, comparison.BaseResult, comparison.DiffResult)));
+        Assert.False(hasRegression);
+    }
+
+    [Fact]
     public void P95RatioRegressionStrategy_WhenMeanDeltaEqualsNoiseBand_ReturnsFalse()
     {
         P95RatioRegressionStrategy strategy = new();
@@ -388,7 +410,8 @@ public sealed class RatioRegressionStrategyTests
         double measurementNs,
         double meanNs,
         double p95Ns,
-        double standardDeviationNs = 0)
+        double standardDeviationNs = 0,
+        bool hasPercentiles = true)
         => new()
         {
             FullName = "Benchmark.A",
@@ -398,10 +421,12 @@ public sealed class RatioRegressionStrategyTests
                 Median = measurementNs,
                 Mean = meanNs,
                 StandardDeviation = standardDeviationNs,
-                Percentiles = new Percentiles
-                {
-                    P95 = p95Ns,
-                },
+                Percentiles = hasPercentiles
+                    ? new Percentiles
+                    {
+                        P95 = p95Ns,
+                    }
+                    : null,
             },
             Measurements = BenchmarkTestData.CreateMeasurements(measurementNs, measurementNs, measurementNs, measurementNs, measurementNs),
         };


### PR DESCRIPTION
## Summary

Closes #1328.

Implemented Option 1 of the three documented options: mean corroboration at benchmark grain. The owner can redirect to option 2, P95-native dispersion, or option 3, wider P95 tolerance, if preferred.

P95 ratio reporting still uses the P95 ratio and P95 delta. Only the stability gate now uses the mean delta after confirming P95 is available. This prevents tail-only jitter from entering the P95 worse-set when the mean stays inside the mean noise band, while keeping missing percentiles out of the P95 ratio path.

## Tradeoff

Option 1 will not gate a pure-tail regression where the mean is unchanged. That is acceptable here because these sub-ms benchmarks run on unstabilizable priority and "Permission denied" runners, where pure-tail signal is dominated by noise.

## Validation Log

- `dotnet build src/tools/PerfDiff/PerfDiff.csproj -c Release --no-incremental /p:PedanticMode=true --nologo`
  - Build succeeded, 0 warnings, 0 errors.
- `dotnet test tests/PerfDiff.Tests/PerfDiff.Tests.csproj -c Release --logger "console;verbosity=minimal"`
  - Passed, 145 total, 0 failed, 0 skipped.
- New tests:
  - `P95RatioRegressionStrategy_WhenP95RegressesButMeanDeltaIsBelowNoiseBand_ReturnsFalse`
  - `P95RatioRegressionStrategy_WhenP95AndMeanRegressBeyondNoiseBand_ReturnsTrue`
  - `P95RatioRegressionStrategy_WhenPercentilesMissingButMeanDeltaExceedsFloor_ReturnsFalseWithoutThrowing`
  - `P95RatioRegressionStrategy_WhenMeanDeltaEqualsNoiseBand_ReturnsFalse`
  - `P95RatioRegressionStrategy_WhenP95AggregateGeomeanEqualsThreshold_ReturnsFalse`
  - `MeanPercentageRegressionStrategy_WithP95CorroborationFixtures_KeepsMeanBehavior`
  - `RegressionRatioMetricConfig_WhenStabilityDeltaSelectorIsOmitted_UsesDeltaSelector`
- Guard verification:
  - Temporarily reverted `stabilityDeltaSelector: GetStabilityDelta` to the mean-only lambda.
  - `P95RatioRegressionStrategy_WhenPercentilesMissingButMeanDeltaExceedsFloor_ReturnsFalseWithoutThrowing` failed with `NullReferenceException` in `GetP95Ratio`, proving the regression test catches the crash.
- Coverage command: `dotnet test tests/PerfDiff.Tests/PerfDiff.Tests.csproj -c Release --collect:"Code Coverage;Format=Cobertura" --logger "console;verbosity=minimal"`
  - Passed, 145 total, 0 failed, 0 skipped.
  - `P95RatioRegressionStrategy.cs`: 100.00% line, 100.00% branch.
  - `RegressionRatioMetricConfig.cs`: 100.00% line, 100.00% branch.
  - `RegressionStrategyHelper.cs`: 100.00% line, 100.00% branch.
- `dotnet format --verify-no-changes --verbosity minimal`
  - Exit code 0, no formatting changes.
- `git diff --check`
  - Exit code 0.
- Codacy local CLI:
  - `codacy-lizard-crashfix.log`: 0 warnings, no thresholds exceeded.
  - `semgrep`: local Codacy CLI reports `tool 'semgrep' is not supported`.
  - `trivy`: local Codacy CLI failed tool install with `failed to extract archive: EOF`; no dependency files changed.

## Moq compatibility

No analyzer rule or Moq API behavior changed. This change is isolated to PerfDiff regression gating.
