### PR TITLE
docs(skills): remove stale test totals

### DIFF
--- a/.github/skills/moq-analyzers-architecture-contract/SKILL.md
+++ b/.github/skills/moq-analyzers-architecture-contract/SKILL.md
@@ -244,7 +244,8 @@ Its verdict logic has multiple confirmed defects — see weak points.
 
 ### tests/
 
-- `tests/Moq.Analyzers.Test` — 3,357 tests (2026-07-02). Helpers in `Helpers/`:
+- `tests/Moq.Analyzers.Test` contains analyzer, fixer, package, and compatibility
+  tests. Helpers in `Helpers/`:
   `Test.cs`, `AnalyzerVerifier`/`CodeFixVerifier`, `ReferenceAssemblyCatalog`
   (keys: `Net80` = no Moq, `Net80WithOldMoq` = 4.8.2, `Net80WithNewMoq` = 4.18.4),
   `TestDataExtensions` (`WithNamespaces() × With*MoqReferenceAssemblyGroups()`
@@ -253,8 +254,8 @@ Its verdict logic has multiple confirmed defects — see weak points.
   no-diagnostic suites), `DoppelgangerTestHelper`. PackageTests snapshot the nupkg
   via Verify.Xunit.
 - `tests/Moq.Analyzers.Benchmarks` — per-rule `Moq{Id}Benchmarks.cs` convention.
-- `tests/PerfDiff.Tests` — 4 tests (2026-07-02), logging-registration only; it does
-  not yet reference PerfDiff itself (planned by #1265–#1269).
+- `tests/PerfDiff.Tests` covers command-line, regression, ETL, input, logging,
+  and integration behavior.
 
 ## Known-weak points (2026-07-02 audit — stated plainly)
 
@@ -336,7 +337,8 @@ Re-verify each volatile claim before relying on it:
 - Issue states: `gh issue view 1241 1242 1248 1250 1265 1266 1267 1268 1269 1270 986 --json state` (or one at a time) — remove fixed items from the weak-points table.
 - Phantom symbols: `grep -n 'Moq.Language.IReturns"' src/Common/WellKnown/MoqKnownSymbols.cs` and the `_ReturnsNull` tests in `tests/Moq.Analyzers.Test/Common/MoqKnownSymbolsTests.ReturnsAndThrows.cs`.
 - SquiggleCop wiring: `grep -rni squigglecop --include='*.yml' --include='*.props' --include='*.targets' .github build` (empty ⇒ still unwired) and version in `.config/dotnet-tools.json`.
-- Test counts: `dotnet test --settings ./build/targets/tests/test.runsettings` (3,357 + 4 as of 2026-07-02; 2 PackageTests fail only in sandboxes with non-github.com git remotes).
+- Test counts: run `dotnet test --settings ./build/targets/tests/test.runsettings`;
+  2 PackageTests fail only in sandboxes with non-github.com git remotes.
 - Perf gate wiring: `grep -n 'failOnRegression' build/scripts/perf/ComparePerfResults.ps1` and the `perf:` job in `.github/workflows/main.yml`.
 
 Last verified: 2026-07-02 against commit 05135b2.

--- a/.github/skills/moq-analyzers-build-and-env/SKILL.md
+++ b/.github/skills/moq-analyzers-build-and-env/SKILL.md
@@ -8,9 +8,9 @@ description: Recreates the moq.analyzers development environment from scratch an
 Goal state, verified 2026-07-02 on commit 05135b2:
 
 - `dotnet build` → 0 warnings, 0 errors (~13 s incremental, longer first run).
-- `dotnet test --settings ./build/targets/tests/test.runsettings` → 3,357 tests in
-  Moq.Analyzers.Test + 4 in PerfDiff.Tests. All pass on a normal GitHub clone
-  (2 environment-only failures in sandboxes — see "PackageTests failures" below).
+- `dotnet test --settings ./build/targets/tests/test.runsettings` passes on a
+  normal GitHub clone. Two environment-only failures can occur in sandboxes;
+  see "PackageTests failures" below.
 
 All commands are repo-root relative. This repo builds a **Roslyn analyzer** — a plugin
 DLL that runs inside other people's C# compilers and IDEs — so the build has unusual
@@ -240,22 +240,13 @@ dotnet test --settings ./build/targets/tests/test.runsettings
 ```
 
 The `--settings` file matters: `build/targets/tests/test.runsettings` enables parallel
-execution (`MaxCpuCount=0`) and Cobertura code coverage limited to the two shipping
-assemblies (`Moq.Analyzers.dll`, `Moq.CodeFixes.dll`). After the run, an MSBuild target
-automatically generates a coverage report at `artifacts/TestResults/coverage/`
-(`SummaryGithub.md`, `Cobertura.xml`, `index.html`).
+execution (`MaxCpuCount=0`) and Cobertura code coverage for the product assemblies
+listed in `ModulePaths`. After the run, an MSBuild target automatically generates a
+coverage report at `artifacts/TestResults/coverage/` (`SummaryGithub.md`,
+`Cobertura.xml`, `index.html`).
 
-**Expected counts (2026-07-02, commit 05135b2):**
-
-| Project | Tests | Notes |
-| --- | --- | --- |
-| tests/Moq.Analyzers.Test | **3,357** | analyzer + code-fix + package tests, net8.0 |
-| tests/PerfDiff.Tests | **4** | tests for the perf-comparison tool |
-| tests/Moq.Analyzers.Benchmarks | 0 | BenchmarkDotNet project, not a test project |
-
-Counts grow with every rule/test PR — treat a *lower* count than an earlier run as a
-red flag (a test project failed to build or an analyzer fell out of discovery), not a
-higher one.
+Read per-project totals from the command output. Counts grow with test changes, so
+treat a lower count than the last known-good run as a red flag.
 
 Run one class or one test while iterating:
 
@@ -280,9 +271,9 @@ which it derives from your git remote.
 In sandboxes/proxies where `git remote get-url origin` is not a github.com URL (e.g. a
 local proxy URL), the scrub misses and both cases fail with a snapshot mismatch. So:
 
-- **3,355/3,357 + 4/4 passing with exactly these 2 failures = green** in such an
-  environment (state this in any evidence you record).
-- On a normal GitHub clone, all 3,357 must pass.
+- All discovered tests except these 2 PackageTests passing is green in such an
+  environment. State this in any evidence you record.
+- On a normal GitHub clone, every discovered test must pass.
 - Check with: `git remote get-url origin`.
 
 These failures produce `*.received.*` files next to the `*.verified.*` baselines.
@@ -376,8 +367,8 @@ dotnet build /p:PedanticMode=true
 
 # 5. Test
 dotnet test --settings ./build/targets/tests/test.runsettings
-# ~2.5 min; expect 3,357 + 4 passing (minus the 2 PackageTests cases iff your
-# origin remote is not a github.com URL — check: git remote get-url origin)
+# Expect every discovered test to pass, except the 2 PackageTests cases when
+# origin is not a github.com URL. Check with: git remote get-url origin
 ```
 
 ## When NOT to use this skill
@@ -409,7 +400,7 @@ Re-verify each volatile claim with one command before trusting it after 2026-07-
 - Pre-push flags: `cat build/scripts/hooks/Invoke-PrePushBuild.ps1`
 - Large-file limits: `head -25 build/scripts/hooks/Test-LargeFiles.ps1`
 - PedanticMode wiring: `sed -n 1,8p build/targets/codeanalysis/CodeAnalysis.targets`
-- Test counts: `dotnet test --settings ./build/targets/tests/test.runsettings` (3,357 + 4 on 2026-07-02; grows over time)
+- Test counts: run `dotnet test --settings ./build/targets/tests/test.runsettings`
 - PackageTests scrubber behavior: `sed -n 28,44p tests/Moq.Analyzers.Test/PackageTests.cs` and `git remote get-url origin`
 - Roslyn/AnalyzerUtilities pins: `grep -n 'CodeAnalysis' Directory.Packages.props`
 - LF rule for ps1: `grep -n 'ps1' .gitattributes` and `docs/architecture/ADR-010-eol-lf-for-powershell-files.md`

--- a/.github/skills/moq-analyzers-debugging-playbook/SKILL.md
+++ b/.github/skills/moq-analyzers-debugging-playbook/SKILL.md
@@ -422,7 +422,7 @@ every `[MemberData]` row:
   Moq 4.18.4 (`Net80WithNewMoq`)
 
 So one authored row = 4 executed rows (2,000 authored rows ≈ 8,000 executed).
-Suite total 2026-07-02: 3,357 tests in Moq.Analyzers.Test.
+Read the current suite total from the full `dotnet test` output.
 
 Debugging value: the group name is the **first** test argument. If only
 `Net80WithOldMoq` rows fail, the behavior is Moq-4.8.2-specific (API missing
@@ -489,7 +489,7 @@ Re-verify before trusting anything volatile:
 - PerfDiff defect issue states: check <https://github.com/rjmurillo/moq.analyzers/issues/1265> through /1269 (all open on 2026-07-02); once fixed, delete the "tool bug" branch of section 10
 - AllAnalyzersVerifier namespace contract: `grep -n '"Moq.Analyzers"' tests/Moq.Analyzers.Test/Helpers/AllAnalyzersVerifier.cs`
 - Hook task list: `cat .husky/task-runner.json`
-- Test count (3,357): `dotnet test --settings ./build/targets/tests/test.runsettings` summary line
+- Test count: `dotnet test --settings ./build/targets/tests/test.runsettings` summary line
 - Received-file rule: `grep -n "received" CONTRIBUTING.md`
 
 Last verified: 2026-07-02 against commit 05135b2.

--- a/.github/skills/moq-analyzers-fp-convergence-campaign/SKILL.md
+++ b/.github/skills/moq-analyzers-fp-convergence-campaign/SKILL.md
@@ -98,10 +98,10 @@ dotnet test --settings ./build/targets/tests/test.runsettings
 
 - Build: **0 warnings, 0 errors** (plain `dotnet build` is lenient; the
   `/p:PedanticMode=true` form is what CI runs — always use it).
-- Tests: **Moq.Analyzers.Test 3,357 total; PerfDiff.Tests 4/4.** In
-  sandboxes whose git remote is not a `https://github.com/...` URL, exactly
-  2 `PackageTests.Baseline` snapshot tests fail (the nuspec scrubber expects
-  a github.com repository URL) — that is environmental, not a defect.
+- Tests: every discovered test passes. In sandboxes whose git remote is not a
+  `https://github.com/...` URL, exactly 2 `PackageTests.Baseline` snapshot
+  tests fail because the nuspec scrubber expects a github.com repository URL.
+  That is environmental, not a defect.
 
 **If you see X instead → branch to Y:**
 
@@ -496,7 +496,7 @@ moq-analyzers-failure-archaeology).
 Re-verify anything volatile before relying on it:
 
 - Backlog states: `gh issue list -R rjmurillo/moq.analyzers --state open --search "1241..1270 in:number"` (or open each of #1241–#1264, #1270; #1244/#1246/#1247/#1249/#1252/#1254 are closed duplicates).
-- Baseline test count (3,357 + 4) and 0-warning build: run the GATE 0 commands and record fresh numbers.
+- Baseline test count and 0-warning build: run the GATE 0 commands and record fresh numbers.
 - Moq version pins (4.8.2 / 4.18.4): `grep -n "PackageIdentity" tests/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalog.cs`.
 - Saga commits still resolve: `for c in 6ec810c c270302 894313b 0bef80b 5eec7e1 4b705e2 3399297 5172cf3 35d363d; do git log -1 --oneline $c; done`.
 - Helper line anchors: `grep -n "WalkDownParentheses" src/Common/SyntaxNodeExtensions.cs; grep -n "FindSetupInvocation" src/Common/InvocationExpressionSyntaxExtensions.cs`.

--- a/.github/skills/moq-analyzers-proof-toolkit/SKILL.md
+++ b/.github/skills/moq-analyzers-proof-toolkit/SKILL.md
@@ -475,10 +475,9 @@ working.
    dotnet test --settings ./build/targets/tests/test.runsettings
    ```
 
-   Baseline 2026-07-02: 3,357 tests in Moq.Analyzers.Test + 4 in PerfDiff.Tests; in
-   sandboxes whose git remote is not a github.com URL, the 2 `PackageTests.Baseline`
-   snapshot tests fail for environment reasons (nuspec repository-URL scrubber) —
-   anything ELSE failing is yours.
+   Read current totals from the command output. In sandboxes whose git remote is
+   not a github.com URL, the 2 `PackageTests.Baseline` snapshot tests fail for
+   environment reasons. Anything else failing is yours.
 2. Read every failure through the span-pin lens: **existing span pins are inviolable.**
    If your change moves a pinned span, the default conclusion is that your change is
    wrong, not the pin. Recipe 4's STOP protocol applies to pre-existing tests with full
@@ -538,7 +537,7 @@ own issue and review, not a test edit in passing.
 - Host-compat maxima: `grep -n "_MaxSystemCollectionsImmutable\|8.0.0.0" build/targets/packaging/Packaging.targets .github/workflows/main.yml | head`
 - Load-test matrix legs: count `tfm:` entries under `analyzer-load-test:` in `.github/workflows/main.yml` (9 as of 2026-07-02)
 - PerfDiff thresholds: `grep -rn "Threshold.Parse" src/tools/PerfDiff/BDN/Regression/` (35%; 5%+0.5ms ×2; 250ms; 100ms as of 2026-07-02)
-- Test count: `dotnet test --settings ./build/targets/tests/test.runsettings` summary (3,357 + 4 as of 2026-07-02); PackageTests sandbox caveat holds only where the git remote is not a github.com URL
+- Test count: `dotnet test --settings ./build/targets/tests/test.runsettings` summary; PackageTests sandbox caveat holds only where the git remote is not a github.com URL
 - Moq overload counts (20 vs 19 Returns; the 4.18.4-only addition is `Returns(InvocationFunc)` — `Returns(Delegate)` exists in both): `dotnet-inspect member "IReturns<TMock, TResult>" --package Moq@4.18.4 --all` and `@4.8.2`
 - Frontmatter stays parser-safe: `python3 -c "import yaml; print(len(yaml.safe_load(open('.github/skills/moq-analyzers-proof-toolkit/SKILL.md').read().split('---')[1])['description']))"` — expect the full description length, not an error or a truncated count
 - Shipped DLL list (3 files): `grep -n "PackagePath=\"analyzers/dotnet/cs\"" src/Analyzers/Moq.Analyzers.csproj`

--- a/.github/skills/moq-analyzers-research-frontier/SKILL.md
+++ b/.github/skills/moq-analyzers-research-frontier/SKILL.md
@@ -146,7 +146,7 @@ would not notice if analyzer logic silently broke.
 
 ### This project's specific assets
 
-- **3,357 tests** in `tests/Moq.Analyzers.Test` with span-exact assertions
+- Tests in `tests/Moq.Analyzers.Test` use span-exact assertions
   (`{|Moq1002:...|}` markup asserts ID *and* character range) — strong
   mutant killers, unlike assertion-light suites where mutants survive
   trivially.
@@ -165,8 +165,8 @@ would not notice if analyzer logic silently broke.
    `stryker-config.json` targeting the `Moq.Analyzers` project with
    `tests/Moq.Analyzers.Test` as the test project. Tool-manifest changes
    need a THIRD-PARTY-NOTICES review per change control.
-2. **Size the runtime before committing to anything.** 3,357 tests × hundreds
-   of mutants is expensive. First run: restrict to a single analyzer file
+2. **Size the runtime before committing to anything.** The full suite times
+   hundreds of mutants is expensive. First run: restrict to a single analyzer file
    (Stryker's mutate filter, e.g. `--mutate "**/MethodSetupShouldSpecifyReturnValueAnalyzer.cs"`)
    and record wall-clock time and mutation score. Extrapolate before scoping
    the CI job; expect to need Stryker's incremental/`since` mode for PRs.
@@ -467,7 +467,7 @@ Re-verify before relying on any volatile claim above:
 - Nightly cron + perf filters: `grep -n "cron\|FileCount" .github/workflows/main.yml`
 - Perf baseline pin: `cat build/perf/baseline.json`
 - Stryker still absent: `grep -i stryker .config/dotnet-tools.json` (expect no hits until Problem 2 step 1 lands).
-- Test count: `dotnet test --settings ./build/targets/tests/test.runsettings` (3,357 in Moq.Analyzers.Test as of 2026-07-02; 2 PackageTests failures are sandbox-remote-URL artifacts, not defects).
+- Test count: run `dotnet test --settings ./build/targets/tests/test.runsettings`; 2 PackageTests failures are sandbox-remote-URL artifacts, not defects.
 - Packed nupkg path: `ls artifacts/package/*/Moq.Analyzers.*.nupkg` (after `dotnet build`).
 
 Last verified: 2026-07-02 against commit 05135b2.

--- a/.github/skills/moq-analyzers-validation-and-qa/SKILL.md
+++ b/.github/skills/moq-analyzers-validation-and-qa/SKILL.md
@@ -37,10 +37,10 @@ Run one test class:
 dotnet test --settings ./build/targets/tests/test.runsettings --filter "FullyQualifiedName~MethodSetupShouldSpecifyReturnValue"
 ```
 
-Suite size (2026-07-02): 3,357 tests in `Moq.Analyzers.Test` (+4 in
-`PerfDiff.Tests`). Tests target net8.0 and run against a pinned Roslyn 4.8
-test compiler, so test code parses as C# 12 — C# 13 features (e.g. `params`
-collections) are NOT parseable inside test sources.
+Read the current suite size from the full command output. Tests target net8.0
+and run against a pinned Roslyn 4.8 test compiler, so test code parses as C# 12.
+C# 13 features such as `params` collections are not parseable inside test
+sources.
 
 ## 1. Evidence hierarchy — compiling test code is the floor
 
@@ -517,7 +517,7 @@ coverage) and `MethodSetupShouldSpecifyReturnValueAnalyzerTests`
 
 Re-verify volatile claims with:
 
-- Test count: `dotnet test --settings ./build/targets/tests/test.runsettings 2>&1 | grep -E "Passed!|Failed!|total"` (3,357 in Moq.Analyzers.Test as of 2026-07-02; 2 PackageTests failures are sandbox-remote-URL artifacts only).
+- Test count: `dotnet test --settings ./build/targets/tests/test.runsettings 2>&1 | grep -E "Passed!|Failed!|total"`; 2 PackageTests failures are sandbox-remote-URL artifacts only.
 - Helper inventory: `ls tests/Moq.Analyzers.Test/Helpers/` (8 files as of 2026-07-02).
 - Catalog keys and Moq pins (4.8.2 / 4.18.4): `grep -n "PackageIdentity" tests/Moq.Analyzers.Test/Helpers/ReferenceAssemblyCatalog.cs`.
 - Namespace-trap filter still exact-match: `grep -n '"Moq.Analyzers"' tests/Moq.Analyzers.Test/Helpers/AllAnalyzersVerifier.cs`.

--- a/.github/skills/roslyn-analyzer-reference/SKILL.md
+++ b/.github/skills/roslyn-analyzer-reference/SKILL.md
@@ -538,7 +538,7 @@ moq-analyzers-research-frontier, moq-analyzers-research-methodology.
 - Unguarded `Arguments[0]` still at `SemanticModelExtensions.cs:60`? `grep -n 'Arguments\[0\]' src/Common/SemanticModelExtensions.cs`
 - Moq1300 error-type guard still missing? `grep -n 'TypeKind' src/Analyzers/AsShouldBeUsedOnlyForInterfaceAnalyzer.cs`
 - All analyzers still compliant with the Initialize trio? `grep -L 'EnableConcurrentExecution' src/Analyzers/*Analyzer*.cs` — expected output today is exactly `SetExplicitMockBehaviorAnalyzer.cs` and `SetStrictMockBehaviorAnalyzer.cs`, which inherit the trio from `MockBehaviorDiagnosticAnalyzerBase`; anything else is a violation.
-- Test-compiler C# ceiling (currently C# 12 via Roslyn 4.8) and test count (3,357 in Moq.Analyzers.Test): re-run `dotnet test --settings ./build/targets/tests/test.runsettings` and check LangVersion behavior notes in moq-analyzers-build-and-env.
+- Test-compiler C# ceiling (currently C# 12 via Roslyn 4.8) and current test count: re-run `dotnet test --settings ./build/targets/tests/test.runsettings` and check LangVersion behavior notes in moq-analyzers-build-and-env.
 - AnalyzerReleases auto-include mechanism: `grep -n 'AnalyzerReleases' ~/.nuget/packages/microsoft.codeanalysis.analyzers/*/buildTransitive/*.targets`
 - Rule count/ID table: `cat src/Common/DiagnosticIds.cs` (25 rules, Moq1000-Moq1600, Moq1209 reserved).
 


### PR DESCRIPTION
## Summary

Removes obsolete test totals from eight project skills. Each skill now reads current totals from `dotnet test` output.

Stacked on #1365.

## Why

The skills claimed 3,357 analyzer tests and 4 PerfDiff tests. The current full run executes 4,338 analyzer tests and 145 PerfDiff tests.

Updating the numbers would create the same drift again. Removing the snapshots keeps the test runner as the source of truth.

## Validation Log

- [x] `rg -n '3,357|3,355/3,357|3,357 \+ 4' .github/skills`, no matches
- [x] `markdownlint-cli2` on all eight changed skill files, 0 issues
- [x] `dotnet format`
- [x] `dotnet build /p:PedanticMode=true`, 0 warnings, 0 errors
- [x] `dotnet test --settings ./build/targets/tests/test.runsettings`, 4,506 tests passed
- [x] Pre-push Release build, 0 warnings, 0 errors
- [x] Pre-push full test suite, 4,506 tests passed
- [x] Codacy CLI, 0 findings
- [x] No `*.received.*` files

## Moq compatibility

No analyzer behavior or Moq API use changed.

## Cognitive payload

Treat suite totals as live command output.

## Mechanical chunks

Removed stale count snapshots under one rule across eight skill files. Markdown lint and full repository gates cover every touched file.
