### PR TITLE
docs(skills): close resolved stale entries

### DIFF
--- a/.github/skills/moq-analyzers-docs-and-writing/SKILL.md
+++ b/.github/skills/moq-analyzers-docs-and-writing/SKILL.md
@@ -329,10 +329,7 @@ normal change control; until then, do not propagate their claims.
 
 | Location | Stale claim | Ground truth |
 | --- | --- | --- |
-| `.serena/memories/complete-analyzer-catalog.md` | "24 Diagnostic Rules"; omits Moq1600 entirely | 25 rule IDs (`src/Common/DiagnosticIds.cs`), 24 `[DiagnosticAnalyzer]` classes (ConstructorArgumentsShouldMatchAnalyzer owns both Moq1001 and Moq1002); Moq1600 shipped via PR #1088 |
-| `.github/instructions/project.instructions.md` | "Target .NET 8, C# 12 by default"; elsewhere "target framework (.NET 9)" | Dev toolchain is .NET 10 SDK / C# 14 per `global.json` and `.github/copilot-instructions.md` Quick Reference; shipped analyzers still target netstandard2.0 (that part is correct) |
 | `.github/copilot-instructions.md` (AnalyzerReleases paragraph) | Unshipped.md "must only contain a `### New Rules` section" | Actual `Unshipped.md` on `main` also carries `### Changed Rules` since PR #1087; build is green. See §5 |
-| Benchmark how-to (multiple variants across docs/memories) | Divergent invocation instructions | Canonical script is `build/scripts/perf/PerfCore.ps1` per `build/scripts/perf/README.md` (`PerfCore.ps1 -projects "<path>" [-filter "<glob>"] [-diff]`). Invoke it via `pwsh build/scripts/perf/PerfCore.ps1 ...` on Linux/macOS — the script has no shebang and is not executable, so a bare `./` call fails; the `Perf.sh`/`Perf.cmd` and `build/scripts/perf/CIPerf.sh`/`.cmd` wrappers do exactly that (`pwsh -File`). `CONTRIBUTING.md` correctly points at PerfCore.ps1 |
 | Issue #944 sometimes cited as open doc debt | "Unshipped categories all say Usage" | CLOSED as completed 2026-03-15 (fixed by PR #1087); do not re-file |
 
 General rule: `.serena/memories/` files are convenience summaries, not docs of
@@ -450,8 +447,6 @@ Re-verify before trusting any volatile fact above:
 - super-linter exclusions: `grep FILTER_REGEX_EXCLUDE .github/workflows/linters.yml`
 - Commit length rule: `grep -n '50 characters' CONTRIBUTING.md`
 - Issue #944 state: `gh issue view 944 --json state` (expect CLOSED)
-- Stale memory check: `grep -n 'Moq1600' .serena/memories/complete-analyzer-catalog.md` (empty ⇒ still stale)
-- Stale instructions check: `grep -n '.NET 8, C# 12' .github/instructions/project.instructions.md`
 - Package description owner: `grep -n '<Description>' Directory.Build.props`
 - Version stem: `grep '"version"' version.json` (expect `0.5.0-alpha.{height}`)
 - Release-drafter behavior: `sed -n 1,20p .github/release-drafter.yml`


### PR DESCRIPTION
## Summary

Removes three resolved entries from the documentation skill's stale-doc registry.

Stacked on #1371.

## Why

The registry still marked the analyzer catalog, project target instructions, and PerfCore commands as broken after the stacked fixes corrected each source. It also retained checks that expected those defects.

## Validation Log

- [x] Analyzer catalog has 25 rows including Moq1600
- [x] Project and JSON instructions no longer claim .NET 8, .NET 9, or C# 12 defaults
- [x] No direct `./build/scripts/perf/PerfCore.ps1` examples remain
- [x] `markdownlint-cli2 .github/skills/moq-analyzers-docs-and-writing/SKILL.md`, 0 issues
- [x] `dotnet format`
- [x] `dotnet build /p:PedanticMode=true`, 0 warnings, 0 errors
- [x] `dotnet test --settings ./build/targets/tests/test.runsettings`, 4,506 tests passed
- [x] Pre-push Release build and full test suite passed
- [x] No `*.received.*` files

Codacy CLI has no configured analyzer for Markdown files.

## Moq compatibility

No analyzer behavior or Moq API use changed.

## Cognitive payload

Keep the stale registry limited to unresolved drift.
