### PR TITLE
test(coverage): include PerfDiff in coverage

### DIFF
--- a/build/targets/tests/test.runsettings
+++ b/build/targets/tests/test.runsettings
@@ -19,12 +19,13 @@
             <ModulePaths>
               <Include>
                 <!--
-                  Limit code coverage to the shipping binary.
+                  Limit code coverage to production binaries with unit tests.
                   TODO: Consider using a "Just my code"-esque tool to automatically include all project references.
                   Discuss in https://github.com/microsoft/codecoverage.
                 -->
                 <ModulePath>.*Moq\.Analyzers\.dll$</ModulePath>
                 <ModulePath>.*Moq\.CodeFixes\.dll$</ModulePath>
+                <ModulePath>.*PerfDiff\.dll$</ModulePath>
               </Include>
               <Exclude>
                 <ModulePath>.*\.TestAdapter\.dll$</ModulePath> <!-- Excludes test adapters -->


### PR DESCRIPTION
## Summary

Adds `PerfDiff.dll` to the canonical coverage module filter.

Closes #1332.

## Why

Before this change, all 145 PerfDiff tests passed while Cobertura contained zero PerfDiff classes. Coverage gates therefore treated PerfDiff-only changes as not applicable.

After this change, the merged report contains 24 PerfDiff classes. ReportGenerator reports PerfDiff at 100% line coverage and 98.2% branch coverage.

## Validation Log

- [x] `dotnet format`
- [x] XML parse of `build/targets/tests/test.runsettings`
- [x] `dotnet build /p:PedanticMode=true`, 0 warnings, 0 errors
- [x] `dotnet test --settings ./build/targets/tests/test.runsettings`, 4,506 tests passed
- [x] Pre-push Release build, 0 warnings, 0 errors
- [x] Pre-push full test suite, 4,506 tests passed
- [x] `grep -q 'name="PerfDiff"' artifacts/TestResults/coverage/Cobertura.xml`
- [x] No `*.received.*` files

Codacy CLI has no configured analyzer for `.runsettings` files. It returned `No tools support the specified file(s)`.

## Moq compatibility

No analyzer behavior or Moq API use changed. The full suite still covers Moq 4.8.2 and 4.18.4.

## Cognitive payload

Add `PerfDiff.dll` to the canonical coverage include filter.

Mechanical chunks: none.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated code coverage configuration to include performance comparison components.
  * Refined coverage inclusion guidance for production binaries with unit tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->