### PR TITLE
refactor(common): remove dead TryGetParameterOfType helper

### DIFF
--- a/src/Common/IMethodSymbolExtensions.cs
+++ b/src/Common/IMethodSymbolExtensions.cs
@@ -77,23 +77,4 @@ internal static class IMethodSymbolExtensions
     {
         return method.TryGetOverloadWithParameterOfType(method.Overloads(), type, out methodMatch, out parameterMatch, comparer, cancellationToken);
     }
-
-    public static bool TryGetParameterOfType(this IMethodSymbol method, INamedTypeSymbol type, [NotNullWhen(true)] out IParameterSymbol? match, SymbolEqualityComparer? comparer = null, CancellationToken cancellationToken = default)
-    {
-        comparer ??= SymbolEqualityComparer.Default;
-
-        foreach (IParameterSymbol parameter in method.Parameters)
-        {
-            cancellationToken.ThrowIfCancellationRequested();
-
-            if (comparer.Equals(parameter.Type, type))
-            {
-                match = parameter;
-                return true;
-            }
-        }
-
-        match = null;
-        return false;
-    }
 }

--- a/tests/Moq.Analyzers.Test/Common/IMethodSymbolExtensionsTests.cs
+++ b/tests/Moq.Analyzers.Test/Common/IMethodSymbolExtensionsTests.cs
@@ -193,65 +193,6 @@ class C
         Assert.True(SymbolEqualityComparer.Default.Equals(parameterMatch!.Type, stringType));
     }
 
-    [Fact]
-    public void TryGetParameterOfType_MethodHasParameterOfType_ReturnsTrueWithMatch()
-    {
-        const string code = @"
-class C
-{
-    void M(int x, string y) { }
-}";
-        (SemanticModel model, IMethodSymbol method, _) =
-            GetMethodContextWithAllOverloads(code, "M", 0);
-        INamedTypeSymbol stringType = model.Compilation.GetSpecialType(SpecialType.System_String);
-
-        bool found = method.TryGetParameterOfType(stringType, out IParameterSymbol? match);
-
-        Assert.True(found);
-        Assert.NotNull(match);
-        Assert.Equal("y", match!.Name);
-        Assert.True(SymbolEqualityComparer.Default.Equals(match.Type, stringType));
-    }
-
-    [Fact]
-    public void TryGetParameterOfType_MethodHasNoParameterOfType_ReturnsFalse()
-    {
-        const string code = @"
-class C
-{
-    void M(int x) { }
-}";
-        (SemanticModel model, IMethodSymbol method, _) =
-            GetMethodContextWithAllOverloads(code, "M", 0);
-        INamedTypeSymbol doubleType = model.Compilation.GetSpecialType(SpecialType.System_Double);
-
-        bool found = method.TryGetParameterOfType(doubleType, out IParameterSymbol? match);
-
-        Assert.False(found);
-        Assert.Null(match);
-    }
-
-    [Fact]
-    public void TryGetParameterOfType_CancellationRequested_ThrowsOperationCanceledException()
-    {
-        const string code = @"
-class C
-{
-    void M(int x, string y) { }
-}";
-        (SemanticModel model, IMethodSymbol method, _) =
-            GetMethodContextWithAllOverloads(code, "M", 0);
-        INamedTypeSymbol stringType = model.Compilation.GetSpecialType(SpecialType.System_String);
-
-        using CancellationTokenSource cts = new();
-        cts.Cancel();
-
-        Assert.Throws<OperationCanceledException>(() =>
-        {
-            method.TryGetParameterOfType(stringType, out _, cancellationToken: cts.Token);
-        });
-    }
-
     private static (IMethodSymbol TargetMethod, IReadOnlyList<IMethodSymbol> AllOverloads) GetMethodAndOverloads(
         string code,
         string methodName,


### PR DESCRIPTION
## Summary

Removes `IMethodSymbolExtensions.TryGetParameterOfType`, a dead internal helper with **no production caller** (only 3 direct unit tests referenced it), plus those 3 tests.

## Why

A coverage/quality evaluation of the shipping DLLs (91% line / 80% branch) found `IMethodSymbolExtensions` at 72.4%. The uncovered lines (`IMethodSymbolExtensions.cs:83-97`) were *exactly* the body of `TryGetParameterOfType`.

The method is unreachable from production:

- Grep across `src/` (excluding worktrees) shows the only references are the definition and the test file.
- `src/Common` compiles into **both** `Moq.Analyzers.dll` and `Moq.CodeFixes.dll`. Direct unit tests hit the test-assembly copy, so they earn **0% coverage in the shipping DLL**. The 3 tests validated behavior of code no shipping path ever invokes.

This is a YAGNI/dead-code defect, not a test gap. The correct fix is deletion, not a manufactured analyzer test to cover unused code.

## Effect

- `IMethodSymbolExtensions` shipping coverage: 72.4% -> 100% (the 8 uncovered lines are removed, not gamed).
- Removes an untested, unused surface; improves non-redundancy and cohesion.
- Retains the used overloads (`Overloads`, `TryGetOverloadWithParameterOfType`) and their 9 tests (still green).

## Validation Log

- `dotnet build tests/Moq.Analyzers.Test` (Release): **Build succeeded, 0 Warning(s), 0 Error(s)**.
- `dotnet test --filter IMethodSymbolExtensionsTests`: **Passed 9 / Failed 0** (was 12; 3 dead-method tests removed).
- `dotnet format --verify-no-changes` on both changed files: **exit 0**.

Moq version compatibility: N/A (internal analyzer helper; no Moq API surface touched).

## Related Files

- `src/Common/IMethodSymbolExtensions.cs`
- `tests/Moq.Analyzers.Test/Common/IMethodSymbolExtensionsTests.cs`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method parameter lookup to search across overloads, making matches more reliable when multiple versions of a method exist.
  * Removed a narrower parameter-checking path in favor of the new overload-aware behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->