### PR TITLE
refactor(common): remove dead IsEventHandlerDelegate/EventHandler1 path (#1322)

### DIFF
--- a/src/Common/NamedTypeSymbolExtensions.cs
+++ b/src/Common/NamedTypeSymbolExtensions.cs
@@ -6,25 +6,6 @@ namespace Moq.Analyzers.Common;
 internal static class NamedTypeSymbolExtensions
 {
     /// <summary>
-    /// Determines if the given <paramref name="namedType"/> represents the generic <see cref="System.EventHandler{TEventArgs}"/> type.
-    /// </summary>
-    /// <param name="namedType">The symbol to check.</param>
-    /// <param name="knownSymbols">A <see cref="KnownSymbols"/> instance providing access to well-known Roslyn symbols.</param>
-    /// <returns>
-    /// <see langword="true"/> if <paramref name="namedType"/> is constructed from <see cref="System.EventHandler{TEventArgs}"/> and has exactly one type argument; otherwise, <see langword="false"/>.
-    /// </returns>
-    /// <remarks>
-    /// This method uses <see cref="SymbolEqualityComparer.Default"/> to compare the constructed generic type definition
-    /// of <paramref name="namedType"/> with the canonical <see cref="System.EventHandler{TEventArgs}"/> symbol.
-    /// </remarks>
-    internal static bool IsEventHandlerDelegate(this INamedTypeSymbol namedType, KnownSymbols knownSymbols)
-    {
-        return knownSymbols.EventHandler1 is not null
-            && SymbolEqualityComparer.Default.Equals(namedType.ConstructedFrom, knownSymbols.EventHandler1)
-            && namedType.TypeArguments.Length == 1;
-    }
-
-    /// <summary>
     /// Determines if the given <paramref name="namedType"/> represents <see cref="System.Action"/> or <see cref="System.Action{T}"/>.
     /// </summary>
     /// <param name="namedType">The symbol to check.</param>

--- a/src/Common/WellKnown/KnownSymbols.cs
+++ b/src/Common/WellKnown/KnownSymbols.cs
@@ -43,11 +43,6 @@ internal class KnownSymbols
     internal INamedTypeSymbol? ValueTask => TypeProvider.GetOrCreateTypeByMetadataName("System.Threading.Tasks.ValueTask");
 
     /// <summary>
-    /// Gets the class <see cref="System.EventHandler{TEventArgs}"/>.
-    /// </summary>
-    internal INamedTypeSymbol? EventHandler1 => TypeProvider.GetOrCreateTypeByMetadataName("System.EventHandler`1");
-
-    /// <summary>
     /// Gets the delegate <see cref="System.EventHandler"/> (the non-generic form).
     /// </summary>
     internal INamedTypeSymbol? EventHandler => TypeProvider.GetOrCreateTypeByMetadataName("System.EventHandler");

--- a/tests/Moq.Analyzers.Test/Common/MoqKnownSymbolsTests.Caching.cs
+++ b/tests/Moq.Analyzers.Test/Common/MoqKnownSymbolsTests.Caching.cs
@@ -118,15 +118,6 @@ public partial class MoqKnownSymbolsTests
     }
 
     [Fact]
-    public void EventHandler1_WithCoreReferences_ReturnsNamedTypeSymbol()
-    {
-        MoqKnownSymbols symbols = CreateSymbolsWithoutMoq();
-        Assert.NotNull(symbols.EventHandler1);
-        Assert.Equal("EventHandler", symbols.EventHandler1!.Name);
-        Assert.Equal(1, symbols.EventHandler1.Arity);
-    }
-
-    [Fact]
     public void Action0_WithCoreReferences_ReturnsNamedTypeSymbol()
     {
         MoqKnownSymbols symbols = CreateSymbolsWithoutMoq();

--- a/tests/Moq.Analyzers.Test/Common/NamedTypeSymbolExtensionsTests.cs
+++ b/tests/Moq.Analyzers.Test/Common/NamedTypeSymbolExtensionsTests.cs
@@ -5,39 +5,6 @@ namespace Moq.Analyzers.Test.Common;
 public class NamedTypeSymbolExtensionsTests
 {
     [Fact]
-    public void IsEventHandlerDelegate_GenericEventHandler_ReturnsTrue()
-    {
-        (INamedTypeSymbol typeSymbol, KnownSymbols knownSymbols) =
-            GetFieldTypeAndKnownSymbols("using System; class C { EventHandler<EventArgs> handler; }");
-
-        bool result = typeSymbol.IsEventHandlerDelegate(knownSymbols);
-
-        Assert.True(result);
-    }
-
-    [Fact]
-    public void IsEventHandlerDelegate_ActionType_ReturnsFalse()
-    {
-        (INamedTypeSymbol typeSymbol, KnownSymbols knownSymbols) =
-            GetFieldTypeAndKnownSymbols("using System; class C { Action<string> handler; }");
-
-        bool result = typeSymbol.IsEventHandlerDelegate(knownSymbols);
-
-        Assert.False(result);
-    }
-
-    [Fact]
-    public void IsEventHandlerDelegate_FuncType_ReturnsFalse()
-    {
-        (INamedTypeSymbol typeSymbol, KnownSymbols knownSymbols) =
-            GetFieldTypeAndKnownSymbols("using System; class C { Func<string> handler; }");
-
-        bool result = typeSymbol.IsEventHandlerDelegate(knownSymbols);
-
-        Assert.False(result);
-    }
-
-    [Fact]
     public void IsActionDelegate_NonGenericAction_ReturnsTrue()
     {
         (INamedTypeSymbol typeSymbol, KnownSymbols knownSymbols) =


### PR DESCRIPTION
Closes #1322.

Resolves both deferred #1278 coverage-bound hardening nits tracked in #1322.

## Item (e): dead `IsEventHandlerDelegate` / `EventHandler1` path — removed

Ground-truthed the issue's own analysis:
- `KnownSymbols.EventHandler1` was read only by `IsEventHandlerDelegate`.
- `IsEventHandlerDelegate` had **no production callers** (`grep -rn IsEventHandlerDelegate src/` returned only its definition).
- Its job is covered by `IsEventHandlerShaped` (`src/Common/EventSyntaxExtensions.cs`), which reads `EventHandler` and `EventArgs`, not `EventHandler1`.

Removed (YAGNI, deletion-only):
- `IsEventHandlerDelegate` (`src/Common/NamedTypeSymbolExtensions.cs`)
- `EventHandler1` property (`src/Common/WellKnown/KnownSymbols.cs`)
- 4 dead unit tests: 3 `IsEventHandlerDelegate_*` + 1 `EventHandler1_WithCoreReferences_ReturnsNamedTypeSymbol` caching test.

`IsActionDelegate` is a live production path (`EventSyntaxExtensions.cs:127`) and its 4 tests are kept.

## Item (b): event-name `[NotNullWhen]` refactor — resolved by keeping current shape

The unreachable defensive branch described in #1322 does **not** exist in current code. `TryGetEventNameFromLambdaSelector` (`src/Common/SemanticModelExtensions.cs:253`) delegates to the shared generic `TryGetEventPropertyFromLambdaSelector`, which has a single clean `return false`. The deferred `[NotNullWhen]` refactor was never adopted, so there is no uncoverable shipping line. Keeping the current API shape is the correct resolution; no code change needed.

## Validation Log

- `dotnet build Moq.Analyzers.sln -c Release --no-incremental /p:PedanticMode=true` → **Build succeeded, 0 warnings**.
- `dotnet test tests/Moq.Analyzers.Test --settings ./build/targets/tests/test.runsettings` → **Passed! Failed: 0, Passed: 4323, Skipped: 0**.
- `dotnet format` (Husky pre-commit) → clean, no changes.
- Coverage: diff is deletion-only (66 deletions, 0 additions) → diff coverage 100% (no new lines). Shipping `NamedTypeSymbolExtensions.cs` line-rate = 1.0. Change **removes** a previously-uncovered shipping line (`EventHandler1`), improving the shipping-diff-coverage posture that #1322 flagged.
- Moq version compatibility: N/A — no Moq API surface used or changed.

- [x] No errors or warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling around delegate-type detection for a simpler, more consistent experience.
  * Adjusted symbol lookup behavior to rely on the standard event delegate shape.

* **Tests**
  * Removed outdated test coverage tied to the retired delegate detection behavior.
  * Updated caching tests to match the current symbol set.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->