### PR TITLE
docs(memory): add Moq1600 to catalog

### DIFF
--- a/.serena/memories/complete-analyzer-catalog.md
+++ b/.serena/memories/complete-analyzer-catalog.md
@@ -1,6 +1,6 @@
 # Complete Analyzer and Code Fix Catalog
 
-## 24 Diagnostic Rules
+## 25 Diagnostic Rules
 
 ### Usage Category
 
@@ -15,6 +15,7 @@
 | Moq1301 | MockGetShouldNotTakeLiteralsAnalyzer | Mock.Get() should not take literals |
 | Moq1302 | LinqToMocksExpressionShouldBeValidAnalyzer | LINQ to Mocks expression should be valid |
 | Moq1420 | RedundantTimesSpecificationAnalyzer | Redundant Times.AtLeastOnce() can be removed |
+| Moq1600 | ProtectedSetupShouldUseItExprAnalyzer | Protected setup should use ItExpr matchers |
 
 ### Correctness Category
 
@@ -62,4 +63,4 @@ Note: Moq1209 is intentionally reserved (undocumented reason).
 ## Analyzers Without Code Fixes (gaps)
 
 Moq1000, Moq1001, Moq1002, Moq1003, Moq1004, Moq1101, Moq1200, Moq1201, Moq1202, Moq1203,
-Moq1204, Moq1205, Moq1206, Moq1207, Moq1300, Moq1301, Moq1302, Moq1420, Moq1500
+Moq1204, Moq1205, Moq1206, Moq1207, Moq1300, Moq1301, Moq1302, Moq1420, Moq1500, Moq1600


### PR DESCRIPTION
## Summary

Adds the shipped Moq1600 rule to the project analyzer catalog.

Stacked on #1368.

## Why

The catalog claimed 24 diagnostic rules and omitted Moq1600. `DiagnosticIds.cs` defines 25 rule IDs, while 24 analyzer classes exist because `ConstructorArgumentsShouldMatchAnalyzer` owns both Moq1001 and Moq1002.

## Validation Log

- [x] Compared catalog IDs with `src/Common/DiagnosticIds.cs` as sets
- [x] 25 diagnostic IDs, 25 catalog rows, no missing or extra IDs
- [x] Verified Moq1600 in root README, rule docs, source, and release tracking
- [x] `markdownlint-cli2 .serena/memories/complete-analyzer-catalog.md`, 0 issues
- [x] `dotnet format`
- [x] `dotnet build /p:PedanticMode=true`, 0 warnings, 0 errors
- [x] `dotnet test --settings ./build/targets/tests/test.runsettings`, 4,506 tests passed
- [x] Pre-push Release build and full test suite passed
- [x] No `*.received.*` files

Codacy CLI has no configured analyzer for Markdown files.

## Moq compatibility

No analyzer behavior or Moq API use changed.

## Cognitive payload

Align catalog IDs with `DiagnosticIds`.
