### PR TITLE
test(codefixes): cover SyntaxGeneratorExtensions guards and defensive fixer branches

### DIFF
--- a/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
+++ b/tests/Moq.Analyzers.Test/SetExplicitMockBehaviorFixerTests.cs
@@ -255,6 +255,47 @@ public class SetExplicitMockBehaviorFixerTests
         await AssertFirstFixAsync(model, tree, creation.Span, source, expected, "Replace", "0");
     }
 
+    [Fact]
+    public async Task MissingEditProperties_DoesNotThrow_AndRegistersNoActions()
+    {
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(Source);
+        SyntaxNode root = await tree.GetRootAsync();
+
+        ObjectCreationExpressionSyntax creation = root
+            .DescendantNodes()
+            .OfType<ObjectCreationExpressionSyntax>()
+            .Single();
+
+        // A diagnostic without the recorded edit properties must be ignored: the fixer cannot know
+        // what edit to apply, so it must no-op rather than throw or register an action.
+        DiagnosticDescriptor descriptor = new(
+            DiagnosticIds.SetExplicitMockBehavior,
+            "Test",
+            "Test message",
+            "Test",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        Diagnostic diagnostic = Diagnostic.Create(descriptor, Location.Create(tree, creation.Span));
+
+        using AdhocWorkspace workspace = new();
+        Project project = workspace.AddProject("TestProject", LanguageNames.CSharp)
+            .AddMetadataReferences(model.Compilation.References);
+        Document document = project.AddDocument("Test.cs", SourceText.From(Source));
+
+        List<CodeAction> actions = [];
+        CodeFixContext context = new(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        Moq.CodeFixes.SetExplicitMockBehaviorFixer fixer = new();
+        await fixer.RegisterCodeFixesAsync(context);
+
+        Assert.Empty(actions);
+    }
+
     private static async Task AssertFixerNoOpAsync(SemanticModel model, SyntaxTree tree, TextSpan span, string sourceText, string editType, string editPosition)
     {
         await AssertFixerAsync(

--- a/tests/Moq.Analyzers.Test/SyntaxGeneratorExtensionsTests.cs
+++ b/tests/Moq.Analyzers.Test/SyntaxGeneratorExtensionsTests.cs
@@ -1,0 +1,262 @@
+using System.Reflection;
+using Microsoft.CodeAnalysis.Editing;
+
+namespace Moq.Analyzers.Test;
+
+/// <summary>
+/// Direct unit tests for the internal <c>Moq.CodeFixes.SyntaxGeneratorExtensions</c> argument
+/// validation guards. The throw paths are not exercised by the higher-level code-fix verifier
+/// tests because the real fixers never violate the contracts, so they are validated here with
+/// positive, negative, and boundary cases for every guard in <c>InsertArguments</c> and
+/// <c>ReplaceArgument</c>.
+/// </summary>
+/// <remarks>
+/// The helper is internal to the shipping <c>Moq.CodeFixes</c> assembly. This project reaches it
+/// via reflection rather than <c>InternalsVisibleTo</c>: that assembly targets netstandard2.0 and
+/// embeds Polyfill-generated BCL attribute types, which collide (CS0433) with the net8.0 framework
+/// types once the internals are made visible. Reflection is the same access strategy used by
+/// <c>VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests.InvokeCanMakeMemberVirtual</c>.
+/// </remarks>
+public class SyntaxGeneratorExtensionsTests
+{
+    private static readonly Type ExtensionsType = typeof(Moq.CodeFixes.VerifyOverridableMembersFixer)
+        .Assembly
+        .GetType("Moq.CodeFixes.SyntaxGeneratorExtensions", throwOnError: true)!;
+
+#pragma warning disable ECS0600 // The literals name methods in another assembly resolved via reflection, not local symbols.
+    private static readonly MethodInfo InsertArgumentsMethod =
+        ExtensionsType.GetMethod("InsertArguments", BindingFlags.Public | BindingFlags.Static)!;
+
+    private static readonly MethodInfo ReplaceArgumentMethod =
+        ExtensionsType.GetMethod("ReplaceArgument", BindingFlags.Public | BindingFlags.Static)!;
+#pragma warning restore ECS0600
+
+    [Fact]
+    public void InsertArguments_IntoInvocation_InsertsArgument()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M(1, 2)");
+
+        SyntaxNode result = InsertArguments(generator, invocation, 1, Argument("3"));
+
+        Assert.Equal(3, ArgumentCount(result));
+        Assert.Equal(["1", "3", "2"], ArgumentExpressions(result));
+    }
+
+    [Fact]
+    public void InsertArguments_IntoObjectCreation_InsertsArgument()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        BaseObjectCreationExpressionSyntax creation = ParseCreation("new C(1, 2)");
+
+        SyntaxNode result = InsertArguments(generator, creation, 0, Argument("3"));
+
+        Assert.Equal(3, ArgumentCount(result));
+        Assert.Equal(["3", "1", "2"], ArgumentExpressions(result));
+    }
+
+    [Fact]
+    public void InsertArguments_IntoObjectCreationWithoutArgumentList_InsertsArgument()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        BaseObjectCreationExpressionSyntax creation = ParseCreation("new C { }");
+        Assert.Null(creation.ArgumentList);
+
+        SyntaxNode result = InsertArguments(generator, creation, 0, Argument("3"));
+
+        Assert.Equal(1, ArgumentCount(result));
+    }
+
+    [Fact]
+    public void InsertArguments_IndexEqualsCount_AppendsArgument()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M(1, 2)");
+
+        SyntaxNode result = InsertArguments(generator, invocation, 2, Argument("3"));
+
+        Assert.Equal(3, ArgumentCount(result));
+        Assert.Equal(["1", "2", "3"], ArgumentExpressions(result));
+    }
+
+    [Fact]
+    public void InsertArguments_ItemNotArgumentSyntax_ThrowsArgumentException()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M(1)");
+
+        Assert.Throws<ArgumentException>(() =>
+            InsertArguments(generator, invocation, 0, SyntaxFactory.ParseExpression("3")));
+    }
+
+    [Fact]
+    public void InsertArguments_UnsupportedSyntaxKind_ThrowsArgumentException()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        SyntaxNode binary = SyntaxFactory.ParseExpression("a + b");
+
+        Assert.Throws<ArgumentException>(() =>
+            InsertArguments(generator, binary, 0, Argument("3")));
+    }
+
+    [Fact]
+    public void InsertArguments_IndexNegative_ThrowsArgumentOutOfRange()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M(1, 2)");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            InsertArguments(generator, invocation, -1, Argument("3")));
+    }
+
+    [Fact]
+    public void InsertArguments_IndexGreaterThanCount_ThrowsArgumentOutOfRange()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M(1, 2)");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            InsertArguments(generator, invocation, 3, Argument("3")));
+    }
+
+    [Fact]
+    public void ReplaceArgument_InInvocation_ReplacesArgument()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M(1, 2)");
+
+        SyntaxNode result = ReplaceArgument(generator, invocation, 0, Argument("3"));
+
+        Assert.Equal(2, ArgumentCount(result));
+        Assert.Equal(["3", "2"], ArgumentExpressions(result));
+    }
+
+    [Fact]
+    public void ReplaceArgument_InObjectCreation_ReplacesArgument()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        BaseObjectCreationExpressionSyntax creation = ParseCreation("new C(1, 2)");
+
+        SyntaxNode result = ReplaceArgument(generator, creation, 1, Argument("3"));
+
+        Assert.Equal(2, ArgumentCount(result));
+        Assert.Equal(["1", "3"], ArgumentExpressions(result));
+    }
+
+    [Fact]
+    public void ReplaceArgument_ItemNotArgumentSyntax_ThrowsArgumentException()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M(1)");
+
+        Assert.Throws<ArgumentException>(() =>
+            ReplaceArgument(generator, invocation, 0, SyntaxFactory.ParseExpression("3")));
+    }
+
+    [Fact]
+    public void ReplaceArgument_UnsupportedSyntaxKind_ThrowsArgumentException()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        SyntaxNode binary = SyntaxFactory.ParseExpression("a + b");
+
+        Assert.Throws<ArgumentException>(() =>
+            ReplaceArgument(generator, binary, 0, Argument("3")));
+    }
+
+    [Fact]
+    public void ReplaceArgument_EmptyInvocation_ThrowsArgumentOutOfRange()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M()");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ReplaceArgument(generator, invocation, 0, Argument("3")));
+    }
+
+    [Fact]
+    public void ReplaceArgument_ObjectCreationWithoutArgumentList_ThrowsArgumentOutOfRange()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        BaseObjectCreationExpressionSyntax creation = ParseCreation("new C { }");
+        Assert.Null(creation.ArgumentList);
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ReplaceArgument(generator, creation, 0, Argument("3")));
+    }
+
+    [Fact]
+    public void ReplaceArgument_IndexNegative_ThrowsArgumentOutOfRange()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M(1, 2)");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ReplaceArgument(generator, invocation, -1, Argument("3")));
+    }
+
+    [Fact]
+    public void ReplaceArgument_IndexEqualsCount_ThrowsArgumentOutOfRange()
+    {
+        SyntaxGenerator generator = CreateGenerator();
+        InvocationExpressionSyntax invocation = ParseInvocation("M(1, 2)");
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            ReplaceArgument(generator, invocation, 2, Argument("3")));
+    }
+
+    private static SyntaxGenerator CreateGenerator()
+    {
+        AdhocWorkspace workspace = new();
+        return SyntaxGenerator.GetGenerator(workspace, LanguageNames.CSharp);
+    }
+
+    private static InvocationExpressionSyntax ParseInvocation(string text) =>
+        (InvocationExpressionSyntax)SyntaxFactory.ParseExpression(text);
+
+    private static BaseObjectCreationExpressionSyntax ParseCreation(string text) =>
+        (BaseObjectCreationExpressionSyntax)SyntaxFactory.ParseExpression(text);
+
+    private static ArgumentSyntax Argument(string expression) =>
+        SyntaxFactory.Argument(SyntaxFactory.ParseExpression(expression));
+
+    private static SeparatedSyntaxList<ArgumentSyntax> Arguments(SyntaxNode node) => node switch
+    {
+        InvocationExpressionSyntax invocation => invocation.ArgumentList.Arguments,
+        BaseObjectCreationExpressionSyntax creation => creation.ArgumentList?.Arguments ?? default,
+        _ => throw new InvalidOperationException("Unexpected node kind."),
+    };
+
+    private static int ArgumentCount(SyntaxNode node) => Arguments(node).Count;
+
+    private static string[] ArgumentExpressions(SyntaxNode node)
+    {
+        SeparatedSyntaxList<ArgumentSyntax> arguments = Arguments(node);
+        string[] expressions = new string[arguments.Count];
+        for (int i = 0; i < arguments.Count; i++)
+        {
+            expressions[i] = arguments[i].Expression.ToString().Trim();
+        }
+
+        return expressions;
+    }
+
+#pragma warning disable ECS0900 // Reflection invocation boxes the int index argument; unavoidable and confined to test code.
+    private static SyntaxNode InsertArguments(SyntaxGenerator generator, SyntaxNode syntax, int index, params SyntaxNode[] items) =>
+        (SyntaxNode)Invoke(InsertArgumentsMethod, generator, syntax, index, items)!;
+
+    private static SyntaxNode ReplaceArgument(SyntaxGenerator generator, SyntaxNode syntax, int index, SyntaxNode item) =>
+        (SyntaxNode)Invoke(ReplaceArgumentMethod, generator, syntax, index, item)!;
+#pragma warning restore ECS0900
+
+    private static object? Invoke(MethodInfo method, params object?[] args)
+    {
+        try
+        {
+            return method.Invoke(null, args);
+        }
+        catch (TargetInvocationException ex) when (ex.InnerException is not null)
+        {
+            throw ex.InnerException;
+        }
+    }
+}

--- a/tests/Moq.Analyzers.Test/SyntaxGeneratorExtensionsTests.cs
+++ b/tests/Moq.Analyzers.Test/SyntaxGeneratorExtensionsTests.cs
@@ -1,4 +1,5 @@
 using System.Reflection;
+using System.Runtime.ExceptionServices;
 using Microsoft.CodeAnalysis.Editing;
 
 namespace Moq.Analyzers.Test;
@@ -23,13 +24,14 @@ public class SyntaxGeneratorExtensionsTests
         .Assembly
         .GetType("Moq.CodeFixes.SyntaxGeneratorExtensions", throwOnError: true)!;
 
-#pragma warning disable ECS0600 // The literals name methods in another assembly resolved via reflection, not local symbols.
-    private static readonly MethodInfo InsertArgumentsMethod =
-        ExtensionsType.GetMethod("InsertArguments", BindingFlags.Public | BindingFlags.Static)!;
+#pragma warning disable ECS1300 // Static field init is simpler than a static constructor for these test fixtures.
+    private static readonly MethodInfo InsertArgumentsMethod = GetGuardMethod(nameof(InsertArguments));
 
-    private static readonly MethodInfo ReplaceArgumentMethod =
-        ExtensionsType.GetMethod("ReplaceArgument", BindingFlags.Public | BindingFlags.Static)!;
-#pragma warning restore ECS0600
+    private static readonly MethodInfo ReplaceArgumentMethod = GetGuardMethod(nameof(ReplaceArgument));
+
+    private static readonly SyntaxGenerator SharedGenerator =
+        SyntaxGenerator.GetGenerator(new AdhocWorkspace(), LanguageNames.CSharp);
+#pragma warning restore ECS1300
 
     [Fact]
     public void InsertArguments_IntoInvocation_InsertsArgument()
@@ -204,10 +206,13 @@ public class SyntaxGeneratorExtensionsTests
             ReplaceArgument(generator, invocation, 2, Argument("3")));
     }
 
-    private static SyntaxGenerator CreateGenerator()
+    private static SyntaxGenerator CreateGenerator() => SharedGenerator;
+
+    private static MethodInfo GetGuardMethod(string name)
     {
-        AdhocWorkspace workspace = new();
-        return SyntaxGenerator.GetGenerator(workspace, LanguageNames.CSharp);
+        const BindingFlags Flags = BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Static;
+        return ExtensionsType.GetMethod(name, Flags)
+            ?? throw new MissingMethodException(ExtensionsType.FullName, name);
     }
 
     private static InvocationExpressionSyntax ParseInvocation(string text) =>
@@ -256,7 +261,8 @@ public class SyntaxGeneratorExtensionsTests
         }
         catch (TargetInvocationException ex) when (ex.InnerException is not null)
         {
-            throw ex.InnerException;
+            ExceptionDispatchInfo.Throw(ex.InnerException);
+            return null;
         }
     }
 }

--- a/tests/Moq.Analyzers.Test/VerifyOverridableMembersFixerTests.cs
+++ b/tests/Moq.Analyzers.Test/VerifyOverridableMembersFixerTests.cs
@@ -1,0 +1,89 @@
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.Text;
+
+namespace Moq.Analyzers.Test;
+
+/// <summary>
+/// Direct unit tests for <see cref="Moq.CodeFixes.VerifyOverridableMembersFixer"/> node resolution.
+/// The analyzer always reports the diagnostic on the whole invocation, so the higher-level
+/// verifier tests never exercise the ancestor-walk branch that fires when the diagnostic span
+/// resolves to a node nested inside the invocation. This test drives that branch with a synthetic
+/// diagnostic positioned on the <c>Verify</c> identifier rather than the full invocation.
+/// </summary>
+public class VerifyOverridableMembersFixerTests
+{
+    private static readonly string Source = """
+        using Moq;
+
+        public class SampleClass
+        {
+            public int Property { get; set; }
+        }
+
+        internal class UnitTest
+        {
+            private void Test()
+            {
+                new Mock<SampleClass>().Verify(x => x.Property);
+            }
+        }
+        """;
+
+    [Fact]
+    public async Task DiagnosticOnNestedNode_ResolvesToInvocation_AndRegistersFix()
+    {
+        (SemanticModel model, SyntaxTree tree) = await CompilationHelper.CreateMoqCompilationAsync(Source);
+        SyntaxNode root = await tree.GetRootAsync();
+
+        // Position the diagnostic on the `Verify` identifier so FindNode returns a non-invocation
+        // node; the fixer must walk up to the enclosing invocation before offering the fix.
+        IdentifierNameSyntax verifyName = root
+            .DescendantNodes()
+            .OfType<IdentifierNameSyntax>()
+            .Single(name => string.Equals(name.Identifier.ValueText, "Verify", StringComparison.Ordinal));
+
+        Diagnostic diagnostic = CreateSyntheticDiagnosticAtSpan(tree, verifyName.Span);
+        using AdhocWorkspace workspace = new();
+        Document document = CreateTestDocument(workspace, model, Source);
+        List<CodeAction> actions = await InvokeFixerAsync(document, diagnostic);
+
+        CodeAction action = Assert.Single(actions);
+        Assert.Equal("Make member virtual", action.Title);
+    }
+
+    private static Diagnostic CreateSyntheticDiagnosticAtSpan(SyntaxTree tree, TextSpan span)
+    {
+        DiagnosticDescriptor descriptor = new(
+            DiagnosticIds.VerifyOnlyUsedForOverridableMembers,
+            "Verify only used for overridable members",
+            "Verify only used for overridable members",
+            "Correctness",
+            DiagnosticSeverity.Warning,
+            isEnabledByDefault: true);
+
+        return Diagnostic.Create(descriptor, Location.Create(tree, span));
+    }
+
+    private static Document CreateTestDocument(AdhocWorkspace workspace, SemanticModel model, string source)
+    {
+        Project project = workspace.AddProject("TestProject", LanguageNames.CSharp)
+            .AddMetadataReferences(model.Compilation.References);
+        return project.AddDocument("Test.cs", SourceText.From(source));
+    }
+
+    private static async Task<List<CodeAction>> InvokeFixerAsync(Document document, Diagnostic diagnostic)
+    {
+        Moq.CodeFixes.VerifyOverridableMembersFixer fixer = new();
+        List<CodeAction> actions = [];
+
+        CodeFixContext context = new(
+            document,
+            diagnostic,
+            (action, _) => actions.Add(action),
+            CancellationToken.None);
+
+        await fixer.RegisterCodeFixesAsync(context).ConfigureAwait(false);
+        return actions;
+    }
+}


### PR DESCRIPTION
## Summary

Closes #1341. Adds unit tests for previously-uncovered guard and defensive branches in the `Moq.CodeFixes` assembly. No production code changes; tests only.

`SyntaxGeneratorExtensions` is internal to the shipping `Moq.CodeFixes` assembly. Tests reach it via reflection on the real assembly (the same strategy as `VerifyShouldBeUsedOnlyForOverridableMembersAnalyzerTests.InvokeCanMakeMemberVirtual`), not `InternalsVisibleTo`. IVT would surface `Moq.CodeFixes`'s Polyfill-generated BCL attribute types to the net8.0 test project and cause 122 CS0433 collisions with `System.Runtime`.

### Changes

- **`SyntaxGeneratorExtensionsTests.cs`** (new): 16 positive/negative/boundary tests covering every guard in `InsertArguments` and `ReplaceArgument` (item-type, syntax-kind, index range) plus the null-`ArgumentList` object-creation branches. `SyntaxGeneratorExtensions` reaches 100% branch coverage.
- **`VerifyOverridableMembersFixerTests.cs`** (new): drives the ancestor-walk branch (`VerifyOverridableMembersFixer.cs:38`) via a synthetic diagnostic on the nested `Verify` identifier. That branch is unreachable through the real pipeline because the analyzer always reports on the whole invocation.
- **`SetExplicitMockBehaviorFixerTests.cs`** (modified): adds a case for the `MockBehaviorFixerBase` early return when a diagnostic carries no edit properties.

### Intentionally left (unreachable-defensive)

- `MockBehaviorFixerBase.cs:26` (null root) requires a document without a syntax tree, not constructible via the fixer harness.
- Remaining null-guards in `VerifyOverridableMembersFixer` are defensive against inputs the pipeline never produces.

## Validation

| Step | Result |
| ---- | ------ |
| `dotnet build -c Release` | Build succeeded, 0 warnings |
| `dotnet test` (new/modified tests) | 28 passed, 0 failed |
| Coverage (`SyntaxGeneratorExtensions`) | branch-rate 1.00; only uncovered line is the unrelated `MemberAccessExpression`, covered by other fixer tests in the full suite |
| `dotnet format --verify-no-changes` | clean |

### Moq version compatibility

No Moq API surface touched. Tests target the same Moq version as the existing test project.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded automated coverage for code-fix behavior, including edge cases where diagnostic details are incomplete.
  * Added validation for argument editing scenarios to improve confidence in refactoring actions.
  * Added coverage for member verification fixes to ensure the expected fix is offered in the right situations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->