### PR TITLE
docs(perf): invoke PerfCore through pwsh

### DIFF
--- a/build/scripts/perf/README.md
+++ b/build/scripts/perf/README.md
@@ -21,7 +21,7 @@ The batch and shell files call out to PowerShell, which can run on Windows, Linu
 The recommended way to run benchmarks is to use PowerShell.
 
 ```powershell
-./build/scripts/perf/PerfCore.ps1 -projects "<relative-path-to-project>" [-filter "<test-filter>"] [-etl] [-ci] [-diff] [-v <verbosity>]
+pwsh -ExecutionPolicy Bypass -NoProfile -File ./build/scripts/perf/PerfCore.ps1 -projects "<relative-path-to-project>" [-filter "<test-filter>"] [-etl] [-ci] [-diff] [-v <verbosity>]
 ```
 
 > NOTE: ETL tracing is only available on Windows and requires admin permissions. If you have not run elevated (from Admin terminal or with `sudo`) the test process will automatically be elevated. On Linux/macOS, ETL will be automatically disabled with a warning message.
@@ -72,7 +72,7 @@ The JSON data is what is used by the performance comparison tools to determine i
 You can run a quick pass of the benchmarks (about 20 minutes with baseline, then the baseline is reused)
 
 ```powershell
-./build/scripts/perf/PerfCore.ps1 -v diag -diff -ci -filter '*(FileCount: 1)'
+pwsh -ExecutionPolicy Bypass -NoProfile -File ./build/scripts/perf/PerfCore.ps1 -v diag -diff -ci -filter '*(FileCount: 1)'
 ```
 
 This is similar to what is run in the [main action](../../../.github/workflows/main.yml) when you raise a PR. To run the full suite, use `-filter '*'` or omit the parameter.


### PR DESCRIPTION
## Summary

Fixes both direct `PerfCore.ps1` examples to invoke the script through PowerShell.

Stacked on #1369.

## Why

`PerfCore.ps1` has no shebang and no execute bit. The documented direct command exits 126 with `Permission denied` on Linux. `CIPerf.sh` already uses `pwsh -File`, which works across supported platforms.

## Validation Log

- [x] Reproduced direct execution failure, exit 126
- [x] `pwsh -ExecutionPolicy Bypass -NoProfile -File build/scripts/perf/PerfCore.ps1 -help`, exit 0
- [x] Verified both README examples use the working invocation
- [x] `markdownlint-cli2 build/scripts/perf/README.md`, 0 issues
- [x] `dotnet format`
- [x] `dotnet build /p:PedanticMode=true`, 0 warnings, 0 errors
- [x] `dotnet test --settings ./build/targets/tests/test.runsettings`, 4,506 tests passed
- [x] Pre-push Release build and full test suite passed
- [x] No `*.received.*` files

Codacy CLI has no configured analyzer for Markdown files.

## Moq compatibility

No analyzer behavior or Moq API use changed.

## Cognitive payload

Invoke PowerShell scripts through PowerShell.
