### PR TITLE
docs(instructions): fix project targets

### DIFF
--- a/.github/instructions/project.instructions.md
+++ b/.github/instructions/project.instructions.md
@@ -34,7 +34,7 @@ Before submitting any changes, verify:
 
 **Build & Dependency Management:**
 
-- [ ] Target .NET 8, C# 12 by default; Analyzers and Code Fixes target .NET Standard 2.0
+- [ ] Use the .NET 10 SDK pinned in global.json with its default C# 14 compiler; shipped analyzers and code fixes target .NET Standard 2.0; tests and tools target .NET 8
 - [ ] All build and dependency requirements met
 - [ ] No warnings or errors in build
 - [ ] All tests pass
@@ -161,7 +161,7 @@ Your changes are successful when:
 
 Before updating any dependencies:
 
-1. **Check compatibility** with target framework (.NET 9)
+1. **Check compatibility** with each consuming project target: .NET Standard 2.0 for shipped assemblies and .NET 8 for tests and tools
 2. **Verify breaking changes** in release notes
 3. **Test locally** with the new dependency version
 4. **Run security scans** using Trivy


### PR DESCRIPTION
## Summary

Corrects the project-file instructions to match the checked-in SDK and project targets.

Stacked on #1367.

## Why

The instructions claimed .NET 8 with C# 12 by default, then told dependency updates to check .NET 9 compatibility. The repository uses the .NET 10 SDK pinned in `global.json`, its default C# 14 compiler, .NET Standard 2.0 for shipped assemblies, and .NET 8 for tests and tools.

## Validation Log

- [x] Verified `global.json` and `build/targets/compiler/Compiler.props`
- [x] Verified target frameworks across `src/**/*.csproj` and `tests/**/*.csproj`
- [x] Removed the obsolete .NET 8, .NET 9, and C# 12 guidance
- [x] `markdownlint-cli2 .github/instructions/project.instructions.md`, 0 issues
- [x] `dotnet format`
- [x] `dotnet build /p:PedanticMode=true`, 0 warnings, 0 errors
- [x] `dotnet test --settings ./build/targets/tests/test.runsettings`, 4,506 tests passed
- [x] Pre-push Release build and full test suite passed
- [x] No `*.received.*` files

Codacy CLI has no configured analyzer for Markdown files.

## Moq compatibility

No analyzer behavior or Moq API use changed.

## Cognitive payload

Align project target guidance with checked-in configuration.
