### PR TITLE
docs(instructions): fix JSON target guidance

### DIFF
--- a/.github/instructions/json.instructions.md
+++ b/.github/instructions/json.instructions.md
@@ -194,7 +194,7 @@ When updating version numbers:
 ### global.json Requirements
 
 - Specify correct .NET SDK version
-- Ensure compatibility with target framework (.NET 9)
+- Check compatibility against the project targets in `src/**/*.csproj` and `tests/**/*.csproj`
 - Maintain consistent SDK version across development team
 - Update when new SDK versions are required
 


### PR DESCRIPTION
## Summary

Replaces the hard-coded .NET 9 compatibility check in the JSON instructions with the checked-in project targets.

Stacked on #1370.

## Why

No project targets .NET 9. Shipped assemblies target .NET Standard 2.0. Tests and tools target .NET 8. Referencing the project files avoids repeating this drift after future SDK updates.

## Validation Log

- [x] Verified target frameworks in `src/**/*.csproj` and `tests/**/*.csproj`
- [x] Removed the .NET 9 instruction
- [x] `markdownlint-cli2 .github/instructions/json.instructions.md`, 0 issues
- [x] `dotnet format`
- [x] `dotnet build /p:PedanticMode=true`, 0 warnings, 0 errors
- [x] `dotnet test --settings ./build/targets/tests/test.runsettings`, 4,506 tests passed
- [x] Pre-push Release build and full test suite passed
- [x] No `*.received.*` files

Codacy CLI has no configured analyzer for Markdown files.

## Moq compatibility

No analyzer behavior or Moq API use changed.

## Cognitive payload

Derive compatibility from project files.
